### PR TITLE
fix(awareness): protocol correctness vs y-protocols / yrs (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] — 2026-05-20
+
+### Added
+
+- **`Awareness.Heartbeat()`** (#73 vector C5): re-emits the local client's current state with an incremented clock so peers learn we're still alive even when the state hasn't changed. Designed to pair with `StartAutoExpiry` on the peer side — they expire clients that go quiet; we keep ourselves visible by heartbeating periodically. Observers are not fired (state itself didn't change, only the clock advanced). Matches Yjs JS's constructor interval which re-emits local state every `outdatedTimeout/2`.
+
+### Fixed
+
+- **Awareness: remote peers can no longer wipe local state (#73 vector C1, HIGH)**. A remote `(self.clientID, ?, "null")` entry previously cleared the local awareness state — meaning any peer could deauthenticate any other peer by broadcasting a null for their clientID. `ApplyUpdate` now detects this case, bumps the local clock past the incoming, and re-emits the current local state so peers learn the new clock. Matches yrs `apply_update_internal` (`awareness.rs:414-419`) and Yjs JS `applyAwarenessUpdate`.
+
+- **Awareness: equal-clock null removals are honored for active clients (#73 vector C2, HIGH)**. The strict `e.clock <= current.Clock` gate dropped legitimate "client X has gone offline at the clock you already know" messages, leaving phantom presence indicators. The gate now uses `e.clock < current.Clock` for the stale-drop path, and additionally accepts `e.clock == current.Clock` when the entry is null AND the client is currently active. Strictly-older clocks and equal-clock non-null updates are still dropped (no new information).
+
+- **Awareness: local clock now reconciles with remote echoes (#73 vector C3, MEDIUM)**. `SetLocalState` previously did a plain `a.clock++`, which could regress if a remote peer had echoed our clientID at a higher clock (e.g. another browser tab also acting as this clientID). It now does `a.clock = max(a.clock, states[a.clientID].Clock) + 1` so the emitted clock is always greater than anything peers have already observed for us.
+
+- **Awareness: `RemoveExpired` exempts the local client (#73 vector C4, MEDIUM)**. Previously the sweep walked every entry in `meta`, including our own — meaning the local client could self-expire in a quiet room. Now skipped. Matches y-protocols / yrs: the local peer can't tell whether *it* has gone silent, so it's responsible for refreshing presence via `SetLocalState` or `Heartbeat`.
+
 ## [1.10.0] — 2026-05-19
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,29 +1,21 @@
 ## What's new
 
-Second in the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) series from the cross-reference audit against Yjs JS and yrs. Closes the lib0 `Any` tagged-union parity gaps in `encoding/`.
+Third in the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) series from the cross-reference audit against Yjs JS and yrs. Closes the awareness self-state protection and clock-semantics gaps in the `awareness/` package.
 
-- **Integer dispatch now matches lib0 by magnitude** (#77). ygo previously emitted tag 125 (int + VarInt) for any `int`/`int64` up to 2^55-1. lib0 only uses tag 125 for int32-range values; larger integers go to tag 123 (float64) or — in ygo's case, where Go's int64 has more range than JS Number — tag 122 (BigInt) to preserve precision. ygo now matches:
+- **Remote peers can no longer wipe local state** (#73 vector C1, HIGH). A `(self.clientID, ?, "null")` entry from a remote peer previously cleared the local awareness state — any peer could effectively deauthenticate any other by broadcasting a null for their clientID. `ApplyUpdate` now detects this case, bumps the local clock past the incoming value, and re-emits the current local state so peers learn the new clock.
 
-  | Range | Tag |
-  |-------|-----|
-  | `[-2^31, 2^31)` | 125 (VarInt) |
-  | safe-int range (outside int32) | 123 (float64) |
-  | beyond float64 safe-int | 122 (BigInt) |
+- **Equal-clock null removals are honored for active clients** (#73 vector C2, HIGH). The strict `<= current.Clock` gate dropped the canonical "I'm going offline at the clock you already know" disconnect message, leaving phantom presence indicators. The gate now uses `<` for stale-drop and additionally accepts equal-clock null when the client is active. Stale and equal-clock-non-null entries are still dropped (no new info).
 
-  Yjs JS readers see byte-for-byte parity with their own writer for the first two ranges and receive `bigint` for the third (which is the natural cross-impl representation when an integer is too large for `Number`).
+- **Local clock follows remote echoes** (#73 vector C3, MEDIUM). `SetLocalState` now reconciles `a.clock` against `states[a.clientID].Clock` before incrementing, so a remote echo of our clientID (e.g. another tab) doesn't cause subsequent updates to emit a clock peers have already seen.
 
-  Compatibility implication for Go callers: an `int64(2^35)` now round-trips as `float64`, and `int64(2^55)` (which previously panicked in `WriteVarInt`) now round-trips as `encoding.BigInt`. See CHANGELOG for the full table.
+- **`RemoveExpired` no longer evicts the local client** (#73 vector C4, MEDIUM). The expiry sweep now skips our own clientID — peers can't reliably tell whether we've gone silent, so it's our job to refresh presence via `SetLocalState` or the new `Heartbeat`.
 
-- **`WriteAny(float64)` narrows to float32 when lossless** (#77). Values like `1.5`, `-0`, and small integer-valued floats now emit tag 124 (4 bytes on the wire) instead of always tag 123 (8 bytes). Matches lib0's `isFloat32` dispatch — halves the wire size for these values.
-
-- **`ReadVarString` rejects invalid UTF-8** (#77). Returns the new `encoding.ErrInvalidUTF8` rather than silently producing a corrupt Go string. Matches lib0's `TextDecoder('utf-8', { fatal: true })`. There's a ~4ns per-call cost from the UTF-8 scan; correctness takes priority — silent corruption surfaces as untraceable bugs downstream.
-
-- **`WriteAny` accepts the rest of Go's numeric tower** (#77). `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `int8`, `int16`, `int32` previously panicked; they're now promoted to `int64` and dispatched normally. `uint64` values exceeding `math.MaxInt64` fall back to tag 123 (float64) with documented precision loss, matching lib0's behavior for very-large `Number`s.
+- **New `Awareness.Heartbeat()` method** (#73 vector C5). Re-emits the local state with an incremented clock so peers see us as still alive even when state hasn't changed. Pairs with their `StartAutoExpiry` to keep us visible in a quiet room. No observers fired (state didn't change, only the clock).
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.10.0
+go get github.com/reearth/ygo@v1.11.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -160,6 +160,15 @@ func (a *Awareness) ClientID() uint64 {
 // Passing nil removes the local client from the awareness set.
 func (a *Awareness) SetLocalState(state map[string]any) {
 	a.mu.Lock()
+	// Reconcile a.clock with any remote echo of our clientID that bumped
+	// states[a.clientID].Clock past a.clock — e.g. another tab also acting
+	// as this clientID. Without this, a.clock++ could produce a value lower
+	// than what peers have already seen, and the update would be ignored
+	// downstream (#73 vector C3). yrs derives the local clock directly from
+	// meta.get(clientID).clock + 1; we do the equivalent via a max() step.
+	if cs, ok := a.states[a.clientID]; ok && cs.Clock > a.clock {
+		a.clock = cs.Clock
+	}
 	// Saturate at MaxUint64 rather than wrapping: a wrap-around would make new
 	// states appear older than existing ones, breaking monotonicity.
 	if a.clock < math.MaxUint64 {
@@ -195,6 +204,38 @@ func (a *Awareness) SetLocalState(state map[string]any) {
 		evt := ChangeEvent{Added: added, Updated: updated, Removed: removed}
 		fireObservers(obs, evt)
 	}
+}
+
+// Heartbeat re-emits the local client's current state at an incremented
+// clock so peers learn that we're still alive even when the state hasn't
+// changed. No-op when no local state is set or when the local client has
+// been removed (state == nil).
+//
+// Typical use is to schedule periodic calls alongside StartAutoExpiry on
+// peers — they expire clients that go quiet, this advertises that we
+// haven't. Matches Yjs JS's constructor interval which re-emits local
+// state every outdatedTimeout/2.
+//
+// Observers are NOT fired — the state itself didn't change, only the
+// clock advanced. Peers will pick up the new clock via EncodeUpdate.
+//
+// Added in v1.11.0 (#73 vector C5).
+func (a *Awareness) Heartbeat() {
+	a.mu.Lock()
+	cs, ok := a.states[a.clientID]
+	if !ok || cs.State == nil {
+		a.mu.Unlock()
+		return
+	}
+	if a.clock < cs.Clock {
+		a.clock = cs.Clock
+	}
+	if a.clock < math.MaxUint64 {
+		a.clock++
+	}
+	a.states[a.clientID] = ClientState{Clock: a.clock, State: cs.State}
+	a.meta[a.clientID] = time.Now()
+	a.mu.Unlock()
 }
 
 // SetLocalStateContext is the context-aware variant of SetLocalState.
@@ -363,8 +404,40 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 
 	for _, e := range entries {
 		current, exists := a.states[e.clientID]
-		// Only apply if incoming clock is strictly greater.
-		if exists && e.clock <= current.Clock {
+		isNullEntry := e.jsonStr == "null" || e.jsonStr == ""
+
+		// y-protocols clock gate (#73 vector C2):
+		//   - strictly-older clock → drop
+		//   - equal clock + null + currently-active → accept (offline signal)
+		//   - equal clock + non-null OR equal clock + already-removed → drop (no new info)
+		//   - strictly-newer clock → accept
+		if exists {
+			if e.clock < current.Clock {
+				continue
+			}
+			if e.clock == current.Clock {
+				validRemoval := isNullEntry && current.State != nil
+				if !validRemoval {
+					continue
+				}
+			}
+		}
+
+		// Self-state protection (#73 vector C1): if a remote sends a null
+		// update for OUR clientID, don't honor it — bump our local clock past
+		// the incoming and re-emit local state so peers learn the new value.
+		// Matches Yjs JS / yrs which both detect this and override the remote.
+		if e.clientID == a.clientID && isNullEntry {
+			if e.clock >= a.clock {
+				a.clock = e.clock + 1
+			}
+			// If we currently have an active local state, re-emit it at the
+			// bumped clock. Wire-bytes accounting is left alone — local state
+			// is excluded from the wireBytes cap (see SetMaxBytes godoc).
+			if exists && current.State != nil {
+				a.states[a.clientID] = ClientState{Clock: a.clock, State: current.State}
+				updated = append(updated, a.clientID)
+			}
 			continue
 		}
 
@@ -372,7 +445,10 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 
 		// Decode JSON state. Reject deeply nested payloads before unmarshalling
 		// to prevent quadratic parse cost from crafted inputs like [[[[...]]]].
-		isNull := e.jsonStr == "null" || e.jsonStr == ""
+		// isNull starts from isNullEntry (computed at the gate above) and can
+		// be further set true by the depth check, unmarshal failure, or one
+		// of the resource caps below.
+		isNull := isNullEntry
 		var state map[string]any
 		if !isNull {
 			if !checkJSONDepth(e.jsonStr) {
@@ -510,11 +586,19 @@ func (a *Awareness) Destroy() {
 
 // RemoveExpired removes clients whose last update is older than timeout.
 // Only active clients (with non-nil State) are tracked in meta and can expire.
+//
+// The local client is exempt: peers can't reliably tell whether we've gone
+// silent, so it's our job to broadcast presence via SetLocalState or
+// Heartbeat. Self-expiry would create false offline signals on quiet rooms.
+// Matches y-protocols / yrs behavior (#73 vector C4).
 func (a *Awareness) RemoveExpired(timeout time.Duration) {
 	now := time.Now()
 	a.mu.Lock()
 	var removed []uint64
 	for id, t := range a.meta {
+		if id == a.clientID {
+			continue // never self-expire
+		}
 		if now.Sub(t) >= timeout {
 			// Mark as removed (keep clock for future clock comparisons).
 			if cs, ok := a.states[id]; ok {

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -741,3 +741,152 @@ func TestUnit_Awareness_C5_Heartbeat_NoOpWhenNoLocalState(t *testing.T) {
 	assert.NotContains(t, a.GetStates(), uint64(1),
 		"Heartbeat without local state must not create one")
 }
+
+// --- #73 edge-case coverage ---
+
+// C1 cont.: the contract isn't just "keep local state" — it's also "advertise
+// the new clock to peers so they learn the value." Verify that the next
+// EncodeUpdate after a wipe attempt carries the bumped clock, by applying it
+// to a fresh peer and checking what they see.
+func TestUnit_Awareness_C1_RemoteWipe_FollowedByEncode_AdvertisesNewClock(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"name": "alice"})
+
+	// Adversarial null update at a high clock.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 1, 999, "null"), nil))
+	bumpedClock := a.GetStates()[1].Clock
+	require.Greater(t, bumpedClock, uint64(999))
+
+	// Now encode and apply to a fresh peer. The peer must see our clientID
+	// at the bumped clock, not at the pre-attack one — otherwise peers that
+	// joined after the attack would never learn the new value.
+	peer := awareness.New(2)
+	require.NoError(t, peer.ApplyUpdate(a.EncodeUpdate([]uint64{1}), nil))
+	require.Contains(t, peer.GetStates(), uint64(1))
+	assert.Equal(t, bumpedClock, peer.GetStates()[1].Clock,
+		"EncodeUpdate after wipe attempt must carry the bumped clock so peers learn it")
+	assert.Equal(t, "alice", peer.GetStates()[1].State["name"])
+}
+
+// C1 cont.: a misbehaving peer might retry the null attack. Local state must
+// survive repeated attempts, and the local clock must monotonically advance
+// past each one so peers always see the latest value.
+func TestUnit_Awareness_C1_RemoteWipe_RepeatAttempts_AlwaysSafe(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"name": "alice"})
+
+	var lastClock uint64
+	for i, clk := range []uint64{100, 200, 300} {
+		require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 1, clk, "null"), nil))
+		got := a.GetStates()[1].Clock
+		assert.Greater(t, got, clk, "iter %d: clock must be bumped past %d", i, clk)
+		assert.Greater(t, got, lastClock, "iter %d: clock must strictly advance", i)
+		require.Contains(t, a.GetStates(), uint64(1), "iter %d: local must survive", i)
+		assert.Equal(t, "alice", a.GetStates()[1].State["name"])
+		lastClock = got
+	}
+}
+
+// C2 cont.: equal-clock null when the client is ALREADY removed (state==nil
+// at the current clock) — must be dropped. There's no active state to mark
+// offline, so the entry conveys no new information.
+func TestUnit_Awareness_C2_EqualClockNull_OnAlreadyRemovedClient_Dropped(t *testing.T) {
+	a := awareness.New(1)
+	// Set up: client 99 active at clock 5.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"x":1}`), nil))
+	// Remove at the same clock 5 (the C2-supported case).
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, "null"), nil))
+	require.NotContains(t, a.GetStates(), uint64(99))
+
+	// Now another equal-clock null — already-removed client, no observer should fire.
+	var fireCount int
+	a.OnChange(func(awareness.ChangeEvent) { fireCount++ })
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, "null"), nil))
+	assert.Equal(t, 0, fireCount,
+		"equal-clock null on already-removed client conveys no new info — observers must not fire")
+}
+
+// C3 cont.: a chain of remote echoes at increasing clocks must each correctly
+// raise the local baseline. One echo working is one thing; verifying that the
+// reconciliation is monotonic across a sequence catches bugs where the local
+// clock latches to the first echo and ignores subsequent ones.
+func TestUnit_Awareness_C3_MultipleRemoteEchoes_AllAdvanceLocalClock(t *testing.T) {
+	a := awareness.New(1)
+	for _, echoClock := range []uint64{50, 150, 300} {
+		require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 1, echoClock, `{"v":1}`), nil))
+		// Each SetLocalState must emit a clock above the just-applied echo.
+		a.SetLocalState(map[string]any{"v": echoClock})
+		assert.Greater(t, a.GetStates()[1].Clock, echoClock,
+			"after echo at %d, SetLocalState must emit > %d", echoClock, echoClock)
+	}
+}
+
+// C5 cont.: Heartbeat must not fire observers — the state itself didn't
+// change, only the clock advanced. Firing would cause downstream UI churn
+// on every heartbeat tick. Yjs JS has the same observer-silent contract.
+func TestUnit_Awareness_C5_Heartbeat_DoesNotFireObservers(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"x": 1})
+
+	var fireCount int
+	a.OnChange(func(awareness.ChangeEvent) { fireCount++ })
+
+	a.Heartbeat()
+	a.Heartbeat()
+	a.Heartbeat()
+
+	assert.Equal(t, 0, fireCount,
+		"Heartbeat must be observer-silent (state unchanged, clock advanced only)")
+}
+
+// C5 cont.: Heartbeat called after SetLocalState(nil) — local state was
+// removed — must be a no-op. Heartbeating a removed client would resurrect
+// it from peers' point of view, which is the opposite of intent.
+func TestUnit_Awareness_C5_Heartbeat_AfterRemoval_NoOp(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"x": 1})
+	clockBeforeRemoval := a.GetStates()[1].Clock
+	a.SetLocalState(nil)
+	require.NotContains(t, a.GetStates(), uint64(1), "removed after nil")
+
+	// Snapshot the underlying record (states map keeps the entry with nil state).
+	preHeartbeat := a.EncodeUpdate([]uint64{1})
+
+	a.Heartbeat()
+
+	// State still removed, EncodeUpdate output unchanged (no clock advance).
+	assert.NotContains(t, a.GetStates(), uint64(1),
+		"Heartbeat must not resurrect a removed client")
+	assert.Equal(t, preHeartbeat, a.EncodeUpdate([]uint64{1}),
+		"Heartbeat on removed client must be a no-op (encoded bytes identical)")
+	_ = clockBeforeRemoval // referenced for clarity; not directly asserted
+}
+
+// C5 cont.: clocks must remain strictly monotonic across mixed Heartbeat and
+// SetLocalState calls. This catches off-by-one bugs in the
+// max(a.clock, cs.Clock) reconciliation logic that powers both methods.
+func TestUnit_Awareness_C5_Heartbeat_PreservesMonotonicity_AcrossMixedUpdates(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"v": 1})
+
+	var clocks []uint64
+	record := func() { clocks = append(clocks, a.GetStates()[1].Clock) }
+	record()
+
+	a.Heartbeat()
+	record()
+	a.SetLocalState(map[string]any{"v": 2})
+	record()
+	a.Heartbeat()
+	record()
+	a.Heartbeat()
+	record()
+	a.SetLocalState(map[string]any{"v": 3})
+	record()
+
+	for i := 1; i < len(clocks); i++ {
+		assert.Greater(t, clocks[i], clocks[i-1],
+			"clock must strictly advance at step %d (got %d after %d)",
+			i, clocks[i], clocks[i-1])
+	}
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -127,8 +127,11 @@ func TestInteg_TwoPeer_StateExchange(t *testing.T) {
 }
 
 func TestInteg_RemoveExpired_FiresObserver(t *testing.T) {
+	// Local client (5) is never expired by RemoveExpired per #73 vector C4;
+	// to exercise the observer, seed a remote client (99) and let it expire.
 	a := awareness.New(5)
 	a.SetLocalState(map[string]any{"x": 1})
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 1, `{"y":2}`), nil))
 
 	var fired bool
 	var removedIDs []uint64
