### PR TITLE
refactor(crdt): Item.integrate architecture note + small extraction (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] — 2026-05-14
+
+### Changed
+
+- **`crdt`: small `Item.integrate` refactor + architecture note (#22)**: extracted the post-insertion housekeeping (ContentMove arbitration, ContentString tracking, ContentType back-pointer, map-key LWW, `addChanged`) into `postIntegrateHousekeeping`. This was the only split that worked under Go's heuristic inliner — `scanConcurrentInserts` and `linkInto` extractions both regressed the hot path by 3-10% because their locals are shared with the conflict-scan loop. Yjs JS and yrs (Rust) keep their equivalents monolithic for the same reason; V8 and LLVM can absorb helper calls transparently, Go cannot. The `Item.integrate` godoc now documents this constraint to spare future maintainers the investigation. Pure refactor — zero behavior change, `benchstat` over n=10 confirms no perf regression on any hot-path benchmark.
+
 ## [1.6.1] — 2026-05-12
 
 ### Changed
@@ -264,6 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.6.2]: https://github.com/reearth/ygo/releases/tag/v1.6.2
 [1.6.1]: https://github.com/reearth/ygo/releases/tag/v1.6.1
 [1.6.0]: https://github.com/reearth/ygo/releases/tag/v1.6.0
 [1.5.0]: https://github.com/reearth/ygo/releases/tag/v1.5.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
 ## What's new
 
