### PR TITLE
Fix lib0 Any bigint and float compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] — 2026-05-15
+
+### Added
+
+- **`encoding.BigInt` type + `Any` tag 122 support.** lib0's BigInt tag (used by Yjs JS to encode int64 values that don't fit in JS `Number.MAX_SAFE_INTEGER`) is now decoded into a new `encoding.BigInt` named type, and `WriteAny` can encode that type with tag 122. Previously, ygo failed to decode updates containing JS BigInt values. Adds `Encoder.WriteBigInt64` and `Decoder.ReadBigInt64` helpers.
+
+### Fixed
+
+- **Float byte order now matches lib0 and yrs (big-endian).** ygo previously encoded float32 and float64 in little-endian, which silently broke binary compatibility with Yjs JS and yrs for any document containing float values. The README has always claimed binary compatibility; this fixes the gap. The wire format for float `Any` values (tags 123 and 124) is now big-endian, matching [lib0's `writeFloat32`/`writeFloat64`](https://github.com/dmonad/lib0/blob/main/src/encoding.js).
+
+  **Compatibility note**: previously persisted ygo updates containing float values will read different float values after upgrading. Cross-implementation use was already broken before this fix; the breakage was in the previous behavior, not this one. If your deployment stores ygo update bytes long-term and uses raw float values (rather than integers encoded via VarInt), plan for a re-encode pass.
+
 ## [1.7.1] — 2026-05-14
 
 ### Documentation
@@ -282,6 +294,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Doc.TransactContext` added for context-aware transaction entry.
 - WebSocket `Server.Shutdown(ctx)` closes all peer connections and waits for goroutines to exit.
 
+[1.8.0]: https://github.com/reearth/ygo/releases/tag/v1.8.0
 [1.7.1]: https://github.com/reearth/ygo/releases/tag/v1.7.1
 [1.7.0]: https://github.com/reearth/ygo/releases/tag/v1.7.0
 [1.6.1]: https://github.com/reearth/ygo/releases/tag/v1.6.1

--- a/crdt/compat_test.go
+++ b/crdt/compat_test.go
@@ -1,6 +1,7 @@
 package crdt_test
 
 import (
+	"encoding/hex"
 	"os"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/reearth/ygo/crdt"
+	yencoding "github.com/reearth/ygo/encoding"
 )
 
 // loadFixture reads a binary fixture file from testutil/fixtures/.
@@ -15,6 +17,13 @@ func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
 	data, err := os.ReadFile("../testutil/fixtures/" + name + ".bin")
 	require.NoError(t, err, "fixture %s.bin not found — run testutil/gen_fixtures.js", name)
+	return data
+}
+
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(s)
+	require.NoError(t, err)
 	return data
 }
 
@@ -67,6 +76,21 @@ func TestCompat_ApplyJSUpdate_YArray(t *testing.T) {
 	assert.Equal(t, map[string]any{"key": "val"}, got[4])
 }
 
+func TestCompat_ApplyJSUpdate_YArrayFloatAny(t *testing.T) {
+	update := mustDecodeHex(t, "0101b7a6ad960b000801046c697374027c3fc000007602066e65737465647c40100000056c6162656c77026f6b00")
+	doc := crdt.New(crdt.WithClientID(99))
+	require.NoError(t, crdt.ApplyUpdateV1(doc, update, nil))
+
+	arr := doc.GetArray("list")
+	got := arr.ToSlice()
+	require.Len(t, got, 2)
+	assert.InDelta(t, float32(1.5), got[0], 0)
+	assert.Equal(t, map[string]any{
+		"nested": float32(2.25),
+		"label":  "ok",
+	}, got[1])
+}
+
 func TestCompat_ApplyJSUpdate_YMap(t *testing.T) {
 	doc := crdt.New(crdt.WithClientID(99))
 	require.NoError(t, crdt.ApplyUpdateV1(doc, loadFixture(t, "ymap_basic"), nil))
@@ -83,6 +107,27 @@ func TestCompat_ApplyJSUpdate_YMap(t *testing.T) {
 	active, ok := m.Get("active")
 	require.True(t, ok)
 	assert.Equal(t, true, active)
+}
+
+func TestCompat_ApplyJSUpdate_YXmlFragmentBigIntAttribute(t *testing.T) {
+	update := mustDecodeHex(t, "0102f08bfe120007010b70726f73656d6972726f720301702800f08bfe120007646174612d6964017a000000000000002a00")
+	doc := crdt.New(crdt.WithClientID(99))
+	require.NoError(t, crdt.ApplyUpdateV1(doc, update, nil))
+
+	frag := doc.GetXmlFragment("prosemirror")
+	assert.Equal(t, 1, frag.Len())
+}
+
+func TestCompat_ApplyJSUpdateV2_YTextFormatBigIntAny(t *testing.T) {
+	update := mustDecodeHex(t, "0002000206cef7d3a41301010001000504004600860b0674786964696441004200010100000103007a000000000000002a7e00")
+	doc := crdt.New(crdt.WithClientID(99))
+	require.NoError(t, crdt.ApplyUpdateV2(doc, update, nil))
+
+	txt := doc.GetText("t")
+	delta := txt.ToDelta()
+	require.Len(t, delta, 1)
+	assert.Equal(t, "x", delta[0].Insert)
+	assert.Equal(t, crdt.Attributes{"id": yencoding.BigInt(42)}, delta[0].Attributes)
 }
 
 func TestCompat_ApplyJSUpdate_ConcurrentMerge(t *testing.T) {

--- a/encoding/decoder.go
+++ b/encoding/decoder.go
@@ -143,24 +143,34 @@ func (d *Decoder) ReadVarBytes() ([]byte, error) {
 	return out, nil
 }
 
-// ReadFloat32 reads a 32-bit little-endian IEEE 754 float.
+// ReadFloat32 reads a 32-bit big-endian IEEE 754 float.
 func (d *Decoder) ReadFloat32() (float32, error) {
 	if d.pos+4 > len(d.buf) {
 		return 0, ErrUnexpectedEOF
 	}
-	bits := binary.LittleEndian.Uint32(d.buf[d.pos:])
+	bits := binary.BigEndian.Uint32(d.buf[d.pos:])
 	d.pos += 4
 	return math.Float32frombits(bits), nil
 }
 
-// ReadFloat64 reads a 64-bit little-endian IEEE 754 float.
+// ReadFloat64 reads a 64-bit big-endian IEEE 754 float.
 func (d *Decoder) ReadFloat64() (float64, error) {
 	if d.pos+8 > len(d.buf) {
 		return 0, ErrUnexpectedEOF
 	}
-	bits := binary.LittleEndian.Uint64(d.buf[d.pos:])
+	bits := binary.BigEndian.Uint64(d.buf[d.pos:])
 	d.pos += 8
 	return math.Float64frombits(bits), nil
+}
+
+// ReadBigInt64 reads a signed 64-bit big-endian integer.
+func (d *Decoder) ReadBigInt64() (int64, error) {
+	if d.pos+8 > len(d.buf) {
+		return 0, ErrUnexpectedEOF
+	}
+	bits := binary.BigEndian.Uint64(d.buf[d.pos:])
+	d.pos += 8
+	return int64(bits), nil
 }
 
 // readVarIntWithSign reads a sign-magnitude VarInt and returns the magnitude
@@ -233,6 +243,12 @@ func (d *Decoder) readAny(depth int) (any, error) {
 		return d.ReadFloat32()
 	case 123:
 		return d.ReadFloat64()
+	case 122:
+		v, err := d.ReadBigInt64()
+		if err != nil {
+			return nil, err
+		}
+		return BigInt(v), nil
 	case 119:
 		return d.ReadVarString()
 	case 116:

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -107,17 +107,27 @@ func (e *Encoder) WriteVarBytes(b []byte) {
 	e.buf = append(e.buf, b...)
 }
 
-// WriteFloat32 writes a 32-bit IEEE 754 float in little-endian byte order.
+// BigInt represents lib0 writeAny tag 122, encoded as a signed 64-bit integer.
+type BigInt int64
+
+// WriteFloat32 writes a 32-bit IEEE 754 float in big-endian byte order.
 func (e *Encoder) WriteFloat32(v float32) {
 	var b [4]byte
-	binary.LittleEndian.PutUint32(b[:], math.Float32bits(v))
+	binary.BigEndian.PutUint32(b[:], math.Float32bits(v))
 	e.buf = append(e.buf, b[:]...)
 }
 
-// WriteFloat64 writes a 64-bit IEEE 754 float in little-endian byte order.
+// WriteFloat64 writes a 64-bit IEEE 754 float in big-endian byte order.
 func (e *Encoder) WriteFloat64(v float64) {
 	var b [8]byte
-	binary.LittleEndian.PutUint64(b[:], math.Float64bits(v))
+	binary.BigEndian.PutUint64(b[:], math.Float64bits(v))
+	e.buf = append(e.buf, b[:]...)
+}
+
+// WriteBigInt64 writes a signed 64-bit integer in big-endian byte order.
+func (e *Encoder) WriteBigInt64(v int64) {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(v))
 	e.buf = append(e.buf, b[:]...)
 }
 
@@ -141,15 +151,16 @@ func (e *Encoder) writeNegVarUint(v uint64) {
 // WriteAny encodes an arbitrary value using lib0's tagged-union format.
 // Supported Go types and their wire tags:
 //
-//	nil           → 126 (null)
-//	bool          → 120 (true) / 121 (false)
-//	int / int64   → 125 + VarInt
-//	float32       → 124 + 4 bytes LE
-//	float64       → 123 + 8 bytes LE
-//	string        → 119 + VarString
-//	[]byte        → 116 + VarBytes
-//	[]any         → 117 + VarUint(len) + elements
-//	map[string]any→ 118 + VarUint(len) + key-value pairs
+//	nil            -> 126 (null)
+//	bool           -> 120 (true) / 121 (false)
+//	int / int64    -> 125 + VarInt
+//	float32        -> 124 + 4 bytes BE
+//	float64        -> 123 + 8 bytes BE
+//	BigInt         -> 122 + 8 bytes BE
+//	string         -> 119 + VarString
+//	[]byte         -> 116 + VarBytes
+//	[]any          -> 117 + VarUint(len) + elements
+//	map[string]any -> 118 + VarUint(len) + key-value pairs
 func (e *Encoder) WriteAny(v any) {
 	switch val := v.(type) {
 	case nil:
@@ -172,6 +183,9 @@ func (e *Encoder) WriteAny(v any) {
 	case float64:
 		e.WriteUint8(123)
 		e.WriteFloat64(val)
+	case BigInt:
+		e.WriteUint8(122)
+		e.WriteBigInt64(int64(val))
 	case string:
 		e.WriteUint8(119)
 		e.WriteVarString(val)

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -212,6 +212,60 @@ func TestUnit_Any_IntAlias(t *testing.T) {
 	assert.Equal(t, int64(42), got)
 }
 
+func TestGolden_Any_Lib0BigInt_KnownBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		val  encoding.BigInt
+		wire []byte
+	}{
+		{
+			name: "positive",
+			val:  encoding.BigInt(42),
+			wire: []byte{122, 0, 0, 0, 0, 0, 0, 0, 42},
+		},
+		{
+			name: "negative",
+			val:  encoding.BigInt(-42),
+			wire: []byte{122, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xd6},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := encoding.NewDecoder(tc.wire).ReadAny()
+			require.NoError(t, err)
+			assert.Equal(t, tc.val, got)
+
+			e := encoding.NewEncoder()
+			e.WriteAny(tc.val)
+			assert.Equal(t, tc.wire, e.Bytes())
+		})
+	}
+}
+
+func TestGolden_Any_Lib0FloatBytes(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		wire := []byte{124, 0x3f, 0xc0, 0x00, 0x00}
+		got, err := encoding.NewDecoder(wire).ReadAny()
+		require.NoError(t, err)
+		assert.InDelta(t, float32(1.5), got, 0)
+
+		e := encoding.NewEncoder()
+		e.WriteAny(float32(1.5))
+		assert.Equal(t, wire, e.Bytes())
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		wire := []byte{123, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18}
+		got, err := encoding.NewDecoder(wire).ReadAny()
+		require.NoError(t, err)
+		assert.InDelta(t, math.Pi, got, 0)
+
+		e := encoding.NewEncoder()
+		e.WriteAny(math.Pi)
+		assert.Equal(t, wire, e.Bytes())
+	})
+}
+
 // --- Encoder reset ---
 
 func TestUnit_Encoder_Reset(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix a long-standing Yjs/lib0 wire-compatibility bug in `Any` float encoding. ygo previously used little-endian bytes for `float32`/`float64`; lib0 and yrs both use big-endian.
- Add lib0 `Any` tag 122 support via `encoding.BigInt`, plus bigint read/write helpers, so updates containing JS `BigInt` values can decode instead of failing.
- Add compatibility coverage for YArray float values, Y.XmlFragment bigint attrs, and V2 YText bigint formatting.

## Compatibility

This changes the encoded bytes for float `Any` values, tags 123 and 124. ygo-to-ygo deployments with previously persisted float updates may read those old bytes differently after upgrading, even though no public API signature changes.

Cross-implementation use with Yjs JS / yrs was already broken before this fix; this aligns ygo with the upstream wire format.

## Reference

lib0 is the authoritative reference for the byte order here:

https://github.com/dmonad/lib0/blob/main/src/encoding.js

`writeFloat32`, `writeFloat64`, and `writeBigInt64` call DataView with `littleEndian = false`, which means big-endian.

## Test Plan

- `git diff --check HEAD`
- GitHub Actions: `golangci-lint run ./...`
- GitHub Actions: `go test -race -timeout 120s -coverprofile=coverage.txt -covermode=atomic ./...`
- GitHub Actions: vulnerability scan
