### PR TITLE
refactor(crdt): split applyV1Txn into three focused helpers (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] — 2026-05-12
+
+### Changed
+
+- **`crdt`: `applyV1Txn` refactored into three helpers (#29)**: the V1 update decoder grew to 277 lines across three releases (#11 pending-structs, #10 cooperative cancellation, v1.4.1 panic-safety). Extracted into `decodeAndPark`, `resolveWithinUpdatePending`, and `drainPending`. Pure refactor — zero behavior change, all existing tests pass without modification.
+
 ## [1.6.0] — 2026-05-12
 
 ### Added
@@ -258,6 +264,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.6.1]: https://github.com/reearth/ygo/releases/tag/v1.6.1
 [1.6.0]: https://github.com/reearth/ygo/releases/tag/v1.6.0
 [1.5.0]: https://github.com/reearth/ygo/releases/tag/v1.5.0
 [1.4.1]: https://github.com/reearth/ygo/releases/tag/v1.4.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,11 @@
 ## What's new
 
-- **Context-aware methods for Awareness and UndoManager (#27)** — four new sibling methods matching the v1.1.2/v1.3.0 TransactContext pattern. Pre-cancelled context returns immediately without invoking the operation. Existing methods unchanged.
-- **pkg.go.dev presentation polish (#39)** — eight runnable `Example*` functions across the public packages so users see canonical usage as copy-pasteable snippets on pkg.go.dev. Each package's docs page now leads with a Quick start section and includes a Stability statement.
-- **`provider/websocket` file split (#21)** — the 956-line `server.go` is now split into three focused files (`server.go`, `peer.go`, `persistence.go`). Pure refactor; zero behavior change, no API change.
+- **`crdt` internal refactor (#29)** — `applyV1Txn` (the V1 update decoder) refactored from a 277-line function into a thin orchestrator + three focused helpers (`decodeAndPark`, `resolveWithinUpdatePending`, `drainPending`). Pure refactor: zero behavior change, all existing tests pass without modification.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.6.0
+go get github.com/reearth/ygo@v1.6.1
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -437,26 +437,63 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		return ErrInvalidUpdate
 	}
 
+	// 1. Decode all items, parking any with future-clock deps or same-client gaps.
+	//    Returns the within-update pending list (items whose parent might resolve
+	//    later in this same update).
+	withinUpdatePending, err := decodeAndPark(txn, dec, sv, numClients)
+	if err != nil {
+		return wrapUpdateErr(err)
+	}
+
+	// 2. Within-update retry pass: items whose parents arrived later in this update.
+	resolveWithinUpdatePending(txn, withinUpdatePending)
+
+	ds, err := decodeDeleteSet(dec)
+	if err != nil {
+		return wrapUpdateErr(err)
+	}
+	unresolvableDs := ds.applyToPartial(txn)
+	if len(unresolvableDs.clients) > 0 {
+		txn.doc.store.pendingDs.Merge(unresolvableDs)
+	}
+
+	drainPending(txn)
+
+	return nil
+}
+
+// decodeAndPark walks the V1 update's per-client struct groups, decodes each
+// item, and either:
+//
+//	(a) skips fully-integrated items
+//	(b) parks items with same-client clock gaps in store.pending
+//	(c) integrates GC items directly via store.Append
+//	(d) integrates items whose parent is known via item.integrate
+//	(e) collects items whose parent is unresolved-but-might-be-in-this-update
+//	    into the returned slice for the within-update retry pass.
+//
+// numClients is the count parsed from the header.
+func decodeAndPark(txn *Transaction, dec *encoding.Decoder, sv StateVector, numClients uint64) ([]*Item, error) {
 	var pending []*Item
 
 	totalStructs := uint64(0)
 	for i := uint64(0); i < numClients; i++ {
 		numStructs, err := dec.ReadVarUint()
 		if err != nil {
-			return wrapUpdateErr(err)
+			return nil, err
 		}
 		totalStructs += numStructs
 		if totalStructs > maxV2Items {
-			return ErrInvalidUpdate
+			return nil, ErrInvalidUpdate
 		}
 		clientU, err := dec.ReadVarUint()
 		if err != nil {
-			return wrapUpdateErr(err)
+			return nil, err
 		}
 		client := ClientID(clientU)
 		clock, err := dec.ReadVarUint()
 		if err != nil {
-			return wrapUpdateErr(err)
+			return nil, err
 		}
 
 		existingEnd := sv.Clock(client)
@@ -464,7 +501,7 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		for j := uint64(0); j < numStructs; j++ {
 			item, err := decodeItem(dec, txn.doc, client, clock)
 			if err != nil {
-				return wrapUpdateErr(err)
+				return nil, err
 			}
 
 			// Skip structs (tag 10) are clock-range placeholders that are
@@ -546,20 +583,7 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		}
 	}
 
-	resolveWithinUpdatePending(txn, pending)
-
-	ds, err := decodeDeleteSet(dec)
-	if err != nil {
-		return wrapUpdateErr(err)
-	}
-	unresolvableDs := ds.applyToPartial(txn)
-	if len(unresolvableDs.clients) > 0 {
-		txn.doc.store.pendingDs.Merge(unresolvableDs)
-	}
-
-	drainPending(txn)
-
-	return nil
+	return pending, nil
 }
 
 // resolveWithinUpdatePending takes the items deferred during decoding

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -612,6 +612,19 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		txn.doc.store.pendingDs.Merge(unresolvableDs)
 	}
 
+	drainPending(txn)
+
+	return nil
+}
+
+// drainPending runs the doc-level pending drain. It first retries any
+// previously-parked delete-set entries (pendingDs), then loops over
+// store.pending as long as progress is being made, integrating items and
+// re-parking those still blocked. A panic-safety closure re-parks any
+// unprocessed items back into store.pending before re-raising, so the
+// outer applyV1Txn recover (v1.1.1) can convert the panic to an error.
+// Also retries pendingDs after each successful integration pass.
+func drainPending(txn *Transaction) {
 	// pendingDs may be drainable even if pending items aren't — integrated
 	// items from this update might be targets of previously-parked deletes.
 	if len(txn.doc.store.pendingDs.clients) > 0 {
@@ -687,8 +700,6 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 			break
 		}
 	}
