### PR TITLE
fix: v1.0.2 — Yjs wire-format compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] — 2026-04-09
+
+### Added
+- `Doc.GUID()` accessor and `WithGUID(string)` option for subdocument identity.
+
+### Fixed
+
+- **V1 GC struct decoding (tag 0)**: Yjs encodes garbage-collected items as `{info=0, VarUint(length)}`. The V1 decoder didn't recognize tag 0, misaligning the decoder for all subsequent items. Fixed: tag 0 returns a `ContentDeleted` placeholder added directly to the store.
+- **V1 skip struct decoding (tag 10)**: Yjs uses skip structs for clock-range placeholders in partial updates. The V1 decoder rejected them as "unknown content tag: 10". Fixed: tag 10 is decoded and the clock advances without storing anything, matching V2 behavior.
+- **Cross-client parent resolution (V1 and V2)**: When items from a lower-client-ID group reference items from a higher-client-ID group via `Origin`, the parent resolution failed because the higher group hadn't been decoded yet. Fixed: unresolvable items are collected in a pending queue and retried in a loop after all client groups are decoded.
+- **ContentDoc discarded subdocument GUID**: Both V1 and V2 decoders read the subdocument GUID from the wire but discarded it, creating an empty Doc. Fixed: GUID is preserved via `WithGUID` and correctly round-trips through V1 and V2 encoding.
+- **Room name validation too restrictive**: `isValidRoomName` only allowed `[A-Za-z0-9._-]`, rejecting room names with spaces or Unicode that the y-websocket JS client permits. Fixed: now allows all printable characters (rejects only control chars, empty string, `"."`, `".."`, and names > 255 bytes).
+- **y-websocket auth message (type 2) unhandled**: Message type 2 (auth) is defined by y-websocket but was not explicitly handled. Fixed: silently ignored with a documented `case msgAuth`.
+
+### Changed
+- `YArray.Move` godoc now warns that it is not CRDT-safe for concurrent multi-client use (delete-then-insert loses causal history).
+
 ## [1.0.1] — 2026-04-09
 
 ### Fixed
@@ -91,5 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.0.2]: https://github.com/reearth/ygo/releases/tag/v1.0.2
 [1.0.1]: https://github.com/reearth/ygo/releases/tag/v1.0.1
 [1.0.0]: https://github.com/reearth/ygo/releases/tag/v1.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,15 @@
-## Fixes
+## Yjs Compatibility Fixes
 
-- **Room-splitting race**: concurrent join + disconnect could fork a document into two rooms for the same name
-- **Awareness validation bypass**: invalid awareness payloads were broadcast to all peers even after server-side rejection
-- **Silent persistence failures**: `LoadDoc`/`StoreUpdate` errors were swallowed; writes are now serialised per room with error logging, and `Shutdown` waits for in-flight persistence
+- **V1 GC struct & skip struct decoding**: Updates from Yjs clients containing garbage-collected (tag 0) or skipped (tag 10) items no longer misalign the decoder
+- **Cross-client parent resolution**: Items referencing origins from a later client group are now retried after all groups are decoded, fixing sync failures in multi-client documents
+- **Subdocument GUID preserved**: `ContentDoc` round-trips now retain the subdocument identity instead of discarding it
+- **Room names with spaces/Unicode**: Relaxed validation to match y-websocket's permissive behavior
+- **y-websocket auth message**: Type 2 messages are now silently handled instead of being dropped as unknown
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.0.1
+go get github.com/reearth/ygo@v1.0.2
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/content.go
+++ b/crdt/content.go
@@ -206,3 +206,15 @@ func (c *ContentDoc) Len() int             { return 1 }
 func (c *ContentDoc) IsCountable() bool    { return true }
 func (c *ContentDoc) Copy() Content        { return &ContentDoc{c.Doc} }
 func (c *ContentDoc) Splice(_ int) Content { panic("crdt: ContentDoc is not splittable") }
