### PR TITLE
fix(sync): WithErrorHandler option (#79) + scope benchmark CI to hot-path PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,33 @@
 name: Benchmark
 
+# Benchmark CI runs in three scenarios:
+#
+#   1. On PRs that touch hot-path source (crdt/, encoding/, benchmarks/, or this
+#      workflow itself). Compares PR branch vs base via benchstat. Skipped for
+#      docs, provider, sync, awareness, and CI-meta changes — none of which
+#      affect the integrate/encode inner loops.
+#
+#   2. Nightly on a cron schedule. Runs the suite on whatever main currently is
+#      and uploads the raw output as a 30-day artifact. Lets us spot slow drift
+#      that no single PR introduces.
+#
+#   3. Manually via workflow_dispatch. Use this when a non-hot-path PR genuinely
+#      needs measurement, or to spot-check main on demand.
+#
+# Rationale: previously this ran on every PR (~20 min per run). Most PRs don't
+# touch the hot paths, so the comparison was noise. See PR #80.
+
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'crdt/**'
+      - 'encoding/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmark.yml'
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,11 +44,22 @@ jobs:
         with:
           go-version: "1.23"
           cache: true
-      - name: Bench PR branch
+      - name: Bench current ref
         run: go test -bench=. -benchmem -count=5 ./... | tee /tmp/new.txt
-      - name: Bench base branch
+      - name: Bench base branch (PR only)
+        if: github.event_name == 'pull_request'
         run: |
           git checkout ${{ github.base_ref }}
           go test -bench=. -benchmem -count=5 ./... | tee /tmp/old.txt
-      - run: go install golang.org/x/perf/cmd/benchstat@latest
-      - run: benchstat /tmp/old.txt /tmp/new.txt
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+      - name: Compare PR vs base
+        if: github.event_name == 'pull_request'
+        run: benchstat /tmp/old.txt /tmp/new.txt
+      - name: Upload nightly/dispatch output
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ github.run_id }}
+          path: /tmp/new.txt
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ code-review-report.md
 # Brainstorming specs and plans — planning artifacts stay local; the durable
 # record lives in CHANGELOG, PR descriptions, and issue threads.
 docs/superpowers/
