### PR TITLE
feat: v1.7.0 additive sibling methods (#26 WriteVarIntE, #35 PersistenceAdapterContext)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] — 2026-05-14
+
+### Added
+
+- **`encoding.Encoder.WriteVarIntE(v int64) error` (#26)**: error-returning sibling for `WriteVarInt`. Returns `ErrVarIntOutOfRange` when v's magnitude exceeds the lib0 55-bit limit instead of panicking. Preferred over `WriteVarInt` for callers that wrap user input or untrusted data. Successful output is byte-identical to `WriteVarInt`. Pattern matches v1.3.0's `TransactE`. Existing `WriteVarInt` unchanged (now a thin wrapper).
+- **`provider/websocket.PersistenceAdapterContext` (#35)**: optional extension interface that lets persistence adapters receive a context cancelled when `Server.Shutdown` begins. The persistence worker type-asserts at runtime and prefers `StoreUpdateContext` when available, falling back to `StoreUpdate` for existing adapters. Pattern matches `io.WriterTo` / `database/sql/driver.QueryerContext`. Existing adapters work unchanged.
+
 ## [1.6.1] — 2026-05-12
 
 ### Changed
@@ -264,6 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.7.0]: https://github.com/reearth/ygo/releases/tag/v1.7.0
 [1.6.1]: https://github.com/reearth/ygo/releases/tag/v1.6.1
 [1.6.0]: https://github.com/reearth/ygo/releases/tag/v1.6.0
 [1.5.0]: https://github.com/reearth/ygo/releases/tag/v1.5.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,14 @@
 ## What's new
 
-- **`crdt` internal refactor (#29)** — `applyV1Txn` (the V1 update decoder) refactored from a 277-line function into a thin orchestrator + three focused helpers (`decodeAndPark`, `resolveWithinUpdatePending`, `drainPending`). Pure refactor: zero behavior change, all existing tests pass without modification.
+- **`encoding.Encoder.WriteVarIntE` (#26)** — error-returning sibling for the panicking `WriteVarInt`. Returns `ErrVarIntOutOfRange` when input exceeds the lib0 55-bit limit instead of panicking. Existing `WriteVarInt` unchanged. Pattern matches v1.3.0's `TransactE`.
+- **`provider/websocket.PersistenceAdapterContext` (#35)** — optional extension interface. Adapters that implement it receive a context cancelled when `Server.Shutdown` begins, letting them abort in-flight network/DB writes rather than blocking shutdown indefinitely. Existing adapters work unchanged.
+
+Both changes are strictly additive — no breaking API changes.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.6.1
+go get github.com/reearth/ygo@v1.7.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -2,10 +2,16 @@ package encoding
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
 )
+
+// ErrVarIntOutOfRange is returned by WriteVarIntE when the magnitude of v
+// exceeds the lib0 VarInt encoding range ((1<<55)-1). The JS Yjs decoder
+// rejects values outside this range, so producing one would be unwire-able.
+var ErrVarIntOutOfRange = errors.New("encoding: VarInt magnitude exceeds lib0 55-bit range")
 
 // Encoder writes values into a growing byte buffer using the lib0 encoding format.
 // Encoder is not safe for concurrent use; each goroutine should use its own instance.
@@ -43,13 +49,14 @@ func (e *Encoder) WriteVarUint(v uint64) {
 	e.buf = append(e.buf, byte(v))
 }
 
-// WriteVarInt encodes a signed integer using the lib0 sign-magnitude format,
-// matching the JavaScript lib0 library's writeVarInt.
-// The sign occupies bit 6 of the first byte; bits 0-5 hold the low 6 bits of
-// the magnitude. Continuation bytes carry 7 data bits each (bit 7 = more).
-// Panics if the magnitude of v exceeds (1<<55)-1, which is the maximum
-// encodable by the lib0 protocol (the decoder rejects anything larger).
-func (e *Encoder) WriteVarInt(v int64) {
+// WriteVarIntE is the error-returning variant of WriteVarInt. Returns
+// ErrVarIntOutOfRange if the magnitude of v exceeds the lib0 55-bit range.
+// Preferred over WriteVarInt for callers who need to surface out-of-range
+// inputs without a panic — for example, encoding pipelines that wrap user
+// input or untrusted data.
+//
+// Successful encoding is byte-identical to WriteVarInt(v) for the same v.
+func (e *Encoder) WriteVarIntE(v int64) error {
 	sign := byte(0)
 	var mag uint64
 	if v < 0 {
@@ -59,11 +66,11 @@ func (e *Encoder) WriteVarInt(v int64) {
 		mag = uint64(v)
 	}
 	if mag > (1<<55)-1 {
-		panic(fmt.Sprintf("encoding: WriteVarInt value %d exceeds 55-bit lib0 VarInt range", v))
+		return ErrVarIntOutOfRange
 	}
 	if mag < 64 {
 		e.buf = append(e.buf, sign|byte(mag))
-		return
+		return nil
 	}
 	e.buf = append(e.buf, 0x80|sign|byte(mag&0x3F))
 	mag >>= 6
@@ -72,6 +79,20 @@ func (e *Encoder) WriteVarInt(v int64) {
 		mag >>= 7
 	}
 	e.buf = append(e.buf, byte(mag))
+	return nil
+}
+
+// WriteVarInt encodes a signed integer using the lib0 sign-magnitude format,
+// matching the JavaScript lib0 library's writeVarInt.
+//
+// Panics if the magnitude of v exceeds (1<<55)-1, which is the maximum
+// encodable by the lib0 protocol (the decoder rejects anything larger).
+// Most callers should prefer WriteVarIntE which returns this case as
+// ErrVarIntOutOfRange instead of panicking.
+func (e *Encoder) WriteVarInt(v int64) {
+	if err := e.WriteVarIntE(v); err != nil {
+		panic(fmt.Sprintf("encoding: WriteVarInt value %d exceeds 55-bit lib0 VarInt range", v))
+	}
 }
 
 // WriteVarString encodes s as VarUint(byteLength) followed by raw UTF-8 bytes.

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -437,7 +437,7 @@ func TestEncoder_WriteVarIntE_ValidInputProducesSameBytesAsWriteVarInt(t *testin
 func TestEncoder_WriteVarIntE_OutOfRangeReturnsError(t *testing.T) {
 	e := encoding.NewEncoder()
 	err := e.WriteVarIntE(1 << 56)
-	assert.ErrorIs(t, err, encoding.ErrVarIntOutOfRange)
+	require.ErrorIs(t, err, encoding.ErrVarIntOutOfRange)
 	assert.Empty(t, e.Bytes(), "no bytes should be written on error")
 }
 

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -420,3 +420,30 @@ func FuzzDecodeAny(f *testing.F) {
 		_, _ = d.ReadAny()
 	})
 }
+
+// --- WriteVarIntE (#26) ---
+
+func TestEncoder_WriteVarIntE_ValidInputProducesSameBytesAsWriteVarInt(t *testing.T) {
+	cases := []int64{0, 1, -1, 63, -63, 64, -64, 1 << 54, -(1 << 54)}
+	for _, v := range cases {
+		a := encoding.NewEncoder()
+		a.WriteVarInt(v)
+		b := encoding.NewEncoder()
+		require.NoError(t, b.WriteVarIntE(v))
+		assert.Equal(t, a.Bytes(), b.Bytes(), "WriteVarInt and WriteVarIntE must produce identical bytes for v=%d", v)
+	}
+}
+
+func TestEncoder_WriteVarIntE_OutOfRangeReturnsError(t *testing.T) {
+	e := encoding.NewEncoder()
+	err := e.WriteVarIntE(1 << 56)
+	assert.ErrorIs(t, err, encoding.ErrVarIntOutOfRange)
+	assert.Empty(t, e.Bytes(), "no bytes should be written on error")
+}
+
+func TestEncoder_WriteVarInt_StillPanicsOnOutOfRange(t *testing.T) {
+	assert.Panics(t, func() {
+		e := encoding.NewEncoder()
+		e.WriteVarInt(1 << 56)
+	})
+}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -1,6 +1,9 @@
 package websocket
 
-import "log"
+import (
+	"context"
+	"log"
+)
 
 // startPersistenceWorker spawns the goroutine that drains r.persistCh and
 // forwards each update to the PersistenceAdapter. It must be called with
@@ -9,16 +12,39 @@ import "log"
 // The worker exits when either r.persistStop or s.shutdownCh is closed,
 // draining any buffered updates before returning so that no committed
 // transaction is silently lost.
+//
+// If s.persistence implements PersistenceAdapterContext, store calls are made
+// via StoreUpdateContext with a ctx that is cancelled when shutdown or stop
+// fires. Otherwise falls back to StoreUpdate (existing behaviour).
 func (s *Server) startPersistenceWorker(r *room, name string) {
 	go func() {
 		defer close(r.persistDone)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Cancel the persistence-adapter ctx when shutdown or stop fires.
+		go func() {
+			select {
+			case <-s.shutdownCh:
+			case <-r.persistStop:
+			}
+			cancel()
+		}()
+
 		store := func(update []byte) {
 			defer func() {
 				if rv := recover(); rv != nil {
 					log.Printf("ygo/websocket: StoreUpdate panic for room %q: %v", name, rv)
 				}
 			}()
-			if err := s.persistence.StoreUpdate(name, update); err != nil {
+			var err error
+			if pac, ok := s.persistence.(PersistenceAdapterContext); ok {
+				err = pac.StoreUpdateContext(ctx, name, update)
+			} else {
+				err = s.persistence.StoreUpdate(name, update)
+			}
+			if err != nil {
 				log.Printf("ygo/websocket: StoreUpdate for room %q: %v", name, err)
 			}
 		}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -88,6 +88,26 @@ type PersistenceAdapter interface {
 	StoreUpdate(room string, update []byte) error
 }
 
+// PersistenceAdapterContext is an optional extension to PersistenceAdapter.
+// Adapters that implement this interface receive a context that is cancelled
+// when the server begins shutdown, letting the adapter abort in-flight writes
+// (network calls, DB queries, etc.) rather than blocking Shutdown indefinitely.
+//
+// The persistence worker checks for this interface at runtime via a type
+// assertion. Adapters that implement only PersistenceAdapter remain fully
+// supported — the worker falls back to StoreUpdate when StoreUpdateContext
+// is unavailable.
+//
+// Pattern mirrors io.WriterTo / http.CloseNotifier and the database/sql/driver
+// Queryer / QueryerContext family in the standard library.
+type PersistenceAdapterContext interface {
+	// StoreUpdateContext is the context-aware variant of StoreUpdate. It is
+	// called with a ctx that is cancelled when Server.Shutdown begins. The
+	// adapter should respect cancellation (e.g., abort the network call or
+	// DB transaction) and return ctx.Err() when ctx is done.
+	StoreUpdateContext(ctx context.Context, room string, update []byte) error
+}
+
 // MemoryPersistence is a thread-safe in-memory PersistenceAdapter that merges
 // all updates into a single V1 snapshot per room. It is the default adapter
 // used when no external persistence is configured and is primarily useful in

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -1,6 +1,7 @@
 package websocket_test
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -559,4 +560,93 @@ func TestServer_MaxConnections_HardCapUnderConcurrentBurst(t *testing.T) {
 		"max concurrent connections (%d) exceeded the cap (%d) — atomic-counter race window",
 		maxObserved.Load(), cap)
 	assert.Positive(t, int(rejected.Load()), "some connections should have been rejected")
+}
+
+// --- PersistenceAdapterContext (#35) ---
+
+// captureCtxAdapter implements both PersistenceAdapter and
+// PersistenceAdapterContext. Records whether the ctx-aware path was used.
+type captureCtxAdapter struct {
+	mu            sync.Mutex
+	contextUsed   bool
+	legacyUsed    bool
+	receivedCtxErr func() error // closure to read ctx.Err() at call time
+}
+
+func (a *captureCtxAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+
+func (a *captureCtxAdapter) StoreUpdate(room string, update []byte) error {
+	a.mu.Lock()
+	a.legacyUsed = true
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *captureCtxAdapter) StoreUpdateContext(ctx context.Context, room string, update []byte) error {
+	a.mu.Lock()
+	a.contextUsed = true
+	a.receivedCtxErr = ctx.Err
+	a.mu.Unlock()
+	return nil
+}
+
+func TestServer_PersistenceAdapterContext_PreferredOverLegacy(t *testing.T) {
+	a := &captureCtxAdapter{}
+	s := ygws.NewServerWithPersistence(a)
+	defer s.Shutdown(context.Background())
+
+	// Trigger a persistence write by calling Apply.
+	err := s.Apply(context.Background(), "room1", func(doc *crdt.Doc, transact func(func(*crdt.Transaction))) {
+		text := doc.GetText("body")
+		transact(func(txn *crdt.Transaction) {
+			text.Insert(txn, 0, "hello", nil)
+		})
+	})
+	require.NoError(t, err)
+
+	// Allow the persistence goroutine to run.
+	time.Sleep(100 * time.Millisecond)
+
+	a.mu.Lock()
+	contextUsed := a.contextUsed
+	legacyUsed := a.legacyUsed
+	a.mu.Unlock()
+
+	assert.True(t, contextUsed, "ctx-aware StoreUpdateContext should be called when adapter implements it")
+	assert.False(t, legacyUsed, "legacy StoreUpdate should be skipped when ctx variant is available")
+}
+
+// legacyAdapter implements only PersistenceAdapter (no ctx variant).
+type legacyAdapter struct {
+	mu     sync.Mutex
+	called bool
+}
+
+func (a *legacyAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+func (a *legacyAdapter) StoreUpdate(room string, update []byte) error {
+	a.mu.Lock()
+	a.called = true
+	a.mu.Unlock()
+	return nil
+}
+
+func TestServer_LegacyPersistenceAdapter_StillWorks(t *testing.T) {
+	a := &legacyAdapter{}
+	s := ygws.NewServerWithPersistence(a)
+	defer s.Shutdown(context.Background())
+
+	err := s.Apply(context.Background(), "room2", func(doc *crdt.Doc, transact func(func(*crdt.Transaction))) {
+		arr := doc.GetArray("items")
+		transact(func(txn *crdt.Transaction) {
+			arr.Insert(txn, 0, []any{"x"})
+		})
+	})
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	a.mu.Lock()
+	called := a.called
+	a.mu.Unlock()
+	assert.True(t, called, "legacy StoreUpdate must still be called for adapters without ctx variant")
 }

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -567,9 +567,9 @@ func TestServer_MaxConnections_HardCapUnderConcurrentBurst(t *testing.T) {
 // captureCtxAdapter implements both PersistenceAdapter and
 // PersistenceAdapterContext. Records whether the ctx-aware path was used.
 type captureCtxAdapter struct {
-	mu            sync.Mutex
-	contextUsed   bool
-	legacyUsed    bool
+	mu             sync.Mutex
+	contextUsed    bool
+	legacyUsed     bool
 	receivedCtxErr func() error // closure to read ctx.Err() at call time
 }
 


### PR DESCRIPTION
## Summary

Closes #26, closes #35. Two additive enhancements bundled as v1.7.0 minor — both originally projected as v2.0 breaking changes, then re-scoped after realizing the same sibling-method pattern that worked for `TransactE` in v1.3.0 works here too. **Zero breaking changes, no module path bump, no migration guide needed.**

## What changes

### #26 — `encoding.Encoder.WriteVarIntE(v int64) error`

New error-returning sibling for `WriteVarInt`. Returns the new sentinel `ErrVarIntOutOfRange` when v's magnitude exceeds the lib0 55-bit limit, instead of panicking. Preferred for callers wrapping user input or untrusted data.

Existing `WriteVarInt` is now a thin wrapper around `WriteVarIntE` that panics on error — source-compatible with every existing caller, panic message preserved.

```go
// Old (still works, still panics on bad input)
e.WriteVarInt(v)

// New (recommended)
if err := e.WriteVarIntE(v); err != nil { /* handle */ }
```

Pattern matches v1.3.0's `TransactE` / `TransactContextE`.

### #35 — `provider/websocket.PersistenceAdapterContext` optional interface

```go
type PersistenceAdapterContext interface {
    StoreUpdateContext(ctx context.Context, room string, update []byte) error
}
```

Optional extension to `PersistenceAdapter`. Adapters that implement it receive a context cancelled when `Server.Shutdown` begins, letting them abort in-flight network/DB writes rather than blocking shutdown indefinitely (the issue tracked as #35).

The persistence worker uses a runtime type assertion: if the configured adapter implements `PersistenceAdapterContext`, `StoreUpdateContext` is called with a `ctx` derived from `shutdownCh` + `persistStop`. Otherwise, the existing `StoreUpdate` is called unchanged.

Pattern mirrors stdlib idioms — `io.WriterTo`, `http.CloseNotifier`, `database/sql/driver.QueryerContext`. Existing adapters work unchanged.

## Why not v2.0

Both issues were originally projected as breaking changes requiring a v2.0 release (module path bump to `github.com/reearth/ygo/v2`, every import path updated, migration guide, etc.). On reconsideration, both can be done additively:

- For #26, parallel method with the `E` suffix — same pattern as v1.3.0's `TransactE`.
- For #35, optional extension interface with runtime type assertion — same pattern as `io.WriterTo`.

The result is the same affordance for callers who want it, with zero breakage for those who don't. v2.0 stays a future option for when there's a genuine clean-break need.

## Test plan

- [x] `WriteVarIntE` byte-equivalence test against `WriteVarInt` across boundary values (0, ±1, ±63, ±64, ±2^54)
- [x] `WriteVarIntE` out-of-range returns `ErrVarIntOutOfRange` and writes nothing
- [x] `WriteVarInt` still panics on out-of-range (legacy contract preserved)
- [x] Adapter implementing `PersistenceAdapterContext` is preferred over legacy `StoreUpdate`
- [x] Adapter implementing only `PersistenceAdapter` still works
- [x] `go test -race -timeout 120s ./...` — all packages PASS
- [x] `go vet ./...` / `go build ./...` — clean
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues

## Semver

**v1.7.0 minor.** Two new public symbols (`WriteVarIntE`, `ErrVarIntOutOfRange`, `PersistenceAdapterContext`). Strictly additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