+
+// contentSkip is a decode-only placeholder for V1 skip structs (tag 10).
+// Skip structs represent clock ranges the sender intentionally omits.
+// They are consumed during decoding and never stored in the document.
+type contentSkip struct{ length int }
+
+func (s *contentSkip) Len() int          { return s.length }
+func (s *contentSkip) IsCountable() bool { return false }
+func (s *contentSkip) Copy() Content     { return &contentSkip{s.length} }
+func (s *contentSkip) Splice(_ int) Content {
+	panic("crdt: contentSkip is not splittable")
+}

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -35,6 +35,12 @@ func WithGC(gc bool) DocOption {
 	return func(d *Doc) { d.gc = gc }
 }
 
+// WithGUID sets the document's subdocument identifier. When a Doc is embedded
+// inside another Doc via ContentDoc, the GUID identifies it across peers.
+func WithGUID(guid string) DocOption {
+	return func(d *Doc) { d.guid = guid }
+}
+
 // updateSub pairs a unique subscription ID with its callback so that
 // unsubscribe closures can find and remove the right entry even when
 // callbacks are removed out-of-order.
@@ -54,6 +60,7 @@ type transactionSub struct {
 type Doc struct {
 	clientID ClientID
 	gc       bool
+	guid     string // subdocument identifier; empty for root docs
 
 	store *StructStore
 	share map[string]sharedType // named root types
@@ -82,6 +89,11 @@ type Doc struct {
 // ClientID returns the document's client identifier (read-only after creation).
 func (d *Doc) ClientID() ClientID {
 	return d.clientID
+}
+
+// GUID returns the document's subdocument identifier (empty for root docs).
+func (d *Doc) GUID() string {
+	return d.guid
 }
 
 // New creates a new Doc with a randomly generated ClientID.

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -312,7 +312,11 @@ func encodeContent(enc *encoding.Encoder, c Content, offset int) {
 			enc.WriteAny(v)
 		}
 	case *ContentDoc:
-		enc.WriteVarBytes([]byte{})
+		guid := ""
+		if ct.Doc != nil {
+			guid = ct.Doc.GUID()
+		}
+		enc.WriteVarBytes([]byte(guid))
 	}
 }
 
@@ -397,6 +401,8 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		return ErrInvalidUpdate
 	}
 
+	var pending []*Item
+
 	totalStructs := uint64(0)
 	for i := uint64(0); i < numClients; i++ {
 		numStructs, err := dec.ReadVarUint()
@@ -424,6 +430,14 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 			if err != nil {
 				return wrapUpdateErr(err)
 			}
+
+			// Skip structs (tag 10) are clock-range placeholders that are
+			// never stored — just advance the clock.
+			if _, isSkip := item.Content.(*contentSkip); isSkip {
+				clock += uint64(item.Content.Len())
+				continue
+			}
+
 			contentLen := uint64(item.Content.Len())
 			itemEnd := clock + contentLen
 
@@ -439,6 +453,26 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 				offset = int(existingEnd - clock)
 			}
 
+			// GC items (tag 0) have no parent — add directly to the store
+			// without linked-list integration.
+			if item.Parent == nil && item.Deleted {
+				if offset > 0 {
+					item.ID.Clock += uint64(offset)
+					item.Content = item.Content.Splice(offset)
+				}
+				txn.doc.store.Append(item)
+				clock = itemEnd
+				continue
+			}
+
+			// Items whose parent can't be resolved yet (cross-client
+			// reference to a group not yet decoded) are deferred.
+			if item.Parent == nil {
+				pending = append(pending, item)
+				clock = itemEnd
+				continue
+			}
+
 			// Resolve left neighbor from the Origin ID so that integrate()
 			// starts its scan from the correct position in the linked list.
 			// (Local inserts set item.Left directly; remote items only have Origin.)
@@ -449,6 +483,36 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 			item.integrate(txn, offset)
 			clock = itemEnd
 		}
