### PR TITLE
docs: add godoc and invariant comments for crdt, awareness, websocket packages

### DIFF
--- a/crdt/delete_set.go
+++ b/crdt/delete_set.go
@@ -97,6 +97,10 @@ func (ds *DeleteSet) Clients() []ClientID {
 //
 // This is the pending-aware variant of applyTo, used by applyV1Txn
 // and applyV2Txn to defer deletes that target not-yet-integrated items.
+//
+// invariant: store.clients[client] is contiguous from clock 0.
+// If a future change relaxes contiguity, the applied-prefix math
+// may under-park ranges spanning a gap.
 func (ds *DeleteSet) applyToPartial(txn *Transaction) DeleteSet {
 	unresolvable := newDeleteSet()
 	for client, ranges := range ds.clients {

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -12,6 +12,13 @@
 //	update := doc.EncodeStateAsUpdate()
 //
 // Reference algorithm: https://github.com/yjs/yjs/blob/main/INTERNALS.md
+//
+// # Origin Tags
+//
+// The Origin field on Transaction, ChangeEvent (awareness), and
+// UndoManager.trackedOrigins uses type any for user-defined tags.
+// Callers must type-assert on read. Origin is used for filtering
+// in observers and undo-manager scope.
 package crdt
 
 import (

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -22,6 +22,8 @@ func (a *YArray) baseType() *abstractType { return &a.abstractType }
 // lock and returns a closure that fires all snapshotted observers. Callers in
 // Transact invoke the returned closure after releasing the lock, so observers
 // may safely call back into any Doc method (N-C1).
+//
+// prepareFire is called by buildPhase2 while the document write lock is held.
 func (a *YArray) prepareFire(txn *Transaction, _ map[string]struct{}) func() {
 	if len(a.observers) == 0 {
 		return nil

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -41,6 +41,12 @@ func (o InjectOp) String() string {
 
 // InjectInfo is passed to OnInject. Additional fields may be added in
 // future versions; callers must not rely on the struct being fixed-size.
+//
+// Fields:
+//   - Room: the room name the operation targets.
+//   - Op: identifies the calling method (BroadcastUpdate or Apply).
+//   - UpdateSize: length of the update bytes for BroadcastUpdate,
+//     or 0 for Apply (the delta has not yet been produced).
 type InjectInfo struct {
 	// Room is the room name the operation targets.
 	Room string


### PR DESCRIPTION
Item 1: Add Origin tags section to crdt package doc (Issue #30)
Item 2: Add godoc to YArray.prepareFire, InjectInfo struct (Issue #30)
Item 3: Add invariant comment to applyToPartial (Issue #30)

Changes:
- crdt/doc.go: Add Origin Tags section explaining the Origin field usage
- crdt/yarray.go: Add godoc to prepareFire explaining its caller context
- crdt/delete_set.go: Add invariant comment for applyToPartial
- provider/websocket/inject.go: Add Fields section to InjectInfo godoc

All changes are godoc-only — no behavioral changes.