### PR TITLE
docs: release notes for v1.8.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,16 @@
 ## What's new
 
-- **README refresh.** Extended Features list covering everything shipped since v1.0; new sections for Persistence, Running in production, and an expanded Security model.
-- **`docs/ROADMAP.md` → `docs/HISTORY.md`.** Retired the pre-1.0 phased plan; replaced with a doc covering the post-1.0 arc and the upstream-alignment design value.
-- **`docs/PERSISTENCE.md`** now documents the v1.7.0 `PersistenceAdapterContext` extension with a Postgres example.
-- **`CONTRIBUTING.md`** documents the PR conventions we settled in practice.
-- All changes are documentation-only; no API or behavior changes.
+Four items bundled — two from an external contributor's lib0 wire-compat fix, two from a security audit, plus a documentation hardening.
+
+- **Lib0 `Any` `BigInt` tag support + float byte-order fix** (#45, contributed by @zombiek731). Adds `encoding.BigInt` and `WriteAny`/`ReadAny` support for lib0's `Any` tag 122. Fixes a long-standing wire-compat bug: ygo encoded `float32`/`float64` `Any` values in little-endian, but lib0 and yrs use big-endian. The README has always claimed Yjs binary compatibility; this finally honors it for documents containing float or BigInt values. See the compatibility note in CHANGELOG for the persisted-update implication.
+- **Cap on the pending-items queue** (#46). `StructStore.pending.items` was previously unbounded. A malicious peer could craft a single max-size update full of items referencing far-future clocks and OOM the server. Now capped at 100,000 by default. Configurable via `crdt.WithMaxPendingItems` and `Server.MaxPendingItems` on both providers.
+- **WebSocket initial read deadline** (#47). The read loop had no deadline before the first message; with `MaxConnections == 0` (default), an attacker could complete handshakes and sit idle, exhausting goroutines. New `Server.HandshakeTimeout` (default 30s) closes idle connections; deadline is cleared after the first successful read.
+- **CSWSH warning on `AllowedOrigins`** (#49). Documentation update: setting `AllowedOrigins` to `"*"` disables same-origin protection and enables Cross-Site WebSocket Hijacking. The godoc and `SECURITY.md` now make this explicit with mitigation guidance.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.7.1
+go get github.com/reearth/ygo@v1.8.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.


### PR DESCRIPTION
Updates RELEASE_NOTES.md from v1.7.1 content to v1.8.0. RELEASE_NOTES.md is what the release workflow uses to populate the GitHub release body, so this needs to land before tagging v1.8.0.

Covers all four items shipping in v1.8.0: lib0 wire-compat fix from PR #45, pending-items cap (#46), WebSocket initial read deadline (#47), CSWSH warning (#49).

No code change. Doc-only.

The original PRs (#45 and #66) deliberately skipped this file to avoid a three-way conflict during the CHANGELOG consolidation. This is the deferred update.