+	}
+
+	// Retry items whose parent couldn't be resolved during the first pass
+	// because their origin items were in a later client group.
+	for len(pending) > 0 {
+		var remaining []*Item
+		for _, item := range pending {
+			if item.Origin != nil {
+				if oi := txn.doc.store.Find(*item.Origin); oi != nil {
+					item.Parent = oi.Parent
+				}
+			}
+			if item.Parent == nil && item.OriginRight != nil {
+				if ori := txn.doc.store.Find(*item.OriginRight); ori != nil {
+					item.Parent = ori.Parent
+				}
+			}
+			if item.Parent != nil {
+				if item.Origin != nil {
+					item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
+				}
+				item.integrate(txn, 0)
+			} else {
+				remaining = append(remaining, item)
+			}
+		}
+		if len(remaining) == len(pending) {
+			return fmt.Errorf("%w: %d items with unresolvable parents", ErrInvalidUpdate, len(remaining))
+		}
+		pending = remaining
 	}
 
 	ds, err := decodeDeleteSet(dec)
@@ -465,6 +529,35 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 		return nil, err
 	}
 	tag := info & 0x1F
+
+	// GC struct (tag 0): placeholder for garbage-collected content.
+	// Yjs encodes these as {info=0, VarUint(length)} — no origins, parent,
+	// or content fields. They fill clock gaps in the store.
+	if tag == 0 {
+		length, err := dec.ReadVarUint()
+		if err != nil {
+			return nil, err
+		}
+		return &Item{
+			ID:      ID{Client: client, Clock: clock},
+			Content: NewContentDeleted(int(length)),
+			Deleted: true,
+		}, nil
+	}
+
+	// Skip struct (tag 10): clock-range placeholder the sender intentionally
+	// omits. Wire format: {info, VarUint(length)}. Not stored in the document.
+	if tag == 10 {
+		length, err := dec.ReadVarUint()
+		if err != nil {
+			return nil, err
+		}
+		return &Item{
+			ID:      ID{Client: client, Clock: clock},
+			Content: &contentSkip{length: int(length)},
+		}, nil
+	}
+
 	hasOrigin := info&flagHasOrigin != 0
 	hasRightOrigin := info&flagHasRightOrigin != 0
 	hasParentSub := info&flagHasParentSub != 0
@@ -567,10 +660,8 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 		}
 	}
 
-	if item.Parent == nil {
-		return nil, fmt.Errorf("could not determine parent for item {%d,%d}", client, clock)
-	}
-
+	// item.Parent may be nil when origin items belong to a client group not
+	// yet decoded in this update. The caller retries these after all groups.
 	return item, nil
 }
 
