### PR TITLE
feat(crdt): TransactE + TransactContextE error-returning variants (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] — 2026-04-24
+
+### Added
+
+- **`Doc.TransactE` and `Doc.TransactContextE` (#14)**: error-returning sibling methods for `Transact` and `TransactContext`. Callers can now signal logical errors from inside a transaction body without resorting to panic (too heavy) or out-of-band channels (clumsy). `fn`'s returned error becomes the method return value. For `TransactContextE`, `ctx.Err()` wins when both a ctx cancellation and an fn error fire. Mutations commit regardless of error (no rollback — matches Yjs JS's `doc.transact(f)` and yrs' RAII semantics); observers fire BEFORE the error returns, matching Yjs JS's `cleanupTransactions`-in-`finally` pattern.
+
+### Changed
+
+- **`transactInternal` refactored** to take `func(*Transaction) error` and return `error`. The existing `Transact` and `TransactContext` are thin wrappers and keep their original signatures — strictly additive for public callers.
+
 ## [1.2.0] — 2026-04-23
 
 ### Fixed
@@ -189,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.3.0]: https://github.com/reearth/ygo/releases/tag/v1.3.0
 [1.2.0]: https://github.com/reearth/ygo/releases/tag/v1.2.0
 [1.1.2]: https://github.com/reearth/ygo/releases/tag/v1.1.2
 [1.1.1]: https://github.com/reearth/ygo/releases/tag/v1.1.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,12 @@
 ## What's new
 
-- **Cross-update Origin resolution on out-of-order delivery (#11).** Peers that received delta updates out of dependency order used to silently orphan items whose `Origin` references hadn't yet integrated — producing permanent convergence gaps. Updates now park unresolved items in a doc-level pending queue and retry them automatically on each subsequent apply. Same-client clock gaps and delete-set entries targeting not-yet-integrated items follow the same path.
-- **Convergence parity with Yjs JS and yrs.** The pending-structs machinery matches the upstream implementations semantically. State vector still reports integrated-only clocks, so remote peers continue to detect gaps and re-send automatically.
+- **`Doc.TransactE` and `Doc.TransactContextE` (#14).** Error-returning variants of the existing transaction methods. Callers who detect a logical error inside `fn` can now return it cleanly instead of panicking or threading an out-of-band channel. `fn`'s returned error becomes the method's return value. Mutations still commit regardless of error (no rollback — matches Yjs JS and yrs); observers fire before the error returns. For `TransactContextE`, ctx cancellation wins over fn error when both fire.
+- **Strictly additive.** Existing `Transact` and `TransactContext` keep their signatures and behavior unchanged.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.2.0
+go get github.com/reearth/ygo@v1.3.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/crdt_test.go
+++ b/crdt/crdt_test.go
@@ -7,6 +7,7 @@ package crdt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -1397,4 +1398,112 @@ func TestUnit_ApplyV1_RetryLoop_PanicRestoresPending(t *testing.T) {
 	// machinery should be no-op on the happy path.
 	require.NoError(t, ApplyUpdateV1(peer, updateA, nil))
 	assert.Nil(t, peer.store.pending, "happy path: retry loop drains without leaving residue")
+}
+
+// ── TransactE / TransactContextE tests ──────────────────────────────────────
+
+func TestInteg_TransactE_ReturnsNilFromFn(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+	err := doc.TransactE(func(txn *Transaction) error {
+		arr.Insert(txn, 0, []any{"x"})
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, arr.Len())
+}
+
+func TestInteg_TransactE_PropagatesFnError(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+	sentinel := errors.New("validation failed")
+	err := doc.TransactE(func(txn *Transaction) error {
+		arr.Insert(txn, 0, []any{"x"})
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+	// No rollback — mutations still commit (matches Yjs JS + yrs).
+	assert.Equal(t, 1, arr.Len(), "mutations commit even when fn returns error")
+}
+
+func TestInteg_TransactE_ObserversFireEvenOnError(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+	var observerFired bool
+	unsub := doc.OnUpdate(func(update []byte, origin any) {
+		observerFired = true
+	})
+	defer unsub()
+
+	err := doc.TransactE(func(txn *Transaction) error {
+		arr.Insert(txn, 0, []any{"x"})
+		return errors.New("boom")
+	})
+	require.Error(t, err)
+	assert.True(t, observerFired, "OnUpdate must fire even when fn returns error (matches Yjs JS finally-block observer firing)")
+}
+
+func TestInteg_TransactE_PanicStillRecovered(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+
+	assert.Panics(t, func() {
+		_ = doc.TransactE(func(txn *Transaction) error {
+			arr.Insert(txn, 0, []any{"x"})
+			panic("boom")
+		})
+	})
+	// Partial state committed per v1.1.1 contract.
+	assert.Equal(t, 1, arr.Len())
+}
+
+func TestInteg_TransactContextE_PropagatesFnError(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+	sentinel := errors.New("validation failed")
+	err := doc.TransactContextE(context.Background(), func(txn *Transaction) error {
+		arr.Insert(txn, 0, []any{"x"})
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, arr.Len())
+}
+
+func TestInteg_TransactContextE_CtxCancelWinsOverFnError(t *testing.T) {
+	doc := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	fnSentinel := errors.New("fn failed")
+
+	err := doc.TransactContextE(ctx, func(txn *Transaction) error {
+		cancel() // cancel ctx inside fn
+		return fnSentinel
+	})
+	// ctx.Err() must win over fn error (matches TransactContext precedent).
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, fnSentinel)
+}
+
+func TestInteg_TransactContextE_PreCancelledCtxReturnsImmediately(t *testing.T) {
+	doc := New()
+	arr := doc.GetArray("a")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fnRan := false
+	err := doc.TransactContextE(ctx, func(txn *Transaction) error {
+		fnRan = true
+		arr.Insert(txn, 0, []any{"x"})
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, fnRan, "fn must not be invoked when ctx is pre-cancelled")
+	assert.Equal(t, 0, arr.Len())
+}
+
+func TestInteg_TransactContextE_NilFnErrorReturnsNil(t *testing.T) {
+	doc := New()
+	err := doc.TransactContextE(context.Background(), func(txn *Transaction) error {
+		return nil
+	})
+	require.NoError(t, err)
 }

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -308,15 +308,20 @@ func buildPhase2(d *Doc, txn *Transaction) func() {
 	}
 }
 
-// transactInternal is the shared transaction entry point that Transact
-// and TransactContext both delegate to. It acquires d.mu, runs fn under
-// the lock with panic-safe cleanup, fires Phase 2 observers outside the
-// lock, and re-raises any panic to the caller. The ctx parameter is
-// stored on the Transaction struct and exposed to fn via Transaction.Ctx().
+// transactInternal is the shared transaction entry point that Transact,
+// TransactContext, TransactE, and TransactContextE all delegate to. It
+// acquires d.mu, runs fn under the lock with panic-safe cleanup, fires
+// Phase 2 observers outside the lock, and re-raises any panic to the
+// caller. The ctx parameter is stored on the Transaction struct and
+// exposed to fn via Transaction.Ctx().
+//
+// fn's returned error is captured as the named return value retErr.
+// Observers fire regardless of whether fn returned an error; the error
+// is propagated to the caller only after the observers have fired.
 //
 // See docs/superpowers/specs/2026-04-21-transact-panic-safety-design.md
 // for the full rationale on the defer/recover structure.
-func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction), origin ...any) {
+func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction) error, origin ...any) (retErr error) {
 	var orig any
 	if len(origin) > 0 {
 		orig = origin[0]
@@ -367,11 +372,12 @@ func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction), origi
 		}
 	}()
 
-	fn(txn)
+	retErr = fn(txn)
 
 	txn.afterState = d.store.StateVector()
 
 	squashRuns(txn)
+	return retErr
 }
 
 // Transact executes fn inside a transaction. All insertions and deletions made