-
-	return nil
 }
 
 func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) (*Item, error) {

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -546,6 +546,29 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		}
 	}
 
+	resolveWithinUpdatePending(txn, pending)
+
+	ds, err := decodeDeleteSet(dec)
+	if err != nil {
+		return wrapUpdateErr(err)
+	}
+	unresolvableDs := ds.applyToPartial(txn)
+	if len(unresolvableDs.clients) > 0 {
+		txn.doc.store.pendingDs.Merge(unresolvableDs)
+	}
+
+	drainPending(txn)
+
+	return nil
+}
+
+// resolveWithinUpdatePending takes the items deferred during decoding
+// (those whose parent might resolve via later items in the same update)
+// and runs a fixed-point loop: try to integrate each item by resolving its
+// parent from the store. If progress was made, try again with the remaining
+// items. When no progress is made, partition survivors into future-clock
+// (park in store.pending) vs truly-unresolvable (orphan-Append).
+func resolveWithinUpdatePending(txn *Transaction, pending []*Item) {
 	// Retry items whose parent couldn't be resolved during the first pass
 	// because their origin items were in a later client group.
 	for len(pending) > 0 {
@@ -602,19 +625,6 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 		}
 		pending = remaining
 	}
-
-	ds, err := decodeDeleteSet(dec)
-	if err != nil {
-		return wrapUpdateErr(err)
-	}
-	unresolvableDs := ds.applyToPartial(txn)
-	if len(unresolvableDs.clients) > 0 {
-		txn.doc.store.pendingDs.Merge(unresolvableDs)
-	}
-
-	drainPending(txn)
-
-	return nil
 }
 
 // drainPending runs the doc-level pending drain. It first retries any


### PR DESCRIPTION
## Summary

Closes #29. Pure internal refactor — **zero behavior change, all existing tests pass without modification, statistically significant -1.76% perf improvement** (Apple M4 Max, n=10, p=0.023).

`applyV1Txn` had grown to 277 lines after accumulating three releases' worth of additions (#11 pending-structs, #10 cooperative cancellation, v1.4.1 panic-safety fixes). Now refactored into a 48-line orchestrator + three focused helpers.

## Structure

| Function | Lines | Responsibility |
|---|---|---|
| `applyV1Txn` | 48 | Orchestrator: parse header, call helpers in sequence, wrap in panic-safety defer |
| `decodeAndPark` | ~120 | Walk per-client struct groups, decode each item, park future-clock / same-client-gap items, collect within-update pending list |
| `resolveWithinUpdatePending` | ~65 | Fixed-point retry for items whose parent might resolve later in same update |
| `drainPending` | ~65 | Doc-level pending drain with panic-safe re-park closure (preserves the v1.4.1 contract) |

## Three commits, one per extraction

Built up incrementally with full test-suite validation after each:

1. `82981cb` — Extract `drainPending`
2. `caf3d2a` — Extract `resolveWithinUpdatePending`
3. `97a89ec` — Extract `decodeAndPark`

Each commit independently passes the full test suite (369/369 in the crdt package alone).

## Benchmark — `benchstat` over n=10 samples

```
goos: darwin
goarch: arm64
pkg: github.com/reearth/ygo/crdt
cpu: Apple M4 Max
                 │  before.txt   │             after.txt              │
                 │    sec/op     │   sec/op     vs base               │
ApplyUpdateV1-16    104.6µ ± 3%    102.7µ ± 2%  -1.76% (p=0.023 n=10)

                 │  before.txt   │           after.txt            │
                 │     B/op      │     B/op      vs base          │
ApplyUpdateV1-16   223.9Ki ± 0%   223.9Ki ± 0%   ~ (p=1.000 n=10)

                 │  before.txt   │           after.txt             │
                 │   allocs/op   │  allocs/op   vs base            │
ApplyUpdateV1-16    3.079k ± 0%    3.079k ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

**sec/op**: -1.76% improvement, statistically significant (p=0.023 < 0.05).
**B/op** and **allocs/op**: byte-identical (`~` = no significant difference; `p=1.000`).

Likely cause for the speedup: smaller functions inline more readily under Go's per-function inliner budget. Memory and allocation identity confirms pure refactor semantics — no algorithmic change, just code organization.

## What's NOT in this PR

- `applyV2Txn` is unchanged. The V2 path has parallel structure and could share these helpers in a follow-up, but that's a separate refactor.
- No external API change. `applyV1Txn` is internal; public callers of `ApplyUpdateV1` see no difference.

## Test plan

- [x] All 369 tests in `crdt` package PASS without modification
- [x] Full `go test -race -timeout 120s ./...` — all packages PASS
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues
- [x] `benchstat` over n=10 samples confirms -1.76% improvement is statistically significant

## Semver

**v1.6.1 patch.** Pure internal refactor, no API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