@@ -665,10 +756,12 @@ func decodeContent(dec *encoding.Decoder, doc *Doc, tag byte) (Content, error) {
 		return NewContentAny(vals...), nil
 
 	case wireDoc:
-		if _, err := dec.ReadVarBytes(); err != nil {
+		guidBytes, err := dec.ReadVarBytes()
+		if err != nil {
 			return nil, err
 		}
-		return NewContentDoc(New()), nil
+		guid := string(guidBytes)
+		return NewContentDoc(New(WithGUID(guid))), nil
 
 	default:
 		return nil, fmt.Errorf("unknown content tag: %d", tag)

--- a/crdt/update_test.go
+++ b/crdt/update_test.go
@@ -432,8 +432,8 @@ func TestUnit_ApplyUpdateV1_GCStructDecode(t *testing.T) {
 	enc.WriteVarUint(5)
 
 	// Struct 1: string item at clock 5, parent = root "content"
-	enc.WriteUint8(wireString)  // tag=4, no flags
-	enc.WriteUint8(1)           // parentInfo=1 → named root
+	enc.WriteUint8(wireString) // tag=4, no flags
+	enc.WriteUint8(1)          // parentInfo=1 → named root
 	enc.WriteVarString("content")
 	enc.WriteVarString("world")
 
@@ -532,7 +532,7 @@ func TestUnit_ApplyUpdateV1_SkipStruct(t *testing.T) {
 	enc.WriteVarUint(0) // startClock = 0
 
 	// Skip struct: info byte with tag=10, then VarUint(length)
-	enc.WriteUint8(10) // tag=10 (skip), no flags
+	enc.WriteUint8(10)  // tag=10 (skip), no flags
 	enc.WriteVarUint(5) // skip 5 clock values
 
 	// Regular string at clock 5
@@ -585,7 +585,7 @@ func TestUnit_WithGUID(t *testing.T) {
 	assert.Equal(t, "test-guid", doc.GUID())
 
 	doc2 := New()
-	assert.Equal(t, "", doc2.GUID())
+	assert.Empty(t, doc2.GUID())
 }
 
 func TestUnit_ApplyUpdateV1_CrossClientMultiHop(t *testing.T) {

--- a/crdt/update_test.go
+++ b/crdt/update_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/encoding"
 )
 
 // ── Unit tests ────────────────────────────────────────────────────────────────
@@ -411,4 +413,225 @@ func FuzzApplyUpdateV2(f *testing.F) {
 		d := New()
 		_ = ApplyUpdateV2(d, data, nil) // must not panic regardless of input
 	})
+}
+
+// ── GC struct and cross-client tests ─────────────────────────────────────────
+
+func TestUnit_ApplyUpdateV1_GCStructDecode(t *testing.T) {
+	// Yjs encodes GC items as {info=0, VarUint(length)}. Verify the V1
+	// decoder handles them without misaligning subsequent items.
+	enc := encoding.NewEncoder()
+
+	enc.WriteVarUint(1) // 1 client group
+	enc.WriteVarUint(2) // 2 structs
+	enc.WriteVarUint(1) // clientID = 1
+	enc.WriteVarUint(0) // startClock = 0
+
+	// Struct 0: GC (info=0, length=5)
+	enc.WriteUint8(0)
+	enc.WriteVarUint(5)
+
+	// Struct 1: string item at clock 5, parent = root "content"
+	enc.WriteUint8(wireString)  // tag=4, no flags
+	enc.WriteUint8(1)           // parentInfo=1 → named root
+	enc.WriteVarString("content")
+	enc.WriteVarString("world")
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(2))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+	assert.Equal(t, "world", doc.GetText("content").ToString())
+}
+
+func TestUnit_ApplyUpdateV1_CrossClientParentResolution(t *testing.T) {
+	// Client 200 creates "hello" in YText "t". Client 100 appends " world"
+	// with origin={200,4}. Encoding order is by client ID: 100 before 200,
+	// so client 100's origin is not yet decoded when first encountered.
+	enc := encoding.NewEncoder()
+
+	enc.WriteVarUint(2) // 2 client groups
+
+	// Group 1: client=100
+	enc.WriteVarUint(1)   // 1 struct
+	enc.WriteVarUint(100) // clientID
+	enc.WriteVarUint(0)   // startClock
+
+	enc.WriteUint8(wireString | flagHasOrigin)
+	enc.WriteVarUint(200) // origin client
+	enc.WriteVarUint(4)   // origin clock (last char of "hello")
+	enc.WriteVarString(" world")
+
+	// Group 2: client=200
+	enc.WriteVarUint(1)   // 1 struct
+	enc.WriteVarUint(200) // clientID
+	enc.WriteVarUint(0)   // startClock
+
+	enc.WriteUint8(wireString) // no flags → explicit parent
+	enc.WriteUint8(1)          // named root
+	enc.WriteVarString("t")
+	enc.WriteVarString("hello")
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(999))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+	assert.Equal(t, "hello world", doc.GetText("t").ToString())
+}
+
+func TestUnit_ApplyUpdateV1_GCThenCrossClient(t *testing.T) {
+	// Combines both GC structs and cross-client references in one update.
+	// Client 100: GC(len=3) at clock 0, then string " end" at clock 3
+	//             with origin={200, 1} (cross-client).
+	// Client 200: string "ab" at clock 0, parent = root "t".
+	enc := encoding.NewEncoder()
+
+	enc.WriteVarUint(2) // 2 client groups
+
+	// Group 1: client=100
+	enc.WriteVarUint(2)   // 2 structs
+	enc.WriteVarUint(100) // clientID
+	enc.WriteVarUint(0)   // startClock
+
+	// GC struct: clock 0, length 3
+	enc.WriteUint8(0)
+	enc.WriteVarUint(3)
+
+	// String item: clock 3, origin={200, 1}
+	enc.WriteUint8(wireString | flagHasOrigin)
+	enc.WriteVarUint(200) // origin client
+	enc.WriteVarUint(1)   // origin clock
+	enc.WriteVarString(" end")
+
+	// Group 2: client=200
+	enc.WriteVarUint(1)   // 1 struct
+	enc.WriteVarUint(200) // clientID
+	enc.WriteVarUint(0)   // startClock
+
+	enc.WriteUint8(wireString) // no flags → explicit parent
+	enc.WriteUint8(1)          // named root
+	enc.WriteVarString("t")
+	enc.WriteVarString("ab")
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(999))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+	assert.Equal(t, "ab end", doc.GetText("t").ToString())
+}
+
+func TestUnit_ApplyUpdateV1_SkipStruct(t *testing.T) {
+	// Skip structs (tag 10) represent clock gaps the sender intentionally
+	// omits. Verify the V1 decoder handles them without error and that
+	// regular items after the skip decode correctly.
+	enc := encoding.NewEncoder()
+
+	enc.WriteVarUint(1) // 1 client group
+	enc.WriteVarUint(2) // 2 structs
+	enc.WriteVarUint(1) // clientID = 1
+	enc.WriteVarUint(0) // startClock = 0
+
+	// Skip struct: info byte with tag=10, then VarUint(length)
+	enc.WriteUint8(10) // tag=10 (skip), no flags
+	enc.WriteVarUint(5) // skip 5 clock values
+
+	// Regular string at clock 5
+	enc.WriteUint8(wireString)
+	enc.WriteUint8(1) // named root
+	enc.WriteVarString("t")
+	enc.WriteVarString("hello")
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(2))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+	assert.Equal(t, "hello", doc.GetText("t").ToString())
+}
+
+func TestUnit_ContentDoc_GUID_V1RoundTrip(t *testing.T) {
+	// Verify that a subdocument's GUID survives V1 encode → decode.
+	// Build a synthetic V1 update with a wireDoc content item.
+	enc := encoding.NewEncoder()
+	enc.WriteVarUint(1) // 1 client group
+	enc.WriteVarUint(1) // 1 struct
+	enc.WriteVarUint(1) // clientID = 1
+	enc.WriteVarUint(0) // startClock = 0
+
+	enc.WriteUint8(wireDoc) // tag=9 (wireDoc), no flags
+	enc.WriteUint8(1)       // parentInfo=1 → named root
+	enc.WriteVarString("subdocs")
+	enc.WriteVarBytes([]byte("my-subdoc-id")) // guid
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(2))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+
+	// Re-encode and decode again to verify GUID round-trips.
+	update2 := EncodeStateAsUpdateV1(doc, nil)
+	doc2 := New(WithClientID(3))
+	require.NoError(t, ApplyUpdateV1(doc2, update2, nil))
+
+	// Walk the store to find the ContentDoc and verify its GUID.
+	items := doc2.store.clients[1]
+	require.Len(t, items, 1)
+	cd, ok := items[0].Content.(*ContentDoc)
+	require.True(t, ok, "expected ContentDoc")
+	assert.Equal(t, "my-subdoc-id", cd.Doc.GUID())
+}
+
+func TestUnit_WithGUID(t *testing.T) {
+	doc := New(WithGUID("test-guid"))
+	assert.Equal(t, "test-guid", doc.GUID())
+
+	doc2 := New()
+	assert.Equal(t, "", doc2.GUID())
+}
+
+func TestUnit_ApplyUpdateV1_CrossClientMultiHop(t *testing.T) {
+	// Three clients where dependencies chain: 100→200→300.
+	// All items end up in the same YText "t".
+	//
+	// Client 300: "A" at clock 0 (root, no origin)
+	// Client 200: "B" at clock 0, origin={300, 0}
+	// Client 100: "C" at clock 0, origin={200, 0}
+	//
+	// Encoded order: 100, 200, 300. Neither 100 nor 200 can resolve
+	// parents on the first pass.
+	enc := encoding.NewEncoder()
+
+	enc.WriteVarUint(3) // 3 client groups
+
+	// Group 1: client=100
+	enc.WriteVarUint(1)
+	enc.WriteVarUint(100)
+	enc.WriteVarUint(0)
+	enc.WriteUint8(wireString | flagHasOrigin)
+	enc.WriteVarUint(200)
+	enc.WriteVarUint(0)
+	enc.WriteVarString("C")
+
+	// Group 2: client=200
+	enc.WriteVarUint(1)
+	enc.WriteVarUint(200)
+	enc.WriteVarUint(0)
+	enc.WriteUint8(wireString | flagHasOrigin)
+	enc.WriteVarUint(300)
+	enc.WriteVarUint(0)
+	enc.WriteVarString("B")
+
+	// Group 3: client=300
+	enc.WriteVarUint(1)
+	enc.WriteVarUint(300)
+	enc.WriteVarUint(0)
+	enc.WriteUint8(wireString)
+	enc.WriteUint8(1)
+	enc.WriteVarString("t")
+	enc.WriteVarString("A")
+
+	enc.WriteVarUint(0) // empty delete set
+
+	doc := New(WithClientID(999))
+	require.NoError(t, ApplyUpdateV1(doc, enc.Bytes(), nil))
+	assert.Equal(t, "ABC", doc.GetText("t").ToString())
 }

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -486,7 +486,11 @@ func encodeContentV2(enc *v2Encoder, c Content, offset int) {
 			enc.restEnc.WriteAny(v)
 		}
 	case *ContentDoc:
