### PR TITLE
fix(security): pending-items cap (#46), slow-loris fix (#47), CSWSH docs (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`crdt`: cap on pending-items queue depth (#46)**: items whose dependencies have not yet arrived are parked in `StructStore.pending.items`. Previously this queue was unbounded — a malicious peer could craft a single max-size update full of items referencing far-future clocks and park multi-GB of items, OOM'ing the server. Now capped at 100,000 by default (configurable via the new `crdt.WithMaxPendingItems` option or `provider/websocket.Server.MaxPendingItems` / `provider/http.Server.MaxPendingItems`). Updates that would exceed the cap return `ErrInvalidUpdate`.
 - **`provider/websocket`: initial read deadline on connections (#47)**: the WebSocket read loop had no read deadline before the first message. With `MaxConnections == 0` (the default), an attacker could complete handshakes on many connections and then send nothing, holding goroutines + buffers indefinitely (slow-loris). Now an initial `HandshakeTimeout` (default 30s, configurable via `Server.HandshakeTimeout`) closes any connection that doesn't send a first message in time. The deadline is cleared after the first successful read.
 
+### Documentation
+
+- **CSWSH warning on `Server.AllowedOrigins` (#49)**: godoc on the `AllowedOrigins` field now explicitly warns about Cross-Site WebSocket Hijacking when set to `"*"`. `SECURITY.md` adds a CSWSH entry to the threat model with mitigation guidance.
+
 ## [1.7.1] — 2026-05-14
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`encoding.BigInt` type + `Any` tag 122 support.** lib0's BigInt tag (used by Yjs JS to encode int64 values that don't fit in JS `Number.MAX_SAFE_INTEGER`) is now decoded into a new `encoding.BigInt` named type, and `WriteAny` can encode that type with tag 122. Previously, ygo failed to decode updates containing JS BigInt values. Adds `Encoder.WriteBigInt64` and `Decoder.ReadBigInt64` helpers.
 - **`crdt.WithMaxPendingItems(n int)`** (#46): doc option to configure the pending-items cap.
 - **`provider/websocket.Server.MaxPendingItems`** and **`provider/http.Server.MaxPendingItems`** (#46): server-level config that forwards the cap to `crdt.New(...)` for all rooms.
+- **`provider/websocket.Server.HandshakeTimeout`** (#47, default 30s): caps how long a peer may stay connected without sending any message after handshake.
 
 ### Fixed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **Compatibility note**: previously persisted ygo updates containing float values will read different float values after upgrading. Cross-implementation use was already broken before this fix; the breakage was in the previous behavior, not this one. If your deployment stores ygo update bytes long-term and uses raw float values (rather than integers encoded via VarInt), plan for a re-encode pass.
 - **`crdt`: cap on pending-items queue depth (#46)**: items whose dependencies have not yet arrived are parked in `StructStore.pending.items`. Previously this queue was unbounded — a malicious peer could craft a single max-size update full of items referencing far-future clocks and park multi-GB of items, OOM'ing the server. Now capped at 100,000 by default (configurable via the new `crdt.WithMaxPendingItems` option or `provider/websocket.Server.MaxPendingItems` / `provider/http.Server.MaxPendingItems`). Updates that would exceed the cap return `ErrInvalidUpdate`.
+- **`provider/websocket`: initial read deadline on connections (#47)**: the WebSocket read loop had no read deadline before the first message. With `MaxConnections == 0` (the default), an attacker could complete handshakes on many connections and then send nothing, holding goroutines + buffers indefinitely (slow-loris). Now an initial `HandshakeTimeout` (default 30s, configurable via `Server.HandshakeTimeout`) closes any connection that doesn't send a first message in time. The deadline is cleared after the first successful read.
 
 ## [1.7.1] — 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`encoding.BigInt` type + `Any` tag 122 support.** lib0's BigInt tag (used by Yjs JS to encode int64 values that don't fit in JS `Number.MAX_SAFE_INTEGER`) is now decoded into a new `encoding.BigInt` named type, and `WriteAny` can encode that type with tag 122. Previously, ygo failed to decode updates containing JS BigInt values. Adds `Encoder.WriteBigInt64` and `Decoder.ReadBigInt64` helpers.
+- **`crdt.WithMaxPendingItems(n int)`** (#46): doc option to configure the pending-items cap.
+- **`provider/websocket.Server.MaxPendingItems`** and **`provider/http.Server.MaxPendingItems`** (#46): server-level config that forwards the cap to `crdt.New(...)` for all rooms.
 
 ### Fixed
 
 - **Float byte order now matches lib0 and yrs (big-endian).** ygo previously encoded float32 and float64 in little-endian, which silently broke binary compatibility with Yjs JS and yrs for any document containing float values. The README has always claimed binary compatibility; this fixes the gap. The wire format for float `Any` values (tags 123 and 124) is now big-endian, matching [lib0's `writeFloat32`/`writeFloat64`](https://github.com/dmonad/lib0/blob/main/src/encoding.js).
 
   **Compatibility note**: previously persisted ygo updates containing float values will read different float values after upgrading. Cross-implementation use was already broken before this fix; the breakage was in the previous behavior, not this one. If your deployment stores ygo update bytes long-term and uses raw float values (rather than integers encoded via VarInt), plan for a re-encode pass.
+- **`crdt`: cap on pending-items queue depth (#46)**: items whose dependencies have not yet arrived are parked in `StructStore.pending.items`. Previously this queue was unbounded — a malicious peer could craft a single max-size update full of items referencing far-future clocks and park multi-GB of items, OOM'ing the server. Now capped at 100,000 by default (configurable via the new `crdt.WithMaxPendingItems` option or `provider/websocket.Server.MaxPendingItems` / `provider/http.Server.MaxPendingItems`). Updates that would exceed the cap return `ErrInvalidUpdate`.
 
 ## [1.7.1] — 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ All hard-capped (semaphore-backed for connection counts):
 - `Server.MaxUpdateBytes` — per-update size cap (default 64 MiB).
 - `Server.MaxMessageBytes` — per-message size on the WebSocket read path (default 64 MiB).
 - `Server.PeerWriteQueueSize` — per-peer broadcast queue depth (default 256). When the queue fills, the peer is disconnected.
+- `Server.MaxPendingItems` — per-document cap on items parked in the out-of-order pending queue (default 100,000). When the cap is reached, updates that would park additional items return `ErrInvalidUpdate`. Defends against a crafted update full of far-future-clock items that would otherwise grow the queue unboundedly. Same cap is available at the doc level via `crdt.WithMaxPendingItems(n)`.
 
 Each defaults to a sensible value or unlimited where noted.
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ All hard-capped (semaphore-backed for connection counts):
 - `Server.MaxMessageBytes` — per-message size on the WebSocket read path (default 64 MiB).
 - `Server.PeerWriteQueueSize` — per-peer broadcast queue depth (default 256). When the queue fills, the peer is disconnected.
 - `Server.MaxPendingItems` — per-document cap on items parked in the out-of-order pending queue (default 100,000). When the cap is reached, updates that would park additional items return `ErrInvalidUpdate`. Defends against a crafted update full of far-future-clock items that would otherwise grow the queue unboundedly. Same cap is available at the doc level via `crdt.WithMaxPendingItems(n)`.
+- `Server.HandshakeTimeout` — first-read deadline applied after WebSocket upgrade (default 30s). Closes connections that complete the handshake but never send a message (slow-loris defense). Cleared after the first successful read.
 
 Each defaults to a sensible value or unlimited where noted.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,7 @@ You can expect an acknowledgement within **48 hours** and a resolution timeline 
   - Awareness update: max 100 000 client entries (`maxAwarenessClients`); max 1 MiB per client state (`maxAwarenessStateBytes`)
   - `ReadAny` recursion: max 100 levels deep (`maxAnyDepth`)
   - Per-document pending-items queue: max 100 000 parked items by default (`defaultMaxPendingItems`; configurable via `crdt.WithMaxPendingItems` or `Server.MaxPendingItems`). Items whose `Origin`/`OriginRight` references a clock not yet integrated are parked in this queue and retried when the dependency arrives — the cap prevents a crafted update full of far-future-clock items from growing the queue without bound. Updates that would exceed the cap return `ErrInvalidUpdate`. (Added in v1.8.0; see #46.)
+  - WebSocket idle connections: peers that complete the handshake but don't send a first message are disconnected after `Server.HandshakeTimeout` (default 30s). Without this, an attacker could exhaust goroutines and per-connection buffers via slow-loris-style idle connections. (Added in v1.8.0; see #47.)
 ### ClientID semantics
 
 `crdt.ClientID` is a 32-bit value generated via `crypto/rand` and used to

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,7 @@ You can expect an acknowledgement within **48 hours** and a resolution timeline 
   - HTTP POST body and WebSocket frame: max 64 MiB (`maxUpdateBytes` / `maxWSMessageBytes`)
   - Awareness update: max 100 000 client entries (`maxAwarenessClients`); max 1 MiB per client state (`maxAwarenessStateBytes`)
   - `ReadAny` recursion: max 100 levels deep (`maxAnyDepth`)
+  - Per-document pending-items queue: max 100 000 parked items by default (`defaultMaxPendingItems`; configurable via `crdt.WithMaxPendingItems` or `Server.MaxPendingItems`). Items whose `Origin`/`OriginRight` references a clock not yet integrated are parked in this queue and retried when the dependency arrives — the cap prevents a crafted update full of far-future-clock items from growing the queue without bound. Updates that would exceed the cap return `ErrInvalidUpdate`. (Added in v1.8.0; see #46.)
 ### ClientID semantics
 
 `crdt.ClientID` is a 32-bit value generated via `crypto/rand` and used to

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,7 @@ You can expect an acknowledgement within **48 hours** and a resolution timeline 
 ## Threat Model
 
 - **Wire format**: ygo validates all incoming binary updates (V1 and V2) but does **not** authenticate them. Applying an update from an untrusted peer is safe in the sense that it cannot crash the process or exhaust unbounded memory, but it can modify the document. Authentication and authorisation are the responsibility of the transport layer (e.g. the WebSocket `AuthFunc` hook).
+- **Cross-Site WebSocket Hijacking (CSWSH)**: setting `Server.AllowedOrigins` to `"*"` disables same-origin protection. A malicious page visited by the user can then open a WebSocket to this server and exercise the user's session if authentication is carried by a cookie. Mitigations: (a) use a specific allow-list of origins rather than `"*"`; (b) use `AuthFunc` with tokens carried explicitly (subprotocol or query parameter), not cookies; (c) deploy behind a reverse proxy that enforces origin checks at the edge. See #49.
 - **Denial of service**: the following resource limits are enforced on untrusted input:
   - Binary update: max 1 048 576 items per update (`maxV2Items`); max `math.MaxInt32` length per field
   - HTTP POST body and WebSocket frame: max 64 MiB (`maxUpdateBytes` / `maxWSMessageBytes`)

--- a/crdt/crdt_test.go
+++ b/crdt/crdt_test.go
@@ -1560,3 +1560,52 @@ func TestUnit_Doc_PendingStats_ReflectsParkedItems(t *testing.T) {
 	assert.Equal(t, 0, statsAfter.Items)
 	assert.Empty(t, statsAfter.MissingFor)
 }
+
+func TestUnit_Doc_MaxPendingItems_CapsParkedItems(t *testing.T) {
+	// Build a doc with a tiny cap and craft an update that would
+	// otherwise park many items in the pending queue. Cap should
+	// fire before the queue grows unbounded.
+	//
+	// Producer A inserts a "seed" item (clock 0). Producer B sees A's
+	// state and inserts 10 further items (each referencing A's item via
+	// Origin). We give the consumer B's update without the seed, so all
+	// 10 items reference a clock the consumer doesn't have and get parked.
+	// With a cap of 5 the apply should fail.
+	a := newTestDoc(1)
+	arrA := a.GetArray("arr")
+	a.Transact(func(txn *Transaction) { arrA.Insert(txn, 0, []any{"seed"}) })
+	seedSV := a.store.StateVector() // state vector after seed: {1: 1}
+
+	b := newTestDoc(2)
+	require.NoError(t, ApplyUpdateV1(b, EncodeStateAsUpdateV1(a, nil), nil))
+	arrB := b.GetArray("arr")
+	for i := 0; i < 10; i++ {
+		idx := i + 1
+		b.Transact(func(txn *Transaction) { arrB.Insert(txn, idx, []any{"item"}) })
+	}
+	// Build an update that omits the seed item: B's new items reference A's
+	// clock but the consumer only gets B's additions.
+	updateBOnly, err := DiffUpdateV1(EncodeStateAsUpdateV1(b, nil), seedSV)
+	require.NoError(t, err)
+
+	doc := New(WithMaxPendingItems(5), WithClientID(99))
+	err = ApplyUpdateV1(doc, updateBOnly, nil)
+	require.ErrorIs(t, err, ErrInvalidUpdate, "applying update that parks > cap items should fail")
+
+	stats := doc.PendingStats()
+	assert.LessOrEqual(t, stats.Items, 5, "pending queue must not exceed the configured cap")
+}
+
+func TestUnit_Doc_MaxPendingItems_DefaultIsHigh(t *testing.T) {
+	doc := New()
+	assert.Equal(t, defaultMaxPendingItems, doc.maxPendingItemsLimit())
+
+	doc2 := New(WithMaxPendingItems(0))
+	assert.Equal(t, defaultMaxPendingItems, doc2.maxPendingItemsLimit(), "zero == default")
+
+	doc3 := New(WithMaxPendingItems(-1))
+	assert.Equal(t, defaultMaxPendingItems, doc3.maxPendingItemsLimit(), "negative == default")
+
+	doc4 := New(WithMaxPendingItems(42))
+	assert.Equal(t, 42, doc4.maxPendingItemsLimit())
+}

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -68,6 +68,23 @@ func WithGUID(guid string) DocOption {
 	return func(d *Doc) { d.guid = guid }
 }
 
+// defaultMaxPendingItems is the default cap on items parked in the per-doc
+// pending queue waiting for out-of-order dependencies. Matches the per-update
+// limit (maxV2Items) used by the decoder. See WithMaxPendingItems and #46.
+const defaultMaxPendingItems = 100_000
+
+// WithMaxPendingItems caps the per-doc pending queue depth — items parked
+// waiting for out-of-order dependencies. Once the cap is reached, further
+// items that would be parked cause ApplyUpdate to return ErrInvalidUpdate.
+// Zero or negative uses the default (100,000).
+//
+// This is a defence against a malicious peer crafting an update full of
+// far-future-clock items, which would otherwise grow the pending queue
+// without bound. See issue #46.
+func WithMaxPendingItems(n int) DocOption {
+	return func(d *Doc) { d.maxPendingItems = n }
+}
+
 // updateSub pairs a unique subscription ID with its callback so that
 // unsubscribe closures can find and remove the right entry even when
 // callbacks are removed out-of-order.
@@ -85,9 +102,10 @@ type transactionSub struct {
 // Doc is the root of a Yjs collaborative document.
 // All shared types (YArray, YMap, YText, …) live inside a Doc.
 type Doc struct {
-	clientID ClientID
-	gc       bool
-	guid     string // subdocument identifier; empty for root docs
+	clientID        ClientID
+	gc              bool
+	guid            string // subdocument identifier; empty for root docs
+	maxPendingItems int    // 0 = use defaultMaxPendingItems; see WithMaxPendingItems and #46
 
 	store *StructStore
 	share map[string]sharedType // named root types
@@ -121,6 +139,14 @@ func (d *Doc) ClientID() ClientID {
 // GUID returns the document's subdocument identifier (empty for root docs).
 func (d *Doc) GUID() string {
 	return d.guid
+}
+
+// maxPendingItemsLimit returns the effective cap on the pending queue depth.
+func (d *Doc) maxPendingItemsLimit() int {
+	if d.maxPendingItems <= 0 {
+		return defaultMaxPendingItems
+	}
+	return d.maxPendingItems
 }
 
 // NewClientID generates a fresh ClientID via crypto/rand.

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -446,7 +446,9 @@ func applyV1Txn(txn *Transaction, update []byte) (retErr error) {
 	}
 
 	// 2. Within-update retry pass: items whose parents arrived later in this update.
-	resolveWithinUpdatePending(txn, withinUpdatePending)
+	if err := resolveWithinUpdatePending(txn, withinUpdatePending); err != nil {
+		return err
+	}
 
 	ds, err := decodeDeleteSet(dec)
 	if err != nil {
@@ -540,6 +542,9 @@ func decodeAndPark(txn *Transaction, dec *encoding.Decoder, sv StateVector, numC
 			// with the store's current clock as the watermark — when the store
 			// reaches that clock, the missing predecessor may be available.
 			if clock > existingEnd {
+				if txn.doc.store.pending != nil && len(txn.doc.store.pending.items) >= txn.doc.maxPendingItemsLimit() {
+					return nil, wrapUpdateErr(ErrInvalidUpdate)
+				}
 				if txn.doc.store.pending == nil {
 					txn.doc.store.pending = &pendingUpdate{missing: make(StateVector)}
 				}
@@ -592,7 +597,8 @@ func decodeAndPark(txn *Transaction, dec *encoding.Decoder, sv StateVector, numC
 // parent from the store. If progress was made, try again with the remaining
 // items. When no progress is made, partition survivors into future-clock
 // (park in store.pending) vs truly-unresolvable (orphan-Append).
-func resolveWithinUpdatePending(txn *Transaction, pending []*Item) {
+// Returns ErrInvalidUpdate (wrapped) if the pending queue cap is exceeded.
+func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 	// Retry items whose parent couldn't be resolved during the first pass
 	// because their origin items were in a later client group.
 	for len(pending) > 0 {
@@ -634,6 +640,9 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) {
 			//     they survive re-encoding. Matches the pre-#11 fallback.
 			for _, item := range remaining {
 				if client, parkedAt, isFuture := itemFutureDep(item, txn.doc.store); isFuture {
+					if txn.doc.store.pending != nil && len(txn.doc.store.pending.items) >= txn.doc.maxPendingItemsLimit() {
+						return wrapUpdateErr(ErrInvalidUpdate)
+					}
 					if txn.doc.store.pending == nil {
 						txn.doc.store.pending = &pendingUpdate{
 							missing: make(StateVector),
@@ -649,6 +658,7 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) {
 		}
 		pending = remaining
 	}
+	return nil
 }
 
 // drainPending runs the doc-level pending drain. It first retries any

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -671,6 +671,9 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 			// with the store's current clock as the watermark — when the store
 			// reaches that clock, the missing predecessor may be available.
 			if clock > existingEnd {
+				if txn.doc.store.pending != nil && len(txn.doc.store.pending.items) >= txn.doc.maxPendingItemsLimit() {
+					return wrapUpdateErr(ErrInvalidUpdate)
+				}
 				if txn.doc.store.pending == nil {
 					txn.doc.store.pending = &pendingUpdate{missing: make(StateVector)}
 				}
@@ -734,6 +737,9 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 			//     they survive re-encoding. Matches the pre-#11 fallback.
 			for _, item := range remaining {
 				if client, parkedAt, isFuture := itemFutureDep(item, txn.doc.store); isFuture {
+					if txn.doc.store.pending != nil && len(txn.doc.store.pending.items) >= txn.doc.maxPendingItemsLimit() {
+						return wrapUpdateErr(ErrInvalidUpdate)
+					}
 					if txn.doc.store.pending == nil {
 						txn.doc.store.pending = &pendingUpdate{
 							missing: make(StateVector),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,6 +94,8 @@ When an update references an item whose dependency hasn't arrived yet — a same
 
 The same machinery handles delete-set entries that target not-yet-integrated items (`pendingDs`). State-vector computation is unaffected — pending items don't appear in `StateVector()` until they're integrated, so peers correctly retry the missing dependencies.
 
+The queue is bounded (default 100,000 parked items; configurable via `crdt.WithMaxPendingItems` or `Server.MaxPendingItems`). Updates that would push past the cap return `ErrInvalidUpdate` — see the v1.8.0 CHANGELOG and #46 for the security rationale.
+
 ### DeleteSet
 
 Tracks deleted ranges as `map[ClientID][]DeleteRange{Clock, Len}`. Items are tombstoned (marked `Deleted = true`) rather than removed, keeping linked-list positions stable.

--- a/provider/http/server.go
+++ b/provider/http/server.go
@@ -29,6 +29,12 @@ const maxSVParamBytes = 1 << 16 // 64 KiB
 type Server struct {
 	mu   sync.RWMutex
 	docs map[string]*crdt.Doc
+
+	// MaxPendingItems caps the per-document pending-items queue depth. The
+	// queue holds items whose dependencies have not yet arrived, waiting for
+	// out-of-order delivery to resolve. Zero or negative uses the crdt default
+	// (100,000). See crdt.WithMaxPendingItems and issue #46.
+	MaxPendingItems int
 }
 
 // NewServer returns a new Server with an empty document store.
@@ -48,7 +54,11 @@ func (s *Server) getOrCreateDoc(room string) *crdt.Doc {
 	}
 	// Use NewClientID (crypto/rand, uint32) to stay within Yjs wire protocol's
 	// 53-bit VarUint limit and avoid predictable IDs in multi-tenant deployments.
-	doc := crdt.New(crdt.WithClientID(crdt.NewClientID()))
+	docOpts := []crdt.DocOption{crdt.WithClientID(crdt.NewClientID())}
+	if s.MaxPendingItems > 0 {
+		docOpts = append(docOpts, crdt.WithMaxPendingItems(s.MaxPendingItems))
+	}
+	doc := crdt.New(docOpts...)
 	s.docs[room] = doc
 	return doc
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -47,6 +47,16 @@ func (s *Server) maxMessageBytes() int64 {
 	return maxWSMessageBytes
 }
 
+const defaultHandshakeTimeout = 30 * time.Second
+
+// handshakeTimeout returns the configured first-read deadline or the default.
+func (s *Server) handshakeTimeout() time.Duration {
+	if s.HandshakeTimeout > 0 {
+		return s.HandshakeTimeout
+	}
+	return defaultHandshakeTimeout
+}
+
 // log returns the configured logger or slog.Default().
 func (s *Server) log() *slog.Logger {
 	if s.Logger != nil {
@@ -249,6 +259,15 @@ type Server struct {
 	// out-of-order delivery to resolve. Zero or negative uses the crdt default
 	// (100,000). See crdt.WithMaxPendingItems and issue #46.
 	MaxPendingItems int
+
+	// HandshakeTimeout caps how long a peer may stay connected without sending
+	// any message after the WebSocket upgrade completes. This is the first-line
+	// defense against slow-loris-style attacks where an attacker completes the
+	// handshake on many connections and then sends nothing, holding goroutines
+	// and buffers indefinitely. After the first successful ReadMessage the
+	// deadline is cleared. Zero or negative uses the default (30 seconds).
+	// See #47.
+	HandshakeTimeout time.Duration
 
 	// connSem enforces MaxConnections as a hard cap. Lazily initialised on
 	// first ServeHTTP. nil when MaxConnections == 0 (unlimited).
@@ -572,10 +591,30 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Read loop — exits when the connection is closed (by peer, by context
 	// cancellation, or by Shutdown).
+	//
+	// An initial read deadline guards against slow-loris: a peer that completes
+	// the WebSocket handshake but never sends a message would otherwise hold
+	// the read goroutine, writeCh buffer, and any connection-tracking memory
+	// indefinitely. After the first successful ReadMessage we clear the
+	// deadline; downstream slow-peer protection is handled by the writeCh
+	// disconnect-on-overflow path (see #19) and gorilla/websocket's pong
+	// handling. See #47.
+	if err := ws.SetReadDeadline(time.Now().Add(s.handshakeTimeout())); err != nil {
+		return
+	}
+	firstMessage := true
 	for {
 		_, data, err := ws.ReadMessage()
 		if err != nil {
 			break
+		}
+		if firstMessage {
+			// Clear the handshake deadline; subsequent reads can take as long
+			// as the WebSocket protocol's own pong-timeout machinery allows.
+			if err := ws.SetReadDeadline(time.Time{}); err != nil {
+				return
+			}
+			firstMessage = false
 		}
 		p.handleMessage(data)
 	}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -197,6 +197,14 @@ type Server struct {
 	// If the slice is empty the server falls back to a same-origin check:
 	// the request Origin header must match the HTTP Host header. Non-browser
 	// clients that omit the Origin header are always permitted.
+	//
+	// Security warning: setting AllowedOrigins to "*" disables same-origin
+	// protection and enables Cross-Site WebSocket Hijacking (CSWSH) — a
+	// malicious page that the user visits can open a WebSocket to this
+	// server and act as that user if authentication is carried by a session
+	// cookie. Use "*" only when AuthFunc validates tokens carried explicitly
+	// (bearer tokens in the WebSocket subprotocol or a query parameter), not
+	// when relying on cookie-based auth. See SECURITY.md.
 	AllowedOrigins []string
 
 	// MaxConnections is the server-wide cap on simultaneous WebSocket peers.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -244,6 +244,12 @@ type Server struct {
 	// Zero (the default) uses 256, sized for typical sync workloads.
 	PeerWriteQueueSize int
 
+	// MaxPendingItems caps the per-document pending-items queue depth. The
+	// queue holds items whose dependencies have not yet arrived, waiting for
+	// out-of-order delivery to resolve. Zero or negative uses the crdt default
+	// (100,000). See crdt.WithMaxPendingItems and issue #46.
+	MaxPendingItems int
+
 	// connSem enforces MaxConnections as a hard cap. Lazily initialised on
 	// first ServeHTTP. nil when MaxConnections == 0 (unlimited).
 	connSem     *semaphore.Weighted
@@ -393,8 +399,12 @@ func (s *Server) getOrCreateRoom(name string) (*room, error) {
 	if s.MaxRooms > 0 && len(s.rooms) >= s.MaxRooms {
 		return nil, ErrTooManyRooms
 	}
+	docOpts := []crdt.DocOption{}
+	if s.MaxPendingItems > 0 {
+		docOpts = append(docOpts, crdt.WithMaxPendingItems(s.MaxPendingItems))
+	}
 	r := &room{
-		doc:       crdt.New(),
+		doc:       crdt.New(docOpts...),
 		awareness: awareness.New(0),
 		peers:     make(map[*peer]struct{}),
 	}

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -650,3 +650,33 @@ func TestServer_LegacyPersistenceAdapter_StillWorks(t *testing.T) {
 	a.mu.Unlock()
 	assert.True(t, called, "legacy StoreUpdate must still be called for adapters without ctx variant")
 }
+
+func TestServer_HandshakeTimeout_ClosesIdleConnection(t *testing.T) {
+	// Regression for #47: a peer that completes the WebSocket handshake but
+	// never sends a message must be disconnected within HandshakeTimeout.
+	s := ygws.NewServer()
+	s.HandshakeTimeout = 300 * time.Millisecond
+	httpSrv := httptest.NewServer(s)
+	defer httpSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/idle-room"
+
+	c, _, err := gws.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Drain the three server-initiated handshake messages (step1, step2, awareness)
+	// so they don't interfere with the idle-connection detection.
+	for i := 0; i < 3; i++ {
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, _, err := c.ReadMessage()
+		require.NoError(t, err, "handshake message %d should arrive cleanly", i+1)
+	}
+	_ = c.SetReadDeadline(time.Time{})
+
+	// Do not send any message. The server's HandshakeTimeout (300ms) fires and
+	// closes the connection. Our read should error within ~HandshakeTimeout.
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, readErr := c.ReadMessage()
+	assert.Error(t, readErr, "idle peer should be disconnected by the server within HandshakeTimeout")
+}


### PR DESCRIPTION
## Summary

Three small security improvements bundled together: two HIGH-severity DoS caps from the post-v1.7.0 architect audit (#46, #47), plus a related documentation fix surfacing the CSWSH foot-gun on `AllowedOrigins` (#49).

Closes #46. Closes #47. Closes #49.

## #46 — Cap on `StructStore.pending.items` queue

Items whose `Origin`/`OriginRight` references a clock not yet integrated are parked in `StructStore.pending.items` and retried when the missing dependency arrives. The queue was **unbounded**.

A malicious peer can craft a single `MaxMessageBytes`-sized update (default 64 MiB) packed with items referencing far-future clocks from many fake client IDs. Each gets parked. At ~2 bytes per item on the wire, a single update can park ~32M items consuming **multi-GB of server memory** before any existing cap catches it.

**Fix**: cap the queue at **100,000 items** by default. Configurable via:

- `crdt.WithMaxPendingItems(n int)` — doc-level primitive
- `provider/websocket.Server.MaxPendingItems` — server-level convenience
- `provider/http.Server.MaxPendingItems` — same for the HTTP provider

Updates that would exceed the cap return `ErrInvalidUpdate`. Affects both V1 and V2 decode paths.

## #47 — WebSocket initial read deadline (slow-loris)

The read loop had no read deadline before the first message. When `Server.MaxConnections == 0` (the default — unlimited), an attacker can complete handshakes on many connections and send nothing. Each held connection consumes a goroutine, a 256-slot `writeCh` buffer, connection-tracking memory, and (if configured) a semaphore slot.

**Fix**: set `ws.SetReadDeadline(time.Now().Add(HandshakeTimeout))` immediately after upgrade. Clear after the first successful `ReadMessage`. New `Server.HandshakeTimeout` field (default 30s) controls the timeout. Subsequent reads run unbounded; steady-state slow-peer protection is handled by the existing `PeerWriteQueueSize` disconnect-on-overflow path (#19).

## #49 — CSWSH warning on `AllowedOrigins`

Setting `Server.AllowedOrigins` to `"*"` disables same-origin protection and enables Cross-Site WebSocket Hijacking — a malicious page that the user visits can open a WebSocket to this server and act as that user if authentication is carried by a session cookie.

**Fix**: documentation only. The `AllowedOrigins` godoc now carries an explicit security warning, and `SECURITY.md` adds a CSWSH entry to the threat model with mitigation guidance (specific allow-list, explicit tokens over cookies, edge-level origin checks).

## Bundling with PR #45

This PR is intended to merge alongside PR #45 (zombiek731's lib0 wire-compat fix) in the same release. Both add to the same upcoming CHANGELOG section.

**Suggested merge order**: #45 first (it was opened first and is fully ready). After #45 merges, this PR will need a quick rebase, and the two CHANGELOG sections will need to be consolidated into a single section under one heading. Both sections are well-scoped — the consolidation is mechanical.

## Documentation

The new caps are surfaced in user-facing docs too:

- **README** — both `MaxPendingItems` and `HandshakeTimeout` added to the "Resource limits" subsection under "Running in production".
- **SECURITY.md** — both DoS caps added under the threat model's "Denial of service" list; CSWSH entry added as a separate threat-model bullet.
- **docs/ARCHITECTURE.md** — pending-structs paragraph notes the queue is bounded.

## Test plan

- [x] `go test -race -timeout 120s ./...` — all packages green
- [x] `go vet ./...` / `go build ./...` — clean
- [x] `golangci-lint run --timeout 5m ./...` — 0 issues
- [x] **New tests**:
  - `TestUnit_Doc_MaxPendingItems_CapsParkedItems` — verifies the cap fires and pending queue stays bounded
  - `TestUnit_Doc_MaxPendingItems_DefaultIsHigh` — verifies default, zero, and negative all resolve to the default
  - `TestServer_HandshakeTimeout_ClosesIdleConnection` — verifies an idle WebSocket peer is disconnected within `HandshakeTimeout`
- [x] All existing pending-structs convergence tests (#11) still pass
- [x] All existing WebSocket-provider tests still pass

## Semver

Minor bump — new exported symbols on `crdt` and both providers; existing API unchanged.

## Commits

```
918f7f1  docs(security): CSWSH warning on AllowedOrigins (#49)
4c2c770  fix(provider/websocket): initial read deadline to prevent slow-loris (#47)
f408fc9  docs: document MaxPendingItems cap in README, SECURITY, and ARCHITECTURE
649bc54  fix(crdt): cap StructStore.pending.items queue depth (#46)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