@@ -139,12 +142,14 @@ func TestInteg_RemoveExpired_FiresObserver(t *testing.T) {
 		}
 	})
 
-	// timeout=0 means everything is expired immediately.
+	// timeout=0: remote 99 expires; local 5 is exempt (C4).
 	a.RemoveExpired(0)
 
-	assert.True(t, fired, "observer should have been called")
-	assert.Contains(t, removedIDs, uint64(5))
-	assert.NotContains(t, a.GetStates(), uint64(5))
+	assert.True(t, fired, "observer should have been called for remote eviction")
+	assert.Contains(t, removedIDs, uint64(99), "remote client must be expired")
+	assert.NotContains(t, removedIDs, uint64(5), "local client must NOT be expired")
+	assert.NotContains(t, a.GetStates(), uint64(99), "remote gone")
+	assert.Contains(t, a.GetStates(), uint64(5), "local stays")
 }
 
 func TestInteg_OnChange_CalledOnApply(t *testing.T) {
@@ -607,4 +612,132 @@ func makeRoughlySized(key string, targetBytes int) string {
 		val[i] = 'a'
 	}
 	return `{"` + key + `":"` + string(val) + `"}`
+}
+
+// ---------------------------------------------------------------------------
+// #73: awareness protocol correctness (y-protocols parity)
+// ---------------------------------------------------------------------------
+
+// C1 (HIGH) — a remote null update targeting our own clientID must NOT wipe
+// our local state. Yjs JS and yrs both detect this and bump the local clock
+// so a re-emit will overrule the remote. ygo previously accepted the wipe.
+func TestUnit_Awareness_C1_RemoteCannotWipeLocalState(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"name": "alice"})
+	initialClock := a.GetStates()[1].Clock
+
+	// Malicious / buggy update: clientID=1 (us), state=null, clock far ahead.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 1, 999, "null"), nil))
+
+	// Local state must remain; local clock must be > 999 so the re-emit wins.
+	require.Contains(t, a.GetStates(), uint64(1), "local state must survive the remote wipe attempt")
+	assert.Equal(t, "alice", a.GetStates()[1].State["name"])
+	assert.Greater(t, a.GetStates()[1].Clock, uint64(999),
+		"local clock must be bumped past the remote attempt so peers learn the new value")
+	assert.Greater(t, a.GetStates()[1].Clock, initialClock,
+		"local clock must monotonically advance")
+}
+
+// C2 (HIGH) — an equal-clock null entry for a currently-active client must
+// be accepted as the canonical "client X went offline at the clock you
+// already know" message. ygo previously dropped it because of the strict
+// `<= current.Clock` check.
+func TestUnit_Awareness_C2_EqualClockNullRemovesActiveClient(t *testing.T) {
+	a := awareness.New(1)
+	// Seed client 99 with an active state at clock 5.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"x":1}`), nil))
+	require.Contains(t, a.GetStates(), uint64(99))
+
+	// Same clock 5, but now null — the offline signal.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, "null"), nil))
+	assert.NotContains(t, a.GetStates(), uint64(99),
+		"equal-clock null must remove an active client (offline signal)")
+}
+
+// C2 cont. — a strictly-less-than-current clock must still be dropped. The
+// fix to accept equal-clock null mustn't accidentally also accept stale ones.
+func TestUnit_Awareness_C2_OlderClockStillRejected(t *testing.T) {
+	a := awareness.New(1)
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"x":1}`), nil))
+	// Older null — must NOT remove.
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 3, "null"), nil))
+	assert.Contains(t, a.GetStates(), uint64(99),
+		"strictly-older null must be dropped, not honored")
+}
+
+// C2 cont. — equal-clock non-null is still a no-op (no new information).
+func TestUnit_Awareness_C2_EqualClockSameStateNoOp(t *testing.T) {
+	a := awareness.New(1)
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"x":1}`), nil))
+	// Same clock 5, non-null — no new info, must not double-fire observer.
+	var fireCount int
+	a.OnChange(func(awareness.ChangeEvent) { fireCount++ })
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"x":2}`), nil))
+	assert.Equal(t, 0, fireCount,
+		"equal-clock non-null update must be dropped (no observer fire)")
+}
+
+// C3 (MEDIUM) — local clock must follow any remote echo of our own
+// clientID. If a peer reports our clientID at a higher clock (e.g. another
+// browser tab is also us), SetLocalState must produce a clock above that,
+// not a stale a.clock++.
+func TestUnit_Awareness_C3_LocalClockFollowsRemoteEcho(t *testing.T) {
+	a := awareness.New(1)
+	// Remote echoes clientID=1 at clock 100 (e.g. another tab).
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 1, 100, `{"name":"alice"}`), nil))
+	require.Equal(t, uint64(100), a.GetStates()[1].Clock)
+
+	// Now SetLocalState — its clock must be > 100, not 1.
+	a.SetLocalState(map[string]any{"name": "alice-v2"})
+	assert.Greater(t, a.GetStates()[1].Clock, uint64(100),
+		"SetLocalState after remote echo must produce a clock above the echo")
+}
+
+// C4 (MEDIUM) — RemoveExpired must skip the local client. Yjs JS and yrs
+// both explicitly exclude self from the expiry sweep so the local peer
+// can't self-remove in a quiet room.
+func TestUnit_Awareness_C4_RemoveExpiredSkipsLocal(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"x": 1})
+
+	// Aggressive expiry: 0 timeout = everything expires immediately.
+	a.RemoveExpired(0)
+
+	assert.Contains(t, a.GetStates(), uint64(1),
+		"local client must never be expired by RemoveExpired")
+}
+
+// C4 cont. — remote clients must STILL be evicted normally.
+func TestUnit_Awareness_C4_RemoveExpiredStillEvictsRemote(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"x": 1})
+	require.NoError(t, a.ApplyUpdate(buildAwarenessPayload(t, 99, 5, `{"y":2}`), nil))
+
+	a.RemoveExpired(0)
+
+	assert.Contains(t, a.GetStates(), uint64(1), "local stays")
+	assert.NotContains(t, a.GetStates(), uint64(99), "remote evicted")
+}
+
+// C5 (new API) — Heartbeat re-emits the local state with an incremented
+// clock so peers learn that we're still alive even when our state hasn't
+// changed. No-op when no local state is set.
+func TestUnit_Awareness_C5_Heartbeat_BumpsClock(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"x": 1})
+	before := a.GetStates()[1].Clock
+
+	a.Heartbeat()
+	after := a.GetStates()[1].Clock
+	assert.Greater(t, after, before, "Heartbeat must bump the local clock")
+	assert.Equal(t, map[string]any{"x": 1}, a.GetStates()[1].State,
+		"Heartbeat must preserve local state")
+}
+
+func TestUnit_Awareness_C5_Heartbeat_NoOpWhenNoLocalState(t *testing.T) {
+	a := awareness.New(1)
+	// No SetLocalState before Heartbeat.
+	assert.NotPanics(t, func() { a.Heartbeat() })
+	assert.NotContains(t, a.GetStates(), uint64(1),
+		"Heartbeat without local state must not create one")
 }


### PR DESCRIPTION
## Summary

Third in the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) series. Closes the awareness self-state protection and clock-semantics gaps in the `awareness/` package.

Five fixes:

- **C1 (HIGH) — Self-state protection.** A remote `(self.clientID, ?, "null")` entry previously wiped the local awareness state. Any peer could effectively deauthenticate any other. `ApplyUpdate` now detects this case, bumps the local clock past the incoming, and re-emits local state.
- **C2 (HIGH) — Equal-clock null removal.** The strict `<= current.Clock` gate dropped the canonical "client X has gone offline at the clock you already know" disconnect message. The gate now uses `<` for stale-drop and additionally accepts equal-clock null when the client is active.
- **C3 (MEDIUM) — Local clock reconciliation.** `SetLocalState` now reconciles `a.clock` against `states[a.clientID].Clock` before incrementing, so remote echoes (e.g. another tab) can't cause subsequent updates to emit a clock peers have already seen.
- **C4 (MEDIUM) — `RemoveExpired` exempts local.** The expiry sweep now skips our own clientID — peers can't tell whether we've gone silent, so it's our job to broadcast presence.
- **C5 (new API) — `Awareness.Heartbeat()`.** Re-emits local state with an incremented clock so peers learn we're still alive even when state hasn't changed. Pairs with their `StartAutoExpiry`.

Target release: **v1.11.0** (minor — `Heartbeat()` is new exported API). CHANGELOG and RELEASE_NOTES are updated in this PR so the tag can be pushed immediately on merge.

Closes #73

## Test plan

- [x] 8 new `TestUnit_Awareness_C*` tests covering each fix + boundary cases
- [x] Existing `TestInteg_RemoveExpired_FiresObserver` updated to test correct behavior (uses a remote peer for the eviction target)
- [x] Full `go test ./...` green
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