-- **`crdt` internal refactor (#29)** — `applyV1Txn` (the V1 update decoder) refactored from a 277-line function into a thin orchestrator + three focused helpers (`decodeAndPark`, `resolveWithinUpdatePending`, `drainPending`). Pure refactor: zero behavior change, all existing tests pass without modification.
+- **`crdt` internal refactor + architecture note (#22)** — extracted the post-insertion housekeeping in `Item.integrate` into `postIntegrateHousekeeping`. The hot conflict-scan and link phases stay inline because their live state spans both — Yjs JS and yrs (Rust) keep their equivalents monolithic for the same reason. The `Item.integrate` godoc now documents why, so future maintainers don't re-discover this constraint independently. Pure refactor — zero behavior change, `benchstat` over n=10 confirms no perf regression.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.6.1
+go get github.com/reearth/ygo@v1.6.2
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -157,6 +157,15 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 	// Register in the document store.
 	txn.doc.store.Append(item)
 
+	item.postIntegrateHousekeeping(txn)
+}
+
+// postIntegrateHousekeeping runs the per-content-type bookkeeping that happens
+// after an item is linked into the parent's list and registered in the store.
+// Extracted from integrate's post-insertion section because none of its work
+// shares live locals with the conflict scan — register-pressure isolation
+// should keep the inliner's choices for integrate unchanged.
+func (item *Item) postIntegrateHousekeeping(txn *Transaction) {
 	// ContentMove priority arbitration: resolve the target item (splitting if
 	// needed so it covers exactly TargetLen elements) and claim it if we are the
 	// winning move. Lower ClientID wins for concurrent moves from different peers;

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -28,6 +28,18 @@ type Item struct {
 // offset > 0 is only needed when the item partially overlaps an existing item
 // in the store (a split scenario during update decoding). For Phase 2 all
 // items arrive cleanly (offset = 0).
+//
+// Architecture note: this function is intentionally kept as a single monolith
+// rather than split into helpers (e.g., scanConcurrentInserts, linkInto). Yjs
+// JS and yrs (Rust) keep their equivalents inline for the same reason — the
+// algorithm's live state (left, conflicting, beforeOrigin) spans both the
+// conflict scan and the link phase, making a clean split awkward in any
+// language. V8 and LLVM can transparently absorb helper-function calls; Go's
+// heuristic inliner has a hard ~80-node budget and cannot. A measured
+// extraction attempt regressed BenchmarkApplyUpdateV1/V2 and YText_Insert by
+// 3-10% (see investigation in closed issue #22). Keep monolithic until either
+// the Go compiler's inlining heuristics improve, or a benchmarked split that
+// stays inside the inliner budget is found.
 func (item *Item) integrate(txn *Transaction, offset int) {
 	if offset > 0 {
 		item.ID.Clock += uint64(offset)


### PR DESCRIPTION
## Summary

Closes #22. Three commits delivering both a small refactor and a documented architectural decision for `Item.integrate`.

## What's in the PR

| Commit | Purpose |
|---|---|
| `88804ff` | Architecture note on `Item.integrate` godoc explaining why the function is intentionally monolithic |
| `b831127` | Extract `postIntegrateHousekeeping` from `Item.integrate` — the only split that's free in Go |
| `50ed996` | CHANGELOG + RELEASE_NOTES for v1.6.2 |

## The investigation

The original issue asked for `scanConcurrentInserts` + `linkInto` helpers extracted from the 161-line `Item.integrate`. We tried, and every extraction regressed the YATA hot path on `benchstat` over n=10 samples:

| Extraction attempt | `ApplyUpdateV1` regression |
|---|---|
| `linkInto` alone | **+9.71%** (p=0.000) |
| `linkInto` + `scanConcurrentInserts` | +0.91% (p=0.004) |
| `linkInto` + scan fast/slow split | +2.75% (p=0.000) |
| **`postIntegrateHousekeeping`** | **~ (no significant change, p > 0.05 every benchmark)** |

## Why most splits fail in Go

Researched how Yjs JS and yrs (Rust) handle the same function. **Both keep `Item.integrate` monolithic.** The algorithm's live state (`left`, `conflicting`, `beforeOrigin`) spans both the conflict-scan and the link phase, making a clean split awkward in any language. V8 (JIT) and LLVM can transparently absorb helper calls; Go's heuristic inliner has a hard ~80-node budget and cannot.

The architecture note (commit `88804ff`) bakes this finding into the godoc so future maintainers don't waste a day re-discovering it.

## Why `postIntegrateHousekeeping` works

The post-insertion section (ContentMove arbitration, ContentString tracking, ContentType back-pointer, map-key LWW, `addChanged`) runs **after** the conflict scan and link phases. It touches different live state. Extracting it doesn't disturb the register allocation that's keeping the hot path fast.

## Benchstat over n=10 (post-extraction vs main)

```
goos: darwin   goarch: arm64   pkg: github.com/reearth/ygo/crdt   cpu: Apple M4 Max

                    │ /tmp/postint-before.txt │       /tmp/postint-after.txt       │
                    │         sec/op          │   sec/op     vs base               │
YText_Insert-16                   615.6n ± 1%   609.1n ± 4%       ~ (p=0.469 n=10)
YText_InsertBulk-16               2.328µ ± 3%   2.250µ ± 7%       ~ (p=0.382 n=10)
ApplyUpdateV1-16                  108.4µ ± 5%   108.2µ ± 1%       ~ (p=0.218 n=10)
ApplyUpdateV2-16                  676.5µ ± 1%   680.0µ ± 1%       ~ (p=0.436 n=10)
YMap_Set-16                       20.95µ ± 2%   20.72µ ± 1%       ~ (p=0.218 n=10)
YArray_Push-16                    55.95µ ± 2%   55.97µ ± 2%       ~ (p=0.796 n=10)
geomean                           22.31µ        22.11µ       -0.88%
```

Every individual benchmark shows `~` (no statistically significant change). Memory and allocation counts identical. Geomean slightly improved (-0.88%) but within noise.

## Test plan

- [x] All existing tests pass without modification
- [x] `go test -race -timeout 120s ./...` — all green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues
- [x] `benchstat` over n=10 — no significant regression on any hot-path benchmark

## Semver

**v1.6.2 patch.** Pure internal refactor + doc note, no API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
