### PR TITLE
feat: v1.5.0 security & observability (#23, #24, #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] — 2026-04-24
+
+### Added
+
+- **`Doc.PendingStats()` for pending-queue observability (#24)**: returns a snapshot of the pending-structs machinery shipped in v1.2.0 — how many items are parked, how many delete-set ranges are queued, which clients we're blocked on. Cheap (one RLock + small copy). Intended for operational monitoring of out-of-order delta convergence: detecting adversarial peers or persistent convergence gaps from misbehaving clients.
+- **`crdt.NewClientID()` public helper**: exposes the same ClientID generator used internally so callers can produce reproducible test setups or coordinate IDs externally.
+
+### Changed
+
+- **`provider/websocket`: hard-cap connections via `semaphore.Weighted` (#23)**: replaces the previous optimistic atomic-counter + rollback for `MaxConnections` and `MaxPeersPerRoom`. The atomic pattern had a race window where N+ε simultaneous connections could briefly exist past the cap before any were rejected. Semaphores provide a hard guarantee under any burst pattern. Adds `golang.org/x/sync` as a direct dependency.
+- **`crdt`, `provider/http`: ClientID generation now uses `crypto/rand` (#28)**: replaces `math/rand` at both sites. ClientIDs aren't authentication tokens, but predictable IDs in multi-tenant deployments are a footgun. `SECURITY.md` updated with explicit ClientID semantics.
+
 ## [1.4.1] — 2026-04-24
 
 ### Fixed
@@ -222,6 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.5.0]: https://github.com/reearth/ygo/releases/tag/v1.5.0
 [1.4.1]: https://github.com/reearth/ygo/releases/tag/v1.4.1
 [1.4.0]: https://github.com/reearth/ygo/releases/tag/v1.4.0
 [1.3.0]: https://github.com/reearth/ygo/releases/tag/v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`provider/websocket`: hard-cap connections via `semaphore.Weighted` (#23)**: replaces the previous optimistic atomic-counter + rollback for `MaxConnections` and `MaxPeersPerRoom`. The atomic pattern had a race window where N+ε simultaneous connections could briefly exist past the cap before any were rejected. Semaphores provide a hard guarantee under any burst pattern. Adds `golang.org/x/sync` as a direct dependency.
 - **`crdt`, `provider/http`: ClientID generation now uses `crypto/rand` (#28)**: replaces `math/rand` at both sites. ClientIDs aren't authentication tokens, but predictable IDs in multi-tenant deployments are a footgun. `SECURITY.md` updated with explicit ClientID semantics.
 
+### Documentation
+
+- **godoc and invariant comment polish (#30)** — contributed by @Jah-yee. Adds an `Origin Tags` section to the `crdt` package doc explaining the `Origin any` convention, struct-level godoc for `provider/websocket.InjectInfo`, godoc for `YArray.prepareFire`, and an invariant comment on `DeleteSet.applyToPartial` documenting the per-client clock-contiguity assumption.
+
 ## [1.4.1] — 2026-04-24
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 ## What's new
 
-Three small improvements bundled as a security + observability mini-release.
+Three small improvements bundled as a security + observability mini-release, plus a documentation polish from an external contributor.
 
 - **`Doc.PendingStats()` (#24)** — snapshot of the pending-structs machinery. Operators can now monitor pending-queue depth to detect adversarial peers, slow convergence, or persistent gaps from misbehaving clients.
 - **Hard-cap connections in `provider/websocket` (#23)** — `MaxConnections` and `MaxPeersPerRoom` now enforced via `semaphore.Weighted` rather than optimistic atomic counters. Closes the race window where bursts of concurrent connections could briefly exceed the configured cap.
 - **`crypto/rand` for ClientID generation (#28)** — replaces `math/rand` at both ClientID generation sites. New public helper `crdt.NewClientID()`. `SECURITY.md` clarifies that ClientIDs are collision-avoidance, not authentication.
+- **godoc and invariant comment polish (#30)** — contributed by @Jah-yee. Cleaner docs for the `Origin` tag convention, `InjectInfo` struct, `YArray.prepareFire`, and `applyToPartial`'s contiguity invariant.
 
 ## Install
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,15 @@
 ## What's new
 
-Two goroutine leak fixes plus one performance cleanup. Recommended upgrade for any v1.4.0 deployment.
+Three small improvements bundled as a security + observability mini-release.
 
-- **`runWriter` goroutine leak (#33)**: regression from v1.4.0. When a peer connected during a small race window where its target room was being deleted, the per-peer write goroutine could leak. Now correctly paired with cleanup on every code path.
-- **`StartAutoExpiry` double-call leak (#34)**: calling `StartAutoExpiry` twice on the same `Awareness` would orphan the first goroutine. Now the previous one is stopped before the new one starts. Returned `stop` is also safe to call more than once.
-- **Per-peer write goroutine spawn cleanup**: three call sites in the server-side inject paths (`BroadcastUpdate`, `Apply`) spawned a fresh goroutine per peer per write. After v1.4.0 made `peer.write()` non-blocking, these goroutines became wasteful and scrambled ordering. Now direct calls.
+- **`Doc.PendingStats()` (#24)** — snapshot of the pending-structs machinery. Operators can now monitor pending-queue depth to detect adversarial peers, slow convergence, or persistent gaps from misbehaving clients.
+- **Hard-cap connections in `provider/websocket` (#23)** — `MaxConnections` and `MaxPeersPerRoom` now enforced via `semaphore.Weighted` rather than optimistic atomic counters. Closes the race window where bursts of concurrent connections could briefly exceed the configured cap.
+- **`crypto/rand` for ClientID generation (#28)** — replaces `math/rand` at both ClientID generation sites. New public helper `crdt.NewClientID()`. `SECURITY.md` clarifies that ClientIDs are collision-avoidance, not authentication.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.4.1
+go get github.com/reearth/ygo@v1.5.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,14 @@ You can expect an acknowledgement within **48 hours** and a resolution timeline 
   - HTTP POST body and WebSocket frame: max 64 MiB (`maxUpdateBytes` / `maxWSMessageBytes`)
   - Awareness update: max 100 000 client entries (`maxAwarenessClients`); max 1 MiB per client state (`maxAwarenessStateBytes`)
   - `ReadAny` recursion: max 100 levels deep (`maxAnyDepth`)
+### ClientID semantics
+
+`crdt.ClientID` is a 32-bit value generated via `crypto/rand` and used to
+distinguish authoring peers during YATA conflict resolution. It is **not** an
+authentication token — the protocol does not validate that incoming updates
+match a peer's declared ClientID. Authentication and authorization are the
+embedder's responsibility (via `Server.AuthFunc`, request-level checks, etc.).
+
 - **Known limitations**:
   - No built-in cryptographic signatures or MACs on updates — add these at the transport layer if needed.
   - Subdocuments (`ContentDoc`) are structurally present in the wire format but not exposed as a user-facing API in this release.

--- a/crdt/crdt_test.go
+++ b/crdt/crdt_test.go
@@ -1522,3 +1522,41 @@ func TestUnit_NewClientID_NonZeroAndDistinct(t *testing.T) {
 		seen[id] = struct{}{}
 	}
 }
+
+func TestUnit_Doc_PendingStats_EmptyByDefault(t *testing.T) {
+	d := New()
+	stats := d.PendingStats()
+	assert.Equal(t, 0, stats.Items)
+	assert.Equal(t, 0, stats.DeleteRanges)
+	assert.Empty(t, stats.MissingFor)
+}
+
+func TestUnit_Doc_PendingStats_ReflectsParkedItems(t *testing.T) {
+	// Force a parked item via reverse-order delivery (same scenario as
+	// the #11 acceptance test). After parking, PendingStats should report
+	// Items > 0 and MissingFor containing the missing client.
+	a := newTestDoc(1)
+	arrA := a.GetArray("arr")
+	a.Transact(func(txn *Transaction) { arrA.Insert(txn, 0, []any{"a"}) })
+	updateA := EncodeStateAsUpdateV1(a, nil)
+
+	b := newTestDoc(2)
+	require.NoError(t, ApplyUpdateV1(b, updateA, nil))
+	arrB := b.GetArray("arr")
+	b.Transact(func(txn *Transaction) { arrB.Insert(txn, 1, []any{"b"}) })
+	updateBOnly, err := DiffUpdateV1(EncodeStateAsUpdateV1(b, nil), a.store.StateVector())
+	require.NoError(t, err)
+
+	peer := newTestDoc(99)
+	require.NoError(t, ApplyUpdateV1(peer, updateBOnly, nil))
+
+	stats := peer.PendingStats()
+	assert.Greater(t, stats.Items, 0, "parked items must be reflected")
+	assert.Contains(t, stats.MissingFor, ClientID(1), "missing client 1 must be reflected")
+
+	// After A arrives, pending drains, stats reset.
+	require.NoError(t, ApplyUpdateV1(peer, updateA, nil))
+	statsAfter := peer.PendingStats()
+	assert.Equal(t, 0, statsAfter.Items)
+	assert.Empty(t, statsAfter.MissingFor)
+}

--- a/crdt/crdt_test.go
+++ b/crdt/crdt_test.go
@@ -1507,3 +1507,18 @@ func TestInteg_TransactContextE_NilFnErrorReturnsNil(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestUnit_NewClientID_NonZeroAndDistinct(t *testing.T) {
+	// 100 fresh Docs should produce 100 distinct (and non-zero) ClientIDs.
+	// Not a tight statistical test, just a sanity check that the source is
+	// random rather than constant or sequential.
+	seen := make(map[ClientID]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		d := New()
+		id := d.ClientID()
+		assert.NotEqual(t, ClientID(0), id, "ClientID should not be zero (clock 0 is meaningful)")
+		_, dup := seen[id]
+		assert.False(t, dup, "ClientID collision after %d generations: %d", i, id)
+		seen[id] = struct{}{}
+	}
+}

--- a/crdt/crdt_test.go
+++ b/crdt/crdt_test.go
@@ -1551,7 +1551,7 @@ func TestUnit_Doc_PendingStats_ReflectsParkedItems(t *testing.T) {
 	require.NoError(t, ApplyUpdateV1(peer, updateBOnly, nil))
 
 	stats := peer.PendingStats()
-	assert.Greater(t, stats.Items, 0, "parked items must be reflected")
+	assert.Positive(t, stats.Items, "parked items must be reflected")
 	assert.Contains(t, stats.MissingFor, ClientID(1), "missing client 1 must be reflected")
 
 	// After A arrives, pending drains, stats reset.

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -26,6 +26,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -599,6 +600,50 @@ func (d *Doc) TransactContextE(ctx context.Context, fn func(*Transaction) error,
 		return ctxErr
 	}
 	return fnErr
+}
+
+// PendingStats is a snapshot of the doc's pending-queue depth. Returned by
+// Doc.PendingStats. Used for observability — operators can monitor queue
+// growth to detect adversarial peers or persistent convergence gaps. The
+// snapshot is immediately stale; do not use as a synchronization primitive.
+type PendingStats struct {
+	// Items is the number of decoded items parked in the pending queue
+	// (waiting for cross-update Origin/OriginRight dependencies or
+	// same-client clock-gap dependencies to arrive).
+	Items int
+
+	// DeleteRanges is the total number of delete-set ranges in pendingDs
+	// across all clients. Each range is one [clock, clock+len) span.
+	DeleteRanges int
+
+	// MissingFor lists the ClientIDs that pending items reference but
+	// haven't yet received. Sorted ascending. Read-only.
+	MissingFor []ClientID
+}
+
+// PendingStats returns a snapshot of the pending-queue state. Cheap; takes
+// a read lock and copies a few values. Intended for operational monitoring
+// of out-of-order delta convergence; see v1.2.0 release notes for the
+// pending-structs machinery this exposes.
+func (d *Doc) PendingStats() PendingStats {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	stats := PendingStats{}
+	if d.store.pending != nil {
+		stats.Items = len(d.store.pending.items)
+		// missing is a StateVector (map[ClientID]uint64) — extract sorted keys
+		missing := make([]ClientID, 0, len(d.store.pending.missing))
+		for c := range d.store.pending.missing {
+			missing = append(missing, c)
+		}
+		sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
+		stats.MissingFor = missing
+	}
+	for _, ranges := range d.store.pendingDs.clients {
+		stats.DeleteRanges += len(ranges)
+	}
+	return stats
 }
 
 // Destroy detaches all observers and clears internal state, releasing

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -23,7 +23,9 @@ package crdt
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
 	"sync"
 )
 
@@ -103,10 +105,27 @@ func (d *Doc) GUID() string {
 	return d.guid
 }
 
+// NewClientID generates a fresh ClientID via crypto/rand.
+//
+// The 32-bit space matches Yjs JS upstream (which uses uint32 to stay within
+// JavaScript's Number.MAX_SAFE_INTEGER). With uniform random distribution, the
+// birthday-bound for collisions is around 65k peers — beyond that, collisions
+// become probable. For multi-tenant deployments, callers may want to coordinate
+// IDs externally; the random generation here is a collision-avoidance
+// heuristic, not an authentication primitive. See SECURITY.md.
+func NewClientID() ClientID {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read returning error is unrecoverable — process is broken.
+		panic(fmt.Errorf("crypto/rand failed: %w", err))
+	}
+	return ClientID(binary.BigEndian.Uint32(b[:]))
+}
+
 // New creates a new Doc with a randomly generated ClientID.
 func New(opts ...DocOption) *Doc {
 	d := &Doc{
-		clientID: ClientID(rand.Uint32()), // uint32 keeps IDs within JS Number.MAX_SAFE_INTEGER
+		clientID: NewClientID(), // uint32 keeps IDs within JS Number.MAX_SAFE_INTEGER
 		gc:       true,
 		store:    newStructStore(),
 		share:    make(map[string]sharedType),

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/reearth/ygo
 
-go 1.25.0
+go 1.23
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sync v0.20.0
+	golang.org/x/sync v0.10.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/reearth/ygo
 
-go 1.23
+go 1.25.0
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.20.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/provider/http/server.go
+++ b/provider/http/server.go
@@ -3,7 +3,6 @@ package http
 import (
 	"encoding/base64"
 	"io"
-	"math/rand"
 	"net/http"
 	"path"
 	"sync"
@@ -47,9 +46,9 @@ func (s *Server) getOrCreateDoc(room string) *crdt.Doc {
 	if doc, ok := s.docs[room]; ok {
 		return doc
 	}
-	// Use Uint32 to stay within Yjs wire protocol's 53-bit VarUint limit and
-	// match crdt/doc.go's default generation (N-M1).
-	doc := crdt.New(crdt.WithClientID(crdt.ClientID(rand.Uint32())))
+	// Use NewClientID (crypto/rand, uint32) to stay within Yjs wire protocol's
+	// 53-bit VarUint limit and avoid predictable IDs in multi-tenant deployments.
+	doc := crdt.New(crdt.WithClientID(crdt.NewClientID()))
 	s.docs[room] = doc
 	return doc
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -20,10 +20,10 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	gws "github.com/gorilla/websocket"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/reearth/ygo/awareness"
 	"github.com/reearth/ygo/crdt"
@@ -138,11 +138,14 @@ func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 
 // room holds the shared document and awareness state for one named room.
 type room struct {
-	mu          sync.Mutex
-	doc         *crdt.Doc
-	awareness   *awareness.Awareness
-	peers       map[*peer]struct{}
-	activePeers atomic.Int64 // atomic; live peers in this room
+	mu        sync.Mutex
+	doc       *crdt.Doc
+	awareness *awareness.Awareness
+	peers     map[*peer]struct{}
+
+	// peerSem enforces MaxPeersPerRoom as a hard cap. Initialised at room
+	// creation time. nil when MaxPeersPerRoom == 0 (unlimited).
+	peerSem *semaphore.Weighted
 
 	// Persistence write queue. nil when no PersistenceAdapter is configured.
 	persistCh   chan []byte   // buffered channel for serialised writes
@@ -253,7 +256,21 @@ type Server struct {
 	// Zero (the default) uses 256, sized for typical sync workloads.
 	PeerWriteQueueSize int
 
-	activeConns atomic.Int64 // atomic; total live WebSocket connections
+	// connSem enforces MaxConnections as a hard cap. Lazily initialised on
+	// first ServeHTTP. nil when MaxConnections == 0 (unlimited).
+	connSem     *semaphore.Weighted
+	connSemOnce sync.Once
+}
+
+// connSemaphore lazily initialises and returns the server-wide connection
+// semaphore. Returns nil when MaxConnections == 0 (unlimited).
+func (s *Server) connSemaphore() *semaphore.Weighted {
+	s.connSemOnce.Do(func() {
+		if s.MaxConnections > 0 {
+			s.connSem = semaphore.NewWeighted(int64(s.MaxConnections))
+		}
+	})
+	return s.connSem
 }
 
 // checkOrigin validates the WebSocket upgrade request's Origin header.
@@ -393,6 +410,9 @@ func (s *Server) getOrCreateRoom(name string) (*room, error) {
 		awareness: awareness.New(0),
 		peers:     make(map[*peer]struct{}),
 	}
+	if s.MaxPeersPerRoom > 0 {
+		r.peerSem = semaphore.NewWeighted(int64(s.MaxPeersPerRoom))
+	}
 	if s.persistence != nil {
 		data, err := s.persistence.LoadDoc(name)
 		if err != nil {
@@ -490,33 +510,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Enforce per-room and server-wide connection limits before upgrading so
 	// that rejected requests get a clean HTTP 503 rather than an abrupt close
 	// after the WebSocket handshake (N-H5).
-	// Atomics are incremented optimistically before the upgrade; on failure
-	// they are decremented so the counts stay accurate (fixes TOCTOU race).
-	if s.MaxPeersPerRoom > 0 {
-		if rm.activePeers.Add(1) > int64(s.MaxPeersPerRoom) {
-			rm.activePeers.Add(-1)
-			http.Error(w, "room full", http.StatusServiceUnavailable)
-			return
-		}
+	// semaphore.Weighted.TryAcquire provides a hard guarantee: never more than
+	// the configured cap simultaneously, regardless of burst pattern.
+	if rm.peerSem != nil && !rm.peerSem.TryAcquire(1) {
+		s.log().Debug("MaxPeersPerRoom cap reached", "room", name)
+		http.Error(w, "room full", http.StatusServiceUnavailable)
+		return
 	}
-	if s.MaxConnections > 0 {
-		if s.activeConns.Add(1) > int64(s.MaxConnections) {
-			s.activeConns.Add(-1)
-			if s.MaxPeersPerRoom > 0 {
-				rm.activePeers.Add(-1) // undo per-room increment
-			}
-			http.Error(w, "too many connections", http.StatusServiceUnavailable)
-			return
+	if sem := s.connSemaphore(); sem != nil && !sem.TryAcquire(1) {
+		if rm.peerSem != nil {
+			rm.peerSem.Release(1) // release per-room ticket we just acquired
 		}
+		s.log().Debug("MaxConnections cap reached")
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
 	}
 
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		if s.MaxPeersPerRoom > 0 {
-			rm.activePeers.Add(-1)
+		if rm.peerSem != nil {
+			rm.peerSem.Release(1)
 		}
-		if s.MaxConnections > 0 {
-			s.activeConns.Add(-1)
+		if sem := s.connSemaphore(); sem != nil {
+			sem.Release(1)
 		}
 		return
 	}
@@ -543,11 +559,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.rmu.RLock()
 	if current, ok := s.rooms[name]; !ok || current != rm {
 		s.rmu.RUnlock()
-		if s.MaxPeersPerRoom > 0 {
-			rm.activePeers.Add(-1)
+		if rm.peerSem != nil {
+			rm.peerSem.Release(1)
 		}
-		if s.MaxConnections > 0 {
-			s.activeConns.Add(-1)
+		if sem := s.connSemaphore(); sem != nil {
+			sem.Release(1)
 		}
 		_ = ws.Close() // close errors during teardown are expected; not logged
 		return
@@ -729,12 +745,12 @@ func (p *peer) handleDisconnect() {
 		rm.mu.Unlock()
 		p.server.rmu.Unlock()
 
-		// Decrement atomic connection counters now that the peer has left.
-		if p.server.MaxPeersPerRoom > 0 {
-			rm.activePeers.Add(-1)
+		// Release semaphore slots now that the peer has left.
+		if rm.peerSem != nil {
+			rm.peerSem.Release(1)
 		}
-		if p.server.MaxConnections > 0 {
-			p.server.activeConns.Add(-1)
+		if sem := p.server.connSemaphore(); sem != nil {
+			sem.Release(1)
 		}
 
 		// Wait for the persistence goroutine to drain buffered writes before the

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -558,5 +558,5 @@ func TestServer_MaxConnections_HardCapUnderConcurrentBurst(t *testing.T) {
 	assert.LessOrEqual(t, int(maxObserved.Load()), cap,
 		"max concurrent connections (%d) exceeded the cap (%d) — atomic-counter race window",
 		maxObserved.Load(), cap)
-	assert.Greater(t, int(rejected.Load()), 0, "some connections should have been rejected")
+	assert.Positive(t, int(rejected.Load()), "some connections should have been rejected")
 }

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -505,4 +507,56 @@ func TestServer_RunWriter_NoLeakOnConnectChurn(t *testing.T) {
 	assert.LessOrEqual(t, gotAfter-gotBefore, slack,
 		"runWriter goroutine leak suspected: %d before, %d after %d connect/disconnect cycles",
 		gotBefore, gotAfter, 50)
+}
+
+func TestServer_MaxConnections_HardCapUnderConcurrentBurst(t *testing.T) {
+	// Open many concurrent connections to a server with MaxConnections=10.
+	// All should either succeed (≤ 10 active at once) or be rejected with
+	// HTTP 503; never more than 10 simultaneously connected.
+
+	const cap = 10
+	const burst = 50
+
+	s := ygws.NewServer()
+	s.MaxConnections = cap
+	httpSrv := httptest.NewServer(s)
+	defer httpSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/cap-room"
+
+	var wg sync.WaitGroup
+	var holding atomic.Int32
+	var maxObserved atomic.Int32
+	var rejected atomic.Int32
+
+	for i := 0; i < burst; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, _, err := gws.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				rejected.Add(1)
+				return
+			}
+			n := holding.Add(1)
+			for {
+				if m := maxObserved.Load(); n > m {
+					if maxObserved.CompareAndSwap(m, n) {
+						break
+					}
+					continue
+				}
+				break
+			}
+			time.Sleep(100 * time.Millisecond) // hold the conn long enough to observe max
+			holding.Add(-1)
+			_ = c.Close()
+		}()
+	}
+	wg.Wait()
+
+	assert.LessOrEqual(t, int(maxObserved.Load()), cap,
+		"max concurrent connections (%d) exceeded the cap (%d) — atomic-counter race window",
+		maxObserved.Load(), cap)
+	assert.Greater(t, int(rejected.Load()), 0, "some connections should have been rejected")
 }


### PR DESCRIPTION
## Summary

Closes [#23](https://github.com/reearth/ygo/issues/23), [#24](https://github.com/reearth/ygo/issues/24), [#28](https://github.com/reearth/ygo/issues/28). Mini security + observability release.

Three small, complementary improvements bundled as v1.5.0. All additive — existing API and behavior preserved.

## What changes

### #24 — `Doc.PendingStats()` for pending-queue observability

```go
type PendingStats struct {
    Items        int          // parked items in store.pending
    DeleteRanges int          // delete-set ranges in pendingDs
    MissingFor   []ClientID   // clients we're blocked on (sorted)
}

func (d *Doc) PendingStats() PendingStats
```

Returns a snapshot of the pending-structs machinery shipped in v1.2.0. Cheap (one `RLock` + small copy). Operators can monitor queue depth to detect adversarial peers or persistent convergence gaps.

### #23 — Hard-cap connections via `semaphore.Weighted`

Replaces the previous optimistic atomic-counter + rollback for `MaxConnections` and `MaxPeersPerRoom`:

```go
// Before: race window where N+ε connections could briefly exist past cap
if s.activeConns.Add(1) > int64(s.MaxConnections) {
    s.activeConns.Add(-1)
    // reject
}

// After: hard guarantee via TryAcquire
if sem := s.connSemaphore(); sem != nil && !sem.TryAcquire(1) {
    // reject
}
```

Adds `golang.org/x/sync` v0.10.0 as a direct dependency (pinned to a version compatible with our Go 1.23 minimum).

### #28 — `crypto/rand` for ClientID generation

Replaces `math/rand.Uint32()` at the two ClientID generation sites (`crdt/doc.go` default + `provider/http/server.go`). ClientIDs aren't authentication tokens, but predictable IDs in multi-tenant deployments are a footgun.

Also exposes `crdt.NewClientID()` as a public helper for callers that want to generate IDs externally. `SECURITY.md` updated with explicit ClientID semantics ("collision-avoidance, not authentication").

## Notes

- **`go.mod` minimum Go stays at 1.23**. The agent's initial `go get golang.org/x/sync@latest` pulled v0.20.0 which would have bumped the minimum to 1.25 — that's a v2.0 concern, not v1.5.0. Pinned to v0.10.0 instead.
- All three issues were prioritized "Medium" or "Low" in the post-v1.4.0 code review.

## Test plan

- [x] `go test -race -timeout 120s ./...` — all packages green
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues
- [x] `go vet ./...` / `go build ./...` — clean
- [x] **New tests**:
  - `TestUnit_NewClientID_NonZeroAndDistinct` — verifies crypto/rand generates distinct non-zero IDs
  - `TestUnit_Doc_PendingStats_EmptyByDefault` — baseline
  - `TestUnit_Doc_PendingStats_ReflectsParkedItems` — verifies stats reflect parking on reverse-order delivery
  - `TestServer_MaxConnections_HardCapUnderConcurrentBurst` — verifies hard cap under 50 concurrent connection attempts with cap=10

## Semver

**v1.5.0 minor.** New public symbols (`Doc.PendingStats`, `PendingStats`, `crdt.NewClientID`). No breaking changes; existing public API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)