-		enc.writeString("")
+		guid := ""
+		if ct.Doc != nil {
+			guid = ct.Doc.GUID()
+		}
+		enc.writeString(guid)
 		enc.restEnc.WriteAny(nil)
 	}
 }
@@ -539,6 +543,8 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 	if numClients > maxV2Items {
 		return ErrInvalidUpdate
 	}
+
+	var pending []*Item
 
 	totalStructs := uint64(0)
 	for i := uint64(0); i < numClients; i++ {
@@ -622,6 +628,14 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 				offset = int(existingEnd - clock)
 			}
 
+			// Items whose parent can't be resolved yet (cross-client
+			// reference to a group not yet decoded) are deferred.
+			if item.Parent == nil {
+				pending = append(pending, item)
+				clock = itemEnd
+				continue
+			}
+
 			if offset == 0 && item.Origin != nil {
 				item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
 			}
@@ -629,6 +643,36 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 			item.integrate(txn, offset)
 			clock = itemEnd
 		}
+	}
+
+	// Retry items whose parent couldn't be resolved during the first pass
+	// because their origin items were in a later client group.
+	for len(pending) > 0 {
+		var remaining []*Item
+		for _, item := range pending {
+			if item.Origin != nil {
+				if oi := txn.doc.store.Find(*item.Origin); oi != nil {
+					item.Parent = oi.Parent
+				}
+			}
+			if item.Parent == nil && item.OriginRight != nil {
+				if ori := txn.doc.store.Find(*item.OriginRight); ori != nil {
+					item.Parent = ori.Parent
+				}
+			}
+			if item.Parent != nil {
+				if item.Origin != nil {
+					item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
+				}
+				item.integrate(txn, 0)
+			} else {
+				remaining = append(remaining, item)
+			}
+		}
+		if len(remaining) == len(pending) {
+			return fmt.Errorf("%w: %d items with unresolvable parents", ErrInvalidUpdate, len(remaining))
+		}
+		pending = remaining
 	}
 
 	// Decode delete set
