### PR TITLE
chore: release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] — 2026-04-13
+
+### Added
+
+- **CRDT-safe array Move**: `YArray.Move()` now creates a `ContentMove` marker item instead of deleting and reinserting. The moved element preserves causal history; concurrent moves of different elements both apply; concurrent moves of the same element converge to the lower-ClientID winner. `ContentMove` is included in V1 and V2 wire encoding (`wireMove = 11`).
+- **XML insert API**: `YXmlFragment.InsertElement`, `YXmlFragment.InsertText`, `YXmlElement.InsertElement`, and `YXmlElement.InsertText` are now exported, allowing external packages to build XML documents programmatically without reflection.
+
+### Fixed
+
+- **YText Format observer delta**: `YText.Format()` now emits an accurate `retain N + attributes` delta to observers. Previously the delta was missing or malformed, causing collaborative editors to show stale formatting to connected peers.
+
 ## [1.0.4] — 2026-04-10
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,13 @@
-## Fixes
+## What's new
 
-- **Nil panic on reconnect**: Server no longer panics when a reconnecting client sends state containing GC'd YMap replacement items. The `delete()` path now guards against orphaned items with no parent.
-- **Cross-browser sync with emoji**: ContentString offset encoding now correctly uses UTF-16 code units instead of Unicode code points. Fixes corrupt binary output when strings contain emoji or supplementary characters, which caused Yjs decode failures across different browser engines (V8 vs JavaScriptCore).
+- **CRDT-safe array Move**: `YArray.Move()` is now a proper CRDT primitive. The previous delete-then-insert approach lost causal history and diverged under concurrent edits. The new implementation uses a `ContentMove` marker so the element preserves its identity, concurrent moves of different elements both apply, and concurrent moves of the same element converge to the lower-ClientID winner. Included in V1 and V2 wire encoding.
+- **YText Format observer delta fix**: `YText.Format()` now emits an accurate `retain + attributes` delta to observers. Previously the delta was missing or reported the wrong range, which would cause collaborative editors to show stale formatting to peers.
+- **XML insert API**: `YXmlFragment` and `YXmlElement` now expose `InsertElement` and `InsertText` as exported methods, making it possible to build XML documents programmatically from outside the `crdt` package.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.0.4
+go get github.com/reearth/ygo@v1.0.5
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.


### PR DESCRIPTION
Updates `CHANGELOG.md` and `RELEASE_NOTES.md` for the v1.0.5 release.

After this merges, tag `v1.0.5` will be pushed to trigger the release workflow.

## What's included

- **CRDT-safe array Move** via `ContentMove` — convergent under concurrent edits, included in V1/V2 wire encoding
- **YText Format observer delta fix** — observers now receive accurate `retain + attributes` deltas
- **Exported XML insert API** — `InsertElement` / `InsertText` on `YXmlFragment` and `YXmlElement`