@@ -400,7 +406,27 @@ func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction), origi
 //     firing, the observer's panic reaches the caller and the original
 //     fn panic value is lost.
 func (d *Doc) Transact(fn func(*Transaction), origin ...any) {
-	d.transactInternal(context.Background(), fn, origin...)
+	_ = d.transactInternal(context.Background(), func(t *Transaction) error {
+		fn(t)
+		return nil
+	}, origin...)
+}
+
+// TransactE is like Transact but allows fn to return an error. The error is
+// returned to the caller after all observers have fired. Mutations commit
+// regardless of the error (no rollback — matches Yjs JS doc.transact(f) and
+// the Rust yrs implementation).
+//
+//   - If fn returns nil, TransactE returns nil.
+//   - If fn returns a non-nil error, that error becomes the return value of
+//     TransactE. Mutations that fn completed before returning are committed.
+//   - Observers (OnUpdate, OnAfterTransaction, per-type) fire BEFORE TransactE
+//     returns the error — matching the Yjs JS "finally-block observer" pattern.
+//   - If fn panics, the existing v1.1.1 panic-safety contract applies: partial
+//     state commits, observers fire with partial changes, and the panic is
+//     re-raised to the caller. TransactE does not swallow panics.
+func (d *Doc) TransactE(fn func(*Transaction) error, origin ...any) error {
+	return d.transactInternal(context.Background(), fn, origin...)
 }
 
 // OnUpdate registers a callback that fires after every committed transaction.