@@ -732,10 +776,8 @@ func decodeItemV2(dec *v2Decoder, doc *Doc, client ClientID, clock uint64, info 
 		}
 	}
 
-	if item.Parent == nil {
-		return nil, 0, fmt.Errorf("could not determine parent for item {%d,%d}", client, clock)
-	}
-
+	// item.Parent may be nil when origin items belong to a client group not
+	// yet decoded in this update. The caller retries these after all groups.
 	return item, content.Len(), nil
 }
 
@@ -836,14 +878,14 @@ func decodeContentV2(dec *v2Decoder, doc *Doc, tag byte) (Content, error) {
 		return NewContentAny(vals...), nil
 
 	case wireDoc:
-		// readString (doc guid) + readAny (opts) — we discard both
-		if _, err := dec.readString(); err != nil {
+		guid, err := dec.readString()
+		if err != nil {
 			return nil, err
 		}
-		if _, err := dec.readAny(); err != nil {
+		if _, err := dec.readAny(); err != nil { // opts — not yet used
 			return nil, err
 		}
-		return NewContentDoc(New()), nil
+		return NewContentDoc(New(WithGUID(guid))), nil
 
 	default:
 		return nil, fmt.Errorf("unknown V2 content tag: %d", tag)

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -244,8 +244,13 @@ func (a *YArray) ForEach(fn func(index int, value any)) {
 
 // Move removes the element at fromIndex and reinserts it at toIndex.
 // Both indices are in terms of the logical (non-deleted) position.
-// Note: this is a simplified delete-then-insert implementation; the moved
-// element receives a new Item ID and loses its original causal history.
+//
+// WARNING: Move is NOT safe for concurrent use across multiple clients.
+// It is implemented as delete-then-insert: the moved element receives a new
+// Item ID and loses its original causal history. If two peers concurrently
+// move the same element, the result may contain duplicates or lose the
+// element entirely. Use Move only in single-writer scenarios or when
+// application-level conflict resolution is in place.
 //
 // Move walks the linked list directly instead of calling Get() because Get()
 // acquires doc.mu.RLock() while Move is called from inside a Transact callback

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode"
 
 	gws "github.com/gorilla/websocket"
 
@@ -39,6 +38,7 @@ const writeTimeout = 10 * time.Second
 const (
 	msgSync           = uint64(0)
 	msgAwareness      = uint64(1)
+	msgAuth           = uint64(2) // y-websocket auth; silently ignored
 	msgQueryAwareness = uint64(3)
 )
 
@@ -198,13 +198,19 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 }
 
 // isValidRoomName reports whether name is a safe, non-empty room identifier.
-// Allowed characters: letters, digits, hyphen, underscore, dot. Max 255 bytes.
+// Rejected: empty string, names exceeding 255 bytes, names consisting solely
+// of "." or ".." (path traversal), and names containing control characters
+// (runes < 0x20). All other printable content, including spaces and Unicode,
+// is permitted — matching the permissive behavior of the y-websocket JS server.
 func isValidRoomName(name string) bool {
 	if len(name) == 0 || len(name) > 255 {
 		return false
 	}
+	if name == "." || name == ".." {
+		return false
+	}
 	for _, r := range name {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' && r != '.' {
+		if r < 0x20 {
 			return false
 		}
 	}
@@ -530,6 +536,10 @@ func (p *peer) handleMessage(data []byte) {
 			return // Drop invalid awareness updates; do not broadcast.
 		}
 		p.broadcastAwareness(awBytes)
+
+	case msgAuth:
+		// Auth messages (type 2) are defined by y-websocket but not used by
+		// this server. Silently ignore.
 
 	case msgQueryAwareness:
 		p.sendAwareness(p.room.awareness.EncodeUpdate(nil))


### PR DESCRIPTION
## Summary

Seven fixes improving interoperability with JavaScript Yjs v13 clients, found via a 4-agent parallel audit of wire format, sync protocol, CRDT semantics, and JS interop test coverage.

- **V1 GC struct decoding (tag 0)**: Yjs encodes garbage-collected items as `{info=0, VarUint(length)}`. The V1 decoder misaligned on these, corrupting all subsequent items in the update.
- **V1 skip struct decoding (tag 10)**: Yjs uses skip structs in partial updates. Rejected as "unknown content tag: 10".
- **Cross-client parent resolution (V1 + V2)**: Items from a lower client ID referencing a higher client ID's origin failed because the higher group hadn't been decoded yet. Added a pending retry loop (matching Yjs's `getMissing` mechanism).
- **ContentDoc GUID preservation**: Subdocument identity was discarded during decode. Now preserved via new `WithGUID`/`GUID()` API.
- **Room name validation**: Relaxed from `[A-Za-z0-9._-]` to all printable characters, matching y-websocket.
- **y-websocket auth (msg type 2)**: Explicitly handled as a no-op instead of silently dropped.
- **YArray.Move**: Godoc now warns about concurrent-use limitations (not CRDT-safe).

## Test plan

- [x] 7 new unit tests added (GC struct, skip struct, cross-client 2-hop, cross-client 3-hop, GC+cross-client combo, ContentDoc GUID round-trip, WithGUID)
- [x] All existing tests pass with `-race` across all packages
- [ ] Manual smoke test with Yjs browser client