+
+# Local working notes (per-issue progress trackers, debug logs, scratch repros).
+# Same rationale: planning stays local, durable record lives in PRs and issues.
+.notes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] — Unreleased
+
+### Added
+
+- **`sync.WithErrorHandler(fn func(error))` option for `ApplySyncMessage` (#79)**: when set, the dispatcher routes `ApplyUpdateV1` errors to the caller-supplied handler and returns `(nil, nil)` instead of propagating the error out. Lets a transport read loop continue across a single malformed update from a peer rather than tearing down the connection. Without the option, the existing return-the-error behavior is preserved (back-compat). Decoding errors on the message header itself (truncated frames, unknown message types) are still returned regardless. Matches y-protocols `readSyncMessage(..., errorHandler)`.
+
 ## [1.8.1] — 2026-05-18
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,25 @@ ygo uses four test layers:
 - New fuzz targets must be registered in the `fuzz` Makefile target and the `fuzz.yml` workflow.
 - Benchmarks should cover hot paths in `encoding/` and `crdt/`.
 
+### Common pitfalls
+
+- **Always obtain shared-type handles outside `Transact` callbacks.** `doc.GetText`, `doc.GetArray`, `doc.GetMap`, `doc.GetXmlFragment` and the other root accessors acquire the doc's write lock — which `Transact` already holds. Calling them inside the callback deadlocks. The same applies to reads like `text.ToString()` and `arr.ToSlice()`. Pattern:
+
+  ```go
+  // CORRECT — capture the handle before Transact.
+  txt := doc.GetText("content")
+  doc.Transact(func(txn *crdt.Transaction) {
+      txt.Insert(txn, 0, "hello", nil)
+  })
+
+  // DEADLOCK — GetText inside Transact tries to re-acquire the write lock.
+  doc.Transact(func(txn *crdt.Transaction) {
+      doc.GetText("content").Insert(txn, 0, "hello", nil) // hangs forever
+  })
+  ```
+
+  README has the user-facing version of this warning; it's repeated here because tests are the most common place to hit it. If a new test hangs indefinitely, this is almost always the cause.
+
 ## Conventional Commits
 
 Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -108,6 +108,31 @@ func EncodeUpdate(update []byte) []byte {
 	return enc.Bytes()
 }
 
+// ApplySyncMessageOption configures ApplySyncMessage. Use WithErrorHandler to
+// keep the sync loop alive across a single malformed message.
+type ApplySyncMessageOption func(*applySyncOpts)
+
+// applySyncOpts is the internal options struct for ApplySyncMessage.
+type applySyncOpts struct {
+	errorHandler func(error)
+}
+
+// WithErrorHandler routes ApplyUpdateV1 errors encountered during sync-step-2
+// or update dispatch to a caller-supplied handler instead of returning them.
+// When set, ApplySyncMessage swallows the apply error after invoking the
+// handler and returns (nil, nil), letting a transport read loop continue
+// processing subsequent messages from the same peer.
+//
+// Without this option, ApplySyncMessage preserves the pre-v1.8.2 behavior of
+// returning the error to the caller. Decoding errors (truncated headers,
+// unknown message types) are always returned regardless of this option —
+// only ApplyUpdateV1 errors on a well-framed payload are routed to the handler.
+//
+// Matches y-protocols `readSyncMessage(..., errorHandler)` (sync.js).
+func WithErrorHandler(fn func(error)) ApplySyncMessageOption {
+	return func(o *applySyncOpts) { o.errorHandler = fn }
+}
+
 // ApplySyncMessage decodes a sync message and applies it to doc.
 // It handles all three message types:
 //   - step-1: returns a step-2 reply that should be sent back to the sender
@@ -116,7 +141,14 @@ func EncodeUpdate(update []byte) []byte {
 //
 // The origin value is passed through to doc.ApplyUpdate and can be used
 // by observers to identify the source of an update (e.g. a connection ID).
-func ApplySyncMessage(doc *crdt.Doc, msg []byte, origin any) (reply []byte, err error) {
+//
+// Pass WithErrorHandler to keep a sync loop alive across malformed updates.
+func ApplySyncMessage(doc *crdt.Doc, msg []byte, origin any, opts ...ApplySyncMessageOption) (reply []byte, err error) {
+	var so applySyncOpts
+	for _, opt := range opts {
+		opt(&so)
+	}
+
 	dec := encoding.NewDecoder(msg)
 
 	msgType, err := dec.ReadVarUint()
@@ -135,6 +167,10 @@ func ApplySyncMessage(doc *crdt.Doc, msg []byte, origin any) (reply []byte, err 
 			return nil, ErrUnexpectedEOF
 		}
 		if err := crdt.ApplyUpdateV1(doc, updateBytes, origin); err != nil {
+			if so.errorHandler != nil {
+				so.errorHandler(err)
+				return nil, nil
+			}
 			return nil, err
 		}
 		return nil, nil

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -290,3 +290,79 @@ func TestUnit_ApplySyncMessage_WithErrorHandler_SuccessUnaffected(t *testing.T) 
 	require.NoError(t, caught, "handler must not fire on a successful apply")
 	assert.Equal(t, "hello", docB.GetText("t").ToString())
 }
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_LoopContinuesAfterFailure(t *testing.T) {
+	// Simulate a transport read loop: good message → bad message → good message.
+	// Without WithErrorHandler the bad message would terminate the loop and
+	// the final message would never apply. With it, we expect:
+	//   - handler fires exactly once (for the bad message)
+	//   - both good messages apply
+	//   - docB's final state reflects both good updates
+	docA := newDoc(1, "hello")
+	txtA := docA.GetText("t") // capture outside Transact to avoid the well-known
+	// GetText-inside-Transact deadlock (see CONTRIBUTING.md / memory file).
+	msg1 := sync.EncodeUpdate(crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	// Mutate docA, then encode the incremental diff for msg3.
+	docA.Transact(func(txn *crdt.Transaction) {
+		txtA.Insert(txn, 5, " world", nil)
+	})
+	// docB hasn't seen anything yet; encode against an empty state vector so
+	// msg3 carries the full doc. Idempotent re-apply on docB is fine after msg1.
+	msg3 := sync.EncodeUpdate(crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	docB := newDoc(2, "")
+	var errs []error
+	handler := func(e error) { errs = append(errs, e) }
+
+	for i, msg := range [][]byte{msg1, malformedStep2(), msg3} {
+		_, err := sync.ApplySyncMessage(docB, msg, nil, sync.WithErrorHandler(handler))
+		require.NoError(t, err, "message %d: dispatch must not return an error when handler is set", i)
+	}
+
+	require.Len(t, errs, 1, "handler must fire exactly once (only the bad message)")
+	require.ErrorIs(t, errs[0], crdt.ErrInvalidUpdate)
+	assert.Equal(t, "hello world", docB.GetText("t").ToString(),
+		"both good messages must apply despite the bad one in the middle")
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_MultipleErrorsAllReported(t *testing.T) {
+	// Each bad message should fire the handler — not just the first one.
+	docB := newDoc(2, "")
+	var errs []error
+	handler := func(e error) { errs = append(errs, e) }
+
+	for i := 0; i < 3; i++ {
+		_, err := sync.ApplySyncMessage(docB, malformedStep2(), nil, sync.WithErrorHandler(handler))
+		require.NoError(t, err, "iteration %d: dispatch must not return error with handler set", i)
+	}
+
+	assert.Len(t, errs, 3, "handler must fire once per bad message")
+	for _, e := range errs {
+		assert.ErrorIs(t, e, crdt.ErrInvalidUpdate)
+	}
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_HeaderErrorsStillReturned(t *testing.T) {
+	// Header-level decode errors (truncated frame, unknown type) must be
+	// returned to the caller regardless of WithErrorHandler. The handler is
+	// only for ApplyUpdateV1 errors on a well-framed payload. These are
+	// signals that the transport itself is broken — the caller should
+	// disconnect, not log-and-continue.
+	docB := newDoc(2, "")
+	var caught error
+	handler := func(e error) { caught = e }
+
+	// Unknown message type.
+	_, err := sync.ApplySyncMessage(docB, []byte{99}, nil, sync.WithErrorHandler(handler))
+	require.ErrorIs(t, err, sync.ErrUnknownMessage,
+		"header-level errors must still be returned with handler set")
+	require.NoError(t, caught, "handler must NOT fire on header-level decode errors")
+
+	// Truncated frame: type byte only, no varBytes wrapper.
+	caught = nil
+	_, err = sync.ApplySyncMessage(docB, []byte{byte(sync.MsgSyncStep2)}, nil,
+		sync.WithErrorHandler(handler))
+	require.ErrorIs(t, err, sync.ErrUnexpectedEOF)
+	require.NoError(t, caught, "handler must NOT fire on truncated frames")
+}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -287,6 +287,6 @@ func TestUnit_ApplySyncMessage_WithErrorHandler_SuccessUnaffected(t *testing.T) 
 		sync.WithErrorHandler(func(e error) { caught = e }))
 	require.NoError(t, err)
 	assert.Nil(t, reply, "MsgUpdate produces no reply")
-	assert.NoError(t, caught, "handler must not fire on a successful apply")
+	require.NoError(t, caught, "handler must not fire on a successful apply")
 	assert.Equal(t, "hello", docB.GetText("t").ToString())
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -343,6 +343,54 @@ func TestUnit_ApplySyncMessage_WithErrorHandler_MultipleErrorsAllReported(t *tes
 	}
 }
 
+func TestUnit_ApplySyncMessage_WithErrorHandler_PanicPropagates(t *testing.T) {
+	// Contract: a panic in the user-supplied handler propagates up through
+	// ApplySyncMessage rather than being silently swallowed. The handler is
+	// caller code — we don't recover and hide their bugs. If the loop wants
+	// resilience against handler panics, the *caller* should defer/recover
+	// around the dispatcher.
+	docB := newDoc(2, "")
+	handler := func(e error) { panic("boom") }
+
+	assert.Panics(t, func() {
+		_, _ = sync.ApplySyncMessage(docB, malformedStep2(), nil, sync.WithErrorHandler(handler))
+	}, "handler panic must propagate, not be silently swallowed")
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_NilHandler_BehavesLikeNoOption(t *testing.T) {
+	// Defensive: WithErrorHandler(nil) should be equivalent to not passing
+	// the option at all — error returned to caller, no panic from a nil
+	// function call. Guards against future regressions where someone
+	// forgets the nil check.
+	docB := newDoc(2, "")
+	_, err := sync.ApplySyncMessage(docB, malformedStep2(), nil, sync.WithErrorHandler(nil))
+	require.Error(t, err, "nil handler should fall through to default error-return behavior")
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_Step1ErrorBypassesHandler(t *testing.T) {
+	// Step1 dispatch (case MsgSyncStep1 → EncodeSyncStep2) can fail when
+	// the state-vector payload is corrupt. Like header-level errors, those
+	// failures are returned to the caller regardless of the handler — they
+	// represent transport-level corruption, not an apply failure on
+	// otherwise-valid update bytes. The handler must NOT fire.
+	docB := newDoc(2, "")
+	var caught error
+	handler := func(e error) { caught = e }
+
+	// Malformed Step1: type=0, varBytes length=2, payload's leading VarUint
+	// claims 255 clients in just 2 bytes — DecodeStateVectorV1 rejects with
+	// ErrInvalidUpdate.
+	malformedStep1 := []byte{
+		byte(sync.MsgSyncStep1), // 0x00
+		0x02,                    // varBytes length = 2
+		0xff, 0x01,              // VarUint = 255; no client/clock pairs follow
+	}
+
+	_, err := sync.ApplySyncMessage(docB, malformedStep1, nil, sync.WithErrorHandler(handler))
+	require.Error(t, err, "Step1 dispatch errors must be returned even with handler set")
+	require.NoError(t, caught, "handler must NOT fire on Step1 dispatch errors")
+}
+
 func TestUnit_ApplySyncMessage_WithErrorHandler_HeaderErrorsStillReturned(t *testing.T) {
 	// Header-level decode errors (truncated frame, unknown type) must be
 	// returned to the caller regardless of WithErrorHandler. The handler is

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -238,3 +238,55 @@ func FuzzApplySyncMessage(f *testing.F) {
 		_, _ = sync.ApplySyncMessage(target, data, nil)
 	})
 }
+
+// ── #79: ApplySyncMessage error-handler option ────────────────────────────────
+
+// malformedStep2 builds a syntactically valid sync-step-2 wrapper around an
+// intentionally corrupt update payload. ReadVarUint parses the type byte and
+// ReadVarBytes pulls out the payload — but ApplyUpdateV1 on the payload
+// returns ErrInvalidUpdate because the embedded varuint is truncated.
+func malformedStep2() []byte {
+	return []byte{
+		byte(sync.MsgSyncStep2), // 0x01 — message type
+		0x01,                    // varuint(1) — payload length
+		0xff,                    // payload byte: lone continuation, no follower → truncated VarUint
+	}
+}
+
+func TestUnit_ApplySyncMessage_NoHandler_ReturnsError(t *testing.T) {
+	// Without an error handler the call still returns the underlying error,
+	// preserving existing behavior (back-compat).
+	doc := crdt.New()
+	_, err := sync.ApplySyncMessage(doc, malformedStep2(), nil)
+	require.Error(t, err, "without handler, malformed update must surface as a returned error")
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_KeepsLoopAlive(t *testing.T) {
+	// With WithErrorHandler the call swallows the apply error, invokes the
+	// handler, and returns (nil, nil) so a sync read loop can continue.
+	doc := crdt.New()
+	var caught error
+	reply, err := sync.ApplySyncMessage(doc, malformedStep2(), nil,
+		sync.WithErrorHandler(func(e error) { caught = e }))
+	require.NoError(t, err, "with handler, apply error is reported via handler not returned")
+	assert.Nil(t, reply, "no reply for an error path")
+	require.Error(t, caught, "handler must be invoked with the underlying error")
+	assert.ErrorIs(t, caught, crdt.ErrInvalidUpdate)
+}
+
+func TestUnit_ApplySyncMessage_WithErrorHandler_SuccessUnaffected(t *testing.T) {
+	// The handler is only invoked on apply errors. A well-formed update
+	// applies normally and the handler stays untouched.
+	docA := newDoc(1, "hello")
+	raw := crdt.EncodeStateAsUpdateV1(docA, nil)
+	msg := sync.EncodeUpdate(raw)
+
+	docB := newDoc(2, "")
+	var caught error
+	reply, err := sync.ApplySyncMessage(docB, msg, nil,
+		sync.WithErrorHandler(func(e error) { caught = e }))
+	require.NoError(t, err)
+	assert.Nil(t, reply, "MsgUpdate produces no reply")
+	assert.NoError(t, caught, "handler must not fire on a successful apply")
+	assert.Equal(t, "hello", docB.GetText("t").ToString())
+}


### PR DESCRIPTION
## Summary

First in the [`gaps` label](https://github.com/reearth/ygo/issues?q=is%3Aopen+label%3Agaps) batch from the cross-reference audit against Yjs JS / yrs (see #79 for context).

`ApplySyncMessage` previously propagated `ApplyUpdateV1` errors out of the function, terminating any caller that uses it as the dispatcher in a read loop. y-protocols' `readSyncMessage` (sync.js) wraps `applyUpdate` in try/catch and routes failures to an optional `errorHandler` callback while still returning the message type for the caller to continue.

This PR adds a variadic-option pattern:

```go
sync.ApplySyncMessage(doc, msg, origin,
    sync.WithErrorHandler(func(err error) { log.Warn(err) }))
```

When set, `ApplyUpdateV1` errors are routed to the handler and the call returns `(nil, nil)`. Without the option, the existing behavior is preserved — the error is returned to the caller.

Decoding errors on the message header itself (truncated frames, unknown message types) are always returned regardless of the option. Only `ApplyUpdateV1` errors on a well-framed payload are eligible for the handler.

Closes #79

## Test plan

- [x] 3 new tests in `sync/sync_test.go` covering no-handler back-compat, handler-swallows-error, and handler-not-invoked-on-success
- [x] All previously passing sync tests still pass (back-compat preserved)
- [x] Full `go test ./...` green
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