@@ -513,8 +539,40 @@ func (d *Doc) TransactContext(ctx context.Context, fn func(*Transaction), origin
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	d.transactInternal(ctx, fn, origin...)
+	_ = d.transactInternal(ctx, func(t *Transaction) error {
+		fn(t)
+		return nil
+	}, origin...)
 	return ctx.Err()
+}
+
+// TransactContextE is like TransactContext but allows fn to return an error.
+// It combines context-cancellation awareness with fn-error propagation.
+//
+//   - If ctx is already cancelled when TransactContextE is called, fn is not
+//     invoked and ctx.Err() is returned immediately.
+//   - If fn returns nil and ctx is not cancelled after the transaction commits,
+//     TransactContextE returns nil.
+//   - If fn returns a non-nil error but ctx is still fine, that error is
+//     returned.
+//   - If ctx cancels during fn (cooperative only — Go cannot safely interrupt
+//     arbitrary fn code), ctx.Err() wins over fn's error. This matches the
+//     precedent set by TransactContext and Yjs JS's ecosystem norm of
+//     cooperative cancellation polling via txn.Ctx().
+//   - Mutations commit regardless of fn's error or ctx cancellation (no
+//     rollback — matches Yjs JS doc.transact(f) and yrs semantics).
+//   - Observers fire BEFORE TransactContextE returns, even when fn errors.
+//   - Panics in fn follow the v1.1.1 panic-safety contract (partial commit,
+//     observer fire, re-raise).
+func (d *Doc) TransactContextE(ctx context.Context, fn func(*Transaction) error, origin ...any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fnErr := d.transactInternal(ctx, fn, origin...)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return fnErr
 }
 
 // Destroy detaches all observers and clears internal state, releasing


### PR DESCRIPTION
## Summary

Closes [#14](https://github.com/reearth/ygo/issues/14). Adds error-returning sibling methods for `Doc.Transact` and `Doc.TransactContext`. Callers who detect a logical error inside `fn` can now return it cleanly instead of resorting to panic (too heavy) or an out-of-band channel (clumsy).

```go
func (d *Doc) TransactE(fn func(*Transaction) error, origin ...any) error
func (d *Doc) TransactContextE(ctx context.Context, fn func(*Transaction) error, origin ...any) error
```

## Upstream grounding

- **Yjs JS** `doc.transact(f)` is generic over `T` — returns whatever `f` returns. If `f` throws, observers fire via `cleanupTransactions` inside a `finally` block BEFORE the exception propagates. No rollback.
- **yrs (Rust)** has no closure-based transact (RAII guards only); not directly applicable, but its drop-based commit semantics confirm the "no rollback on error" stance.
- Go lacks generics over return type at this call site, so a separate method is required. `E` suffix chosen over `Err` for terseness and to compose cleanly with `TransactContextE` (matches go-redis `Do`/`DoE` and similar community patterns).

## Behavioral contract

| Scenario | Behavior |
|---|---|
| `fn` returns `nil` | Transaction commits normally; method returns `nil` |
| `fn` returns `err` | Transaction **still commits** (no rollback — matches upstream); method returns `err`. Observers fire **before** return. |
| `fn` panics | Existing v1.1.1 panic-safety contract: partial state commits, observers fire, panic re-raises |
| `TransactContextE`: ctx cancelled before call | Returns `ctx.Err()` immediately; `fn` not invoked |
| `TransactContextE`: ctx cancels during `fn` | `fn` runs to completion (cooperative only); after commit, `ctx.Err()` wins over `fn`'s error |
| `TransactContextE`: `fn` returns error, ctx still fine | Returns `fn`'s error |

## Implementation

- `transactInternal` refactored to take `func(*Transaction) error` and return `error`.
- Existing `Transact` and `TransactContext` are thin wrappers around `transactInternal` with an adapter closure. **Signatures and observable behavior unchanged.**
- New `TransactE` and `TransactContextE` pass `fn` directly and propagate the error.

## Test plan

- [x] `go test -race -timeout 120s ./...` — all packages green.
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues.
- [x] `go vet ./...` / `go build ./...` — clean.
- [x] **8 new tests** covering:
  - `TransactE` returns nil from fn
  - `TransactE` propagates fn's error
  - Observers fire even when fn returns error (the Yjs-JS-`finally`-block parallel)
  - Panic still recovered (v1.1.1 regression)
  - `TransactContextE` propagates fn's error
  - Ctx cancellation wins over fn error
  - Pre-cancelled ctx returns immediately (fn not invoked)
  - `TransactContextE` returns nil from nil fn
- [x] All existing `Transact` / `TransactContext` tests pass unchanged (backward compat).

## Semver

**v1.3.0 minor.** Strictly additive — new public methods. Existing API surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)