### PR TITLE
fix(crdt): ToJSON nested unwrap + YTextEvent embed delta + README refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] — 2026-05-25
+
+### Fixed
+
+- **`YArray.ToSlice` / `YArray.ToJSON` / `YMap.Entries` / `YMap.ToJSON` recursively unwrap nested shared types** (#75, HIGH). Pre-fix, items wrapping a nested `*YArray`, `*YMap`, `*YText`, or `*YXml*` via `ContentType` were silently dropped from the output — `json.Marshal` of a YArray containing a nested YMap produced an array with the nested map missing entirely. Now: nested YArray → `[]any`, nested YMap → `map[string]any`, nested YText → `string`, nested YXml* → XML string serialisation. Arbitrarily-deep nesting (array → map → array → …) recurses cleanly. Matches Yjs JS's `toJSON` convention.
+
+- **`YTextEvent.Delta` emits insert/delete/retain ops for `ContentEmbed` and `ContentType` items** (#74 vector D3, MEDIUM). Pre-fix, `computeDelta` only handled `ContentString` and `ContentFormat`, so observers received delta events that silently omitted embeds (images, formulas, custom inline objects). Now: embed inserts surface as `Delta{Op: Insert, Insert: embedValue}`, embed deletes as `Delta{Op: Delete, Delete: 1}`, and retains across embeds advance by 1 (matching Yjs's UTF-16 length convention).
+
+### Internal refactor
+
+- Factored `toSliceLocked` / `entriesLocked` / `toStringLocked` helpers in YArray / YMap / YText so the recursive `toJSONValue` (used by #75) can traverse nested types from within a held doc lock without re-entering. No public API change.
+
+### Documentation
+
+- **README refresh.** Bumped the version reference from v1.7.0 to v1.14.0 (five months stale). Extended the post-v1.0 hardening section through v1.14.0: security hardening (v1.8.x), lib0 wire-format parity (v1.8.0/v1.10.0), cross-reference audit (v1.9.0–v1.14.0), sync read-loop resilience (v1.9.0), awareness heartbeat (v1.11.0). Added a callout for the `gaps` label tracking the audit work.
+
 ## [1.13.0] — 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - WebSocket and HTTP transport bindings (the core is transport-agnostic)
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.7.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.14.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 
@@ -47,6 +47,11 @@ Post-v1.0 hardening:
 - **Semaphore-backed hard caps** (v1.5.0). `MaxConnections` and `MaxPeersPerRoom` are now hard guarantees, not optimistic atomic counters with race windows.
 - **`crypto/rand` ClientID** (v1.5.0). Predictable IDs in multi-tenant deployments are a footgun; the default `ClientID` is now cryptographically random. `crdt.NewClientID()` is exposed for callers who want to generate IDs externally.
 - **Context-aware persistence** (v1.7.0). Adapters can opt into `PersistenceAdapterContext` to receive a context cancelled when `Server.Shutdown` begins, letting them abort in-flight DB calls instead of blocking shutdown.
+- **Security hardening** (v1.8.0–v1.8.1). Pending-items queue cap (`Server.MaxPendingItems`), WebSocket handshake read deadline (`Server.HandshakeTimeout`), CSWSH documentation for `AllowedOrigins`, and a per-room awareness state cap (`Server.MaxAwarenessBytesPerRoom` plus `Awareness.SetMaxBytes`).
+- **lib0 wire-format parity** (v1.8.0, v1.10.0). Float byte-order fixed to big-endian (contributed by @zombiek731), lib0 `Any` tag 122 (BigInt) support, integer dispatch by magnitude matching lib0, lossless float64→float32 narrowing, strict UTF-8 in `ReadVarString` (`ErrInvalidUTF8`), and acceptance of Go's full numeric tower in `WriteAny`.
+- **Cross-reference audit** (v1.9.0–v1.14.0). A systematic comparison of ygo against Yjs JS and yrs reference implementations surfaced ten correctness gaps, tracked under the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps). Notable fixes: YATA `OriginRight` boundary (#65, #68), awareness self-state protection (#73), `Item.delete` cascade into nested types + `DeleteSet` partial-overlap split (#72), YText format-marker correctness (#71: bleed, accumulation, gap cleanup, current-attribute inheritance), `YText.InsertEmbed` (#76), and `YArray/YMap.ToJSON` recursive unwrap of nested types (#75). See [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) for the full list.
+- **Sync read-loop resilience** (v1.9.0). `sync.WithErrorHandler` option lets `ApplySyncMessage` route a single malformed update to a caller-supplied handler rather than tearing down the connection.
+- **Awareness heartbeat** (v1.11.0). `Awareness.Heartbeat()` re-emits local state at an incremented clock so peers learn we're still alive without the local state needing to change. Pairs with `StartAutoExpiry` on the peer side.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 
@@ -448,7 +453,7 @@ document has started accepting operations will corrupt the item store.
 
 ## What's changed since v1.0
 
-Eleven minor and patch releases between v1.1.0 and v1.7.0, focused on hardening: panic safety, out-of-order convergence, WebSocket production hooks, observability, error-returning variants, and an optional context-aware persistence extension. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the design narrative.
+Eighteen minor and patch releases between v1.1.0 and v1.14.0. The early arc (v1.1.x–v1.7.x) focused on production hardening: panic safety, out-of-order convergence, WebSocket hooks, observability, error-returning variants, context-aware persistence. The recent arc (v1.8.x–v1.14.x) delivered a systematic cross-reference audit against Yjs JS and yrs, closing correctness gaps in YATA boundary handling, awareness protocol, delete-path cascade, lib0 wire-format parity, YText format markers, and JSON serialisation of nested shared types — tracked under the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps). See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the design narrative.
 
 ## Contributing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,17 @@
 ## What's new
 
-Closes #71 entirely. This is the deferred companion to v1.12.0's partial YText overhaul: `YText.Insert` now computes `currentAttributes` at the cursor and uses a diff-based approach to emit opening and negating markers, matching Yjs JS's `insertText` exactly.
+Two correctness fixes from the cross-reference audit, plus a long-overdue README refresh. After this lands the audit will have one remaining PR (#74 D1+D2 and #78) targeted for v1.15.0.
 
-**Two behavior changes** vs v1.12.0:
+- **`ToJSON` / `ToSlice` / `Entries` now recursively unwrap nested shared types** (#75). Pre-fix, a YArray containing a nested YMap silently dropped the nested map from `ToSlice` output, and `ToJSON` round-trips lost data. Now nested types serialize as their JSON-equivalent values (YArray → `[]any`, YMap → `map[string]any`, YText → `string`, YXml* → XML string). Arbitrarily-deep nesting recurses cleanly. Matches Yjs JS's `toJSON` convention.
 
-- **Inheritance (A2)**: typing with `nil`/empty attrs at the end of a formatted span now properly tracks `currentAttributes` from the linked-list state. Functionally users see the same continuation-of-bold behavior as before, but the underlying mechanism is now correct (and `currentAttributes` is available for future features like relative cursors).
+- **`YTextEvent.Delta` now reports embed inserts/deletes/retains** (#74 D3). Observers were missing embed events entirely because `computeDelta` only switched on `ContentString` and `ContentFormat`. Now also handles `ContentEmbed` (and `ContentType` for rare YText-inside-YText cases), emitting `Insert{embedValue}`, `Delete{1}`, and contributing 1 to retains — matching Yjs's UTF-16 length convention for embeds.
 
-- **No more right-bleed (A3)**: `Insert` with explicit attrs now emits negating closing markers after the text. Without them, formatting bled rightward through subsequent retained text — visible to a peer doing `ToDelta` after sync as runs of incorrectly-formatted plain text.
-
-The wire format now matches Yjs JS byte-for-byte for `Insert`-with-attrs scenarios. Cross-peer convergence tests confirm a fresh peer applying these updates produces the same `ToDelta` as the originating peer.
-
-Plus an incidental bug fix in the closer's `Origin` reference (was being set to the first clock of the wrapped text item instead of the last, which placed closers mid-text after YATA integration on a fresh peer).
+- **README refresh** — the version reference was five months stale (v1.7.0 → v1.14.0). Extended the post-v1.0 hardening section to cover the v1.8.x security work, the v1.10.0 lib0 wire-format parity, the v1.9.0–v1.14.0 cross-reference audit, and the smaller features in between (`sync.WithErrorHandler`, `Awareness.Heartbeat`, `YText.InsertEmbed`). Added a callout for the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) tracking the audit.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.13.0
+go get github.com/reearth/ygo@v1.14.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/observer_embed_test.go
+++ b/crdt/observer_embed_test.go
@@ -1,0 +1,109 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for #74 D3 — YTextEvent.computeDelta must emit Delta entries for
+// ContentEmbed (and ContentType) items, not just ContentString. Pre-fix,
+// the switch only handled ContentString and ContentFormat, so observers
+// missed embed inserts and deletes entirely.
+
+// D3 — Embed insert produces a Delta entry in the observer event with the
+// embed value as Insert (not a string).
+func TestUnit_YTextEvent_DeliversEmbedInsert(t *testing.T) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+
+	var observed []Delta
+	txt.Observe(func(e YTextEvent) { observed = e.Delta })
+
+	embed := map[string]any{"image": "https://example.com/x.png"}
+	doc.Transact(func(txn *Transaction) {
+		txt.InsertEmbed(txn, 0, embed, nil)
+	})
+
+	require.NotEmpty(t, observed,
+		"observer must receive at least one Delta entry for the embed insert")
+	// Find the entry whose Insert is the embed value (not a string).
+	var found bool
+	for _, d := range observed {
+		if d.Op != DeltaOpInsert {
+			continue
+		}
+		if got, ok := d.Insert.(map[string]any); ok {
+			if got["image"] == "https://example.com/x.png" {
+				found = true
+				break
+			}
+		}
+	}
+	assert.True(t, found,
+		"observer Delta must carry the embed value as Insert (#74 D3)")
+}
+
+// D3 — Embed delete produces a Delta entry of length 1 (embed counts as one
+// UTF-16 unit, matching Yjs convention).
+func TestUnit_YTextEvent_DeliversEmbedDelete(t *testing.T) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	embed := map[string]any{"video": "y.mp4"}
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "before", nil)
+		txt.InsertEmbed(txn, 6, embed, nil)
+	})
+
+	var observed []Delta
+	txt.Observe(func(e YTextEvent) { observed = e.Delta })
+
+	doc.Transact(func(txn *Transaction) {
+		txt.Delete(txn, 6, 1) // delete the embed
+	})
+
+	require.NotEmpty(t, observed)
+	// Expect a Retain(6) followed by Delete(1).
+	var retainSeen, deleteSeen bool
+	for _, d := range observed {
+		if d.Op == DeltaOpRetain && d.Retain == 6 {
+			retainSeen = true
+		}
+		if d.Op == DeltaOpDelete && d.Delete == 1 {
+			deleteSeen = true
+		}
+	}
+	assert.True(t, retainSeen, "must retain past the leading 'before' text")
+	assert.True(t, deleteSeen, "must report a 1-unit delete for the embed (#74 D3)")
+}
+
+// D3 — Retain past an embed during a subsequent edit advances by 1 (not 0).
+func TestUnit_YTextEvent_RetainAcrossEmbed(t *testing.T) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	embed := map[string]any{"x": "y"}
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "ab", nil)
+		txt.InsertEmbed(txn, 2, embed, nil)
+		txt.Insert(txn, 3, "cd", nil)
+	})
+
+	var observed []Delta
+	txt.Observe(func(e YTextEvent) { observed = e.Delta })
+
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 5, "Z", nil) // insert at end (position 5: ab + embed + cd)
+	})
+
+	// Expected: Retain(5) + Insert("Z"). The embed contributes 1 to the retain.
+	require.NotEmpty(t, observed)
+	var totalRetain int
+	for _, d := range observed {
+		if d.Op == DeltaOpRetain {
+			totalRetain += d.Retain
+		}
+	}
+	assert.Equal(t, 5, totalRetain,
+		"retain past 'ab' + embed + 'cd' must total 5 (embed counts as 1)")
+}

--- a/crdt/tojson_nested_test.go
+++ b/crdt/tojson_nested_test.go
@@ -1,0 +1,170 @@
+package crdt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for issue #75 — YArray.ToJSON / YMap.ToJSON must recursively unwrap
+// nested ContentType values into their JSON representation. Pre-fix, nested
+// shared types were silently dropped (omitted from the output entirely),
+// causing silent data loss for editors, persistence layers, and snapshot
+// dumps that round-trip through JSON.
+
+// insertNestedYMap is a tiny helper that builds a nested YMap parented to
+// the given YArray at the specified index, populating it inside the same
+// transaction. Returns the nested map for further assertions.
+func insertNestedYMap(t *testing.T, doc *Doc, arr *YArray, index int, kv map[string]any) *YMap {
+	t.Helper()
+	nested := &YMap{}
+	nested.doc = doc
+	nested.itemMap = make(map[string]*Item)
+	nested.owner = nested
+	doc.Transact(func(txn *Transaction) {
+		at := arr.baseType()
+		item := &Item{
+			ID:      ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:  at,
+			Content: NewContentType(&nested.abstractType),
+		}
+		// Position at the end for simplicity — tests can shuffle if they need
+		// a specific layout.
+		_ = index
+		item.integrate(txn, 0)
+		for k, v := range kv {
+			nested.Set(txn, k, v)
+		}
+	})
+	return nested
+}
+
+// #75 — YArray containing a nested YMap must serialise via JSON as a slice
+// of plain values where the nested YMap appears as map[string]any, not as
+// a *YMap pointer or as silently-dropped data.
+func TestUnit_YArray_ToJSON_RecursesIntoNestedYMap(t *testing.T) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("a")
+	insertNestedYMap(t, doc, arr, 0, map[string]any{"k1": "v1", "k2": int64(42)})
+
+	// Add some plain values alongside.
+	doc.Transact(func(txn *Transaction) {
+		arr.Push(txn, []any{"after"})
+	})
+
+	got := arr.ToSlice()
+	require.Len(t, got, 2,
+		"the nested YMap plus the plain string should produce two entries")
+
+	nestedJSON, ok := got[0].(map[string]any)
+	require.True(t, ok,
+		"first entry must be the unwrapped nested YMap as map[string]any, not a raw owner pointer")
+	assert.Equal(t, "v1", nestedJSON["k1"])
+	assert.Equal(t, int64(42), nestedJSON["k2"])
+
+	assert.Equal(t, "after", got[1])
+
+	// ToJSON round-trip via json.Marshal must succeed and produce parseable JSON.
+	jsonBytes, err := arr.ToJSON()
+	require.NoError(t, err)
+	var roundTrip []any
+	require.NoError(t, json.Unmarshal(jsonBytes, &roundTrip))
+	require.Len(t, roundTrip, 2)
+	nestedRT, ok := roundTrip[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "v1", nestedRT["k1"])
+}
+
+// #75 cont. — YMap containing a nested YArray must serialise the nested
+// array as []any in its Entries / ToJSON output.
+func TestUnit_YMap_ToJSON_RecursesIntoNestedYArray(t *testing.T) {
+	doc := newTestDoc(1)
+	m := doc.GetMap("m")
+
+	// Build a nested YArray inside the map.
+	nested := &YArray{}
+	nested.doc = doc
+	nested.itemMap = make(map[string]*Item)
+	nested.owner = nested
+	doc.Transact(func(txn *Transaction) {
+		// Set the nested array under key "list" via raw item placement.
+		at := m.baseType()
+		item := &Item{
+			ID:        ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:    at,
+			ParentSub: "list",
+			Content:   NewContentType(&nested.abstractType),
+		}
+		item.integrate(txn, 0)
+		nested.Push(txn, []any{int64(1), int64(2), int64(3)})
+
+		// Plain key alongside.
+		m.Set(txn, "name", "alice")
+	})
+
+	entries := m.Entries()
+	assert.Equal(t, "alice", entries["name"])
+
+	nestedSlice, ok := entries["list"].([]any)
+	require.True(t, ok,
+		"nested YArray under key 'list' must be unwrapped to []any, not a raw owner pointer")
+	assert.Equal(t, []any{int64(1), int64(2), int64(3)}, nestedSlice)
+
+	// JSON round-trip.
+	jsonBytes, err := m.ToJSON()
+	require.NoError(t, err)
+	var roundTrip map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &roundTrip))
+	assert.Equal(t, "alice", roundTrip["name"])
+	require.Contains(t, roundTrip, "list")
+}
+
+// #75 cont. — Two-level nesting (array → map → array) recurses correctly
+// all the way down. Pin the depth contract.
+func TestUnit_YArray_ToJSON_DeepNesting(t *testing.T) {
+	doc := newTestDoc(1)
+	outer := doc.GetArray("outer")
+
+	// outer = [ { "inner": [1, 2] } ]
+	mid := &YMap{}
+	mid.doc = doc
+	mid.itemMap = make(map[string]*Item)
+	mid.owner = mid
+	inner := &YArray{}
+	inner.doc = doc
+	inner.itemMap = make(map[string]*Item)
+	inner.owner = inner
+
+	doc.Transact(func(txn *Transaction) {
+		// Insert mid into outer.
+		atOuter := outer.baseType()
+		midItem := &Item{
+			ID:      ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:  atOuter,
+			Content: NewContentType(&mid.abstractType),
+		}
+		midItem.integrate(txn, 0)
+
+		// Insert inner into mid under key "inner".
+		atMid := mid.baseType()
+		innerItem := &Item{
+			ID:        ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:    atMid,
+			ParentSub: "inner",
+			Content:   NewContentType(&inner.abstractType),
+		}
+		innerItem.integrate(txn, 0)
+
+		inner.Push(txn, []any{int64(1), int64(2)})
+	})
+
+	got := outer.ToSlice()
+	require.Len(t, got, 1)
+	midJSON, ok := got[0].(map[string]any)
+	require.True(t, ok)
+	innerJSON, ok := midJSON["inner"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{int64(1), int64(2)}, innerJSON)
+}

--- a/crdt/tojson_nested_test.go
+++ b/crdt/tojson_nested_test.go
@@ -119,6 +119,110 @@ func TestUnit_YMap_ToJSON_RecursesIntoNestedYArray(t *testing.T) {
 	require.Contains(t, roundTrip, "list")
 }
 
+// Regression — ContentJSON values (legacy wire variant, tag wireJSON=2)
+// must appear in YArray.ToSlice output, not be silently dropped. Mirrors
+// the ContentAny handling. Without this case in the type switch, any
+// items received from JS peers via V1 wire as ContentJSON would vanish
+// from ToJSON output.
+func TestUnit_YArray_ToSlice_HandlesContentJSON(t *testing.T) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("a")
+	doc.Transact(func(txn *Transaction) {
+		// First a normal item via ContentAny.
+		arr.Push(txn, []any{"first"})
+		// Then a manually-integrated ContentJSON item (simulating an item
+		// decoded from a JS-peer V1 update with wireJSON tag).
+		at := arr.baseType()
+		item := &Item{
+			ID:      ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:  at,
+			Content: NewContentJSON("legacy-string", int64(42), true),
+		}
+		item.integrate(txn, 0)
+	})
+
+	got := arr.ToSlice()
+	require.Len(t, got, 4,
+		"ContentAny 'first' + 3 ContentJSON values = 4 total")
+	// The manually-integrated ContentJSON has no Origin set, so YATA places
+	// it at the start of the array (before "first"). The order is therefore:
+	// ContentJSON values first, then the ContentAny value. The actual
+	// assertion is just that ContentJSON values appear at all — order is
+	// implementation detail of where Origin was set.
+	assert.Equal(t, "legacy-string", got[0])
+	assert.Equal(t, int64(42), got[1])
+	assert.Equal(t, true, got[2])
+	assert.Equal(t, "first", got[3])
+}
+
+// Regression — ContentJSON values must appear in YMap.Entries output too.
+// Same gap mirrored to the map type.
+func TestUnit_YMap_Entries_HandlesContentJSON(t *testing.T) {
+	doc := newTestDoc(1)
+	m := doc.GetMap("m")
+	doc.Transact(func(txn *Transaction) {
+		m.Set(txn, "fresh", "via-ContentAny")
+		// Manually integrate a ContentJSON-backed entry under key 'legacy'.
+		at := m.baseType()
+		item := &Item{
+			ID:        ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:    at,
+			ParentSub: "legacy",
+			Content:   NewContentJSON("legacy-value"),
+		}
+		item.integrate(txn, 0)
+	})
+
+	entries := m.Entries()
+	assert.Equal(t, "via-ContentAny", entries["fresh"])
+	assert.Equal(t, "legacy-value", entries["legacy"],
+		"keys backed by ContentJSON must appear in Entries output (was silently dropped pre-fix)")
+}
+
+// Regression — nested YXml types in YArray.ToSlice must serialise via the
+// lock-free toXMLLocked path. The contract is: nested XML appears as an
+// XML string in the array's JSON representation. Incidentally exercises
+// the locked-variant code path that prevents the deadlock fixed alongside
+// the ContentJSON gap.
+func TestUnit_YArray_ToSlice_NestedYXml_SerializesAsString(t *testing.T) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("a")
+	elem := NewYXmlElement("p")
+	elem.doc = doc
+	xmlText := NewYXmlText()
+	xmlText.doc = doc
+
+	doc.Transact(func(txn *Transaction) {
+		// Place the XML element into the array.
+		at := arr.baseType()
+		item := &Item{
+			ID:      ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:  at,
+			Content: NewContentType(&elem.abstractType),
+		}
+		item.integrate(txn, 0)
+
+		// Add a YXmlText child to the element with some content.
+		atElem := elem.baseType()
+		textItem := &Item{
+			ID:      ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Parent:  atElem,
+			Content: NewContentType(&xmlText.abstractType),
+		}
+		textItem.integrate(txn, 0)
+		xmlText.Insert(txn, 0, "hello", nil)
+	})
+
+	got := arr.ToSlice()
+	require.Len(t, got, 1)
+	xmlStr, ok := got[0].(string)
+	require.True(t, ok,
+		"nested YXmlElement must serialise as a string via XML escaping")
+	assert.Contains(t, xmlStr, "<p>")
+	assert.Contains(t, xmlStr, "hello")
+	assert.Contains(t, xmlStr, "</p>")
+}
+
 // #75 cont. — Two-level nesting (array → map → array) recurses correctly
 // all the way down. Pin the depth contract.
 func TestUnit_YArray_ToJSON_DeepNesting(t *testing.T) {

--- a/crdt/tojson_nested_test.go
+++ b/crdt/tojson_nested_test.go
@@ -14,10 +14,11 @@ import (
 // causing silent data loss for editors, persistence layers, and snapshot
 // dumps that round-trip through JSON.
 
-// insertNestedYMap is a tiny helper that builds a nested YMap parented to
-// the given YArray at the specified index, populating it inside the same
+// insertNestedYMap is a tiny helper that appends a nested YMap to the given
+// YArray (always at the end — tests requiring specific placement should
+// construct the items directly). Populates the nested map in the same
 // transaction. Returns the nested map for further assertions.
-func insertNestedYMap(t *testing.T, doc *Doc, arr *YArray, index int, kv map[string]any) *YMap {
+func insertNestedYMap(t *testing.T, doc *Doc, arr *YArray, kv map[string]any) *YMap {
 	t.Helper()
 	nested := &YMap{}
 	nested.doc = doc
@@ -30,9 +31,6 @@ func insertNestedYMap(t *testing.T, doc *Doc, arr *YArray, index int, kv map[str
 			Parent:  at,
 			Content: NewContentType(&nested.abstractType),
 		}
-		// Position at the end for simplicity — tests can shuffle if they need
-		// a specific layout.
-		_ = index
 		item.integrate(txn, 0)
 		for k, v := range kv {
 			nested.Set(txn, k, v)
@@ -47,7 +45,7 @@ func insertNestedYMap(t *testing.T, doc *Doc, arr *YArray, index int, kv map[str
 func TestUnit_YArray_ToJSON_RecursesIntoNestedYMap(t *testing.T) {
 	doc := newTestDoc(1)
 	arr := doc.GetArray("a")
-	insertNestedYMap(t, doc, arr, 0, map[string]any{"k1": "v1", "k2": int64(42)})
+	insertNestedYMap(t, doc, arr, map[string]any{"k1": "v1", "k2": int64(42)})
 
 	// Add some plain values alongside.
 	doc.Transact(func(txn *Transaction) {

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -184,6 +184,12 @@ func (a *YArray) toSliceLocked() []any {
 		switch c := item.Content.(type) {
 		case *ContentAny:
 			result = append(result, c.Vals...)
+		case *ContentJSON:
+			// ContentJSON is the legacy JSON wire variant (tag wireJSON=2),
+			// functionally equivalent to ContentAny. Updates received from
+			// JS peers can land as ContentJSON items; without this case they
+			// would be silently dropped from ToSlice/ToJSON output.
+			result = append(result, c.Vals...)
 		case *ContentEmbed:
 			result = append(result, c.Val)
 		case *ContentType:
@@ -209,11 +215,11 @@ func toJSONValue(ct *ContentType) any {
 	case *YText:
 		return owner.toStringLocked()
 	case *YXmlElement:
-		return owner.ToXML()
+		return owner.toXMLLocked()
 	case *YXmlFragment:
-		return owner.ToXML()
+		return owner.toXMLLocked()
 	case *YXmlText:
-		return owner.ToXML()
+		return owner.toXMLLocked()
 	default:
 		return nil
 	}

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -140,13 +140,24 @@ func (a *YArray) Delete(txn *Transaction, index, length int) {
 	deleteRange(&a.abstractType, txn, index, length)
 }
 
-// ToSlice returns all non-deleted elements as a new slice.
+// ToSlice returns all non-deleted elements as a new slice. Nested shared
+// types are recursively unwrapped via toJSONValue (#75): a nested YArray
+// appears as []any, a nested YMap as map[string]any, a nested YText as
+// string. Pre-fix these were silently dropped from the output.
+//
 // Must not be called from inside a Transact callback.
 func (a *YArray) ToSlice() []any {
 	if doc := a.doc; doc != nil {
 		doc.mu.RLock()
 		defer doc.mu.RUnlock()
 	}
+	return a.toSliceLocked()
+}
+
+// toSliceLocked is the lock-free body of ToSlice; callers must already
+// hold the doc lock. Used by ToSlice (top-level) and toJSONValue (during
+// recursive unwrap of nested types under #75).
+func (a *YArray) toSliceLocked() []any {
 	t := &a.abstractType
 	result := make([]any, 0, t.length)
 	for item := t.start; item != nil; item = item.Right {
@@ -154,7 +165,6 @@ func (a *YArray) ToSlice() []any {
 			continue
 		}
 		if cm, ok := item.Content.(*ContentMove); ok {
-			// Render the moved item at this position if this move won.
 			if a.doc != nil {
 				target := a.doc.store.Find(*cm.Target)
 				if target != nil && target.MovedBy == item && !target.Deleted {
@@ -169,14 +179,44 @@ func (a *YArray) ToSlice() []any {
 			continue
 		}
 		if item.MovedBy != nil {
-			// Rendered at the ContentMove's position; skip here.
 			continue
 		}
-		if ca, ok := item.Content.(*ContentAny); ok {
-			result = append(result, ca.Vals...)
+		switch c := item.Content.(type) {
+		case *ContentAny:
+			result = append(result, c.Vals...)
+		case *ContentEmbed:
+			result = append(result, c.Val)
+		case *ContentType:
+			result = append(result, toJSONValue(c))
 		}
 	}
 	return result
+}
+
+// toJSONValue recursively unwraps a ContentType into its JSON-shaped value.
+// YArray → []any, YMap → map[string]any, YText → string, YXmlElement /
+// YXmlFragment / YXmlText → string (XML serialisation). Unknown nested
+// types fall back to nil. Caller must hold the doc lock. See #75.
+func toJSONValue(ct *ContentType) any {
+	if ct == nil || ct.Type == nil || ct.Type.owner == nil {
+		return nil
+	}
+	switch owner := ct.Type.owner.(type) {
+	case *YArray:
+		return owner.toSliceLocked()
+	case *YMap:
+		return owner.entriesLocked()
+	case *YText:
+		return owner.toStringLocked()
+	case *YXmlElement:
+		return owner.ToXML()
+	case *YXmlFragment:
+		return owner.ToXML()
+	case *YXmlText:
+		return owner.ToXML()
+	default:
+		return nil
+	}
 }
 
 // ToJSON returns the array serialised as a JSON array.

--- a/crdt/ymap.go
+++ b/crdt/ymap.go
@@ -147,6 +147,13 @@ func (m *YMap) entriesLocked() map[string]any {
 			if len(c.Vals) > 0 {
 				out[k] = c.Vals[0]
 			}
+		case *ContentJSON:
+			// ContentJSON is the legacy JSON wire variant (tag wireJSON=2);
+			// functionally equivalent to ContentAny. Without this case,
+			// keys received via JS-peer updates would be silently dropped.
+			if len(c.Vals) > 0 {
+				out[k] = c.Vals[0]
+			}
 		case *ContentEmbed:
 			out[k] = c.Val
 		case *ContentType:

--- a/crdt/ymap.go
+++ b/crdt/ymap.go
@@ -118,21 +118,39 @@ func (m *YMap) Keys() []string {
 	return keys
 }
 
-// Entries returns a snapshot of all live key-value pairs.
+// Entries returns a snapshot of all live key-value pairs. Nested shared
+// types are recursively unwrapped (#75): nested YArray → []any, nested
+// YMap → map[string]any, nested YText → string. Pre-fix these were
+// silently dropped from the output.
+//
 // Must not be called from inside a Transact callback.
 func (m *YMap) Entries() map[string]any {
 	if doc := m.doc; doc != nil {
 		doc.mu.RLock()
 		defer doc.mu.RUnlock()
 	}
+	return m.entriesLocked()
+}
+
+// entriesLocked is the lock-free body of Entries; callers must already
+// hold the doc lock. Used by Entries (top-level) and toJSONValue (during
+// recursive unwrap of nested types).
+func (m *YMap) entriesLocked() map[string]any {
 	t := &m.abstractType
 	out := make(map[string]any, len(t.itemMap))
 	for k, item := range t.itemMap {
 		if item.Deleted {
 			continue
 		}
-		if ca, ok := item.Content.(*ContentAny); ok && len(ca.Vals) > 0 {
-			out[k] = ca.Vals[0]
+		switch c := item.Content.(type) {
+		case *ContentAny:
+			if len(c.Vals) > 0 {
+				out[k] = c.Vals[0]
+			}
+		case *ContentEmbed:
+			out[k] = c.Val
+		case *ContentType:
+			out[k] = toJSONValue(c)
 		}
 	}
 	return out

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -109,6 +109,54 @@ func (txt *YText) computeDelta(txn *Transaction) []Delta {
 				retain += c.Len()
 			}
 
+		case *ContentEmbed:
+			// #74 D3: observers must see embed inserts/deletes/retains
+			// alongside text. Each embed counts as one UTF-16 unit
+			// (matches Yjs convention; see YText.InsertEmbed in v1.12.0).
+			if isNew {
+				if !item.Deleted {
+					flushRetain()
+					d := Delta{Op: DeltaOpInsert, Insert: c.Val}
+					if len(currentAttrs) > 0 {
+						attrs := make(Attributes, len(currentAttrs))
+						for k, v := range currentAttrs {
+							attrs[k] = v
+						}
+						d.Attributes = attrs
+					}
+					ops = append(ops, d)
+				}
+			} else if txn.deleteSet.IsDeleted(item.ID) {
+				flushRetain()
+				ops = append(ops, Delta{Op: DeltaOpDelete, Delete: 1})
+			} else if !item.Deleted {
+				retain += 1
+			}
+
+		case *ContentType:
+			// #74 D3: rare in YText (used by some editors to embed YArray/
+			// YMap as inline objects). Treat like an embed for delta
+			// purposes — length 1, value is the unwrapped nested type.
+			if isNew {
+				if !item.Deleted {
+					flushRetain()
+					d := Delta{Op: DeltaOpInsert, Insert: toJSONValue(c)}
+					if len(currentAttrs) > 0 {
+						attrs := make(Attributes, len(currentAttrs))
+						for k, v := range currentAttrs {
+							attrs[k] = v
+						}
+						d.Attributes = attrs
+					}
+					ops = append(ops, d)
+				}
+			} else if txn.deleteSet.IsDeleted(item.ID) {
+				flushRetain()
+				ops = append(ops, Delta{Op: DeltaOpDelete, Delete: 1})
+			} else if !item.Deleted {
+				retain += 1
+			}
+
 		case *ContentFormat:
 			if isNew {
 				if !item.Deleted {
@@ -800,6 +848,13 @@ func (txt *YText) ToString() string {
 		doc.mu.RLock()
 		defer doc.mu.RUnlock()
 	}
+	return txt.toStringLocked()
+}
+
+// toStringLocked is the lock-free body of ToString; callers must already
+// hold the doc lock. Used by ToString (top-level) and toJSONValue (#75)
+// when a YText appears as a value inside a YArray or YMap.
+func (txt *YText) toStringLocked() string {
 	t := &txt.abstractType
 	var sb strings.Builder
 	for item := t.start; item != nil; item = item.Right {

--- a/crdt/yxml.go
+++ b/crdt/yxml.go
@@ -7,8 +7,15 @@ import (
 
 // xmlNode is implemented by all XML node types (*YXmlFragment, *YXmlElement,
 // *YXmlText). It is used internally to walk and serialise XML trees.
+//
+// toXMLLocked is the lock-free counterpart to ToXML, used by toJSONValue
+// (#75) when serialisation is happening from a context that already holds
+// the doc lock — most notably computeDelta running under the doc write
+// lock via prepareFire. Calling ToXML there would re-enter the lock and
+// deadlock on the YXmlText path (which delegates to YText.ToString).
 type xmlNode interface {
 	ToXML() string
+	toXMLLocked() string
 	baseXMLType() *abstractType
 }
 
@@ -150,6 +157,16 @@ func (f *YXmlFragment) ToXML() string {
 	var sb strings.Builder
 	for _, child := range f.Children() {
 		sb.WriteString(child.ToXML())
+	}
+	return sb.String()
+}
+
+// toXMLLocked is the lock-free body of ToXML; safe to call from a context
+// holding the doc lock. See the xmlNode interface comment.
+func (f *YXmlFragment) toXMLLocked() string {
+	var sb strings.Builder
+	for _, child := range f.Children() {
+		sb.WriteString(child.toXMLLocked())
 	}
 	return sb.String()
 }
@@ -307,6 +324,25 @@ func (e *YXmlElement) ToXML() string {
 	return sb.String()
 }
 
+// toXMLLocked is the lock-free body of ToXML; calls the locked variant of
+// YXmlFragment so the recursion into YXmlText descendants doesn't re-enter
+// the doc lock. See the xmlNode interface comment.
+func (e *YXmlElement) toXMLLocked() string {
+	attrs := e.GetAttributes()
+	var sb strings.Builder
+	sb.WriteByte('<')
+	sb.WriteString(e.NodeName)
+	for _, k := range xmlSortedKeys(attrs) {
+		fmt.Fprintf(&sb, ` %s="%s"`, k, xmlEscapeAttr(attrs[k]))
+	}
+	sb.WriteByte('>')
+	sb.WriteString(e.YXmlFragment.toXMLLocked())
+	sb.WriteString("</")
+	sb.WriteString(e.NodeName)
+	sb.WriteByte('>')
+	return sb.String()
+}
+
 // Observe registers fn to be called after every transaction that modifies this
 // element (children added/removed or attributes changed). Returns an
 // unsubscribe function. Uses ID-based lookup so out-of-order unsubscription
@@ -350,6 +386,14 @@ func (t *YXmlText) baseXMLType() *abstractType { return &t.abstractType }
 // ToXML returns the text content with XML-special characters escaped.
 func (t *YXmlText) ToXML() string {
 	return xmlEscapeText(t.YText.ToString()) //nolint:staticcheck // intentional: avoids recursion with YXmlText.ToXML
+}
+
+// toXMLLocked is the lock-free body of ToXML; uses YText.toStringLocked so
+// it's safe to call from a context already holding the doc lock. Without
+// this, calling YXmlText.ToXML from computeDelta (under write lock) would
+// deadlock on the RLock inside YText.ToString.
+func (t *YXmlText) toXMLLocked() string {
+	return xmlEscapeText(t.YText.toStringLocked())
 }
 
 // ── Constructors ──────────────────────────────────────────────────────────────

--- a/crdt/yxml.go
+++ b/crdt/yxml.go
@@ -393,7 +393,7 @@ func (t *YXmlText) ToXML() string {
 // this, calling YXmlText.ToXML from computeDelta (under write lock) would
 // deadlock on the RLock inside YText.ToString.
 func (t *YXmlText) toXMLLocked() string {
-	return xmlEscapeText(t.YText.toStringLocked())
+	return xmlEscapeText(t.toStringLocked())
 }
 
 // ── Constructors ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two correctness fixes from the cross-reference audit, plus a long-overdue README refresh. Targets v1.14.0.

- **#75** — `YArray/YMap.ToJSON` and friends now recursively unwrap nested shared types instead of silently dropping them.
- **#74 D3** — `YTextEvent.Delta` now reports embed inserts, deletes, and retains (previously missing entirely from observer events).
- **README refresh** — version reference was five months stale; brought to v1.14.0 and surfaced the new APIs from v1.8.x–v1.13.0 plus the audit work.

Closes #75. Partially addresses #74 (D1 and D2 remain for a follow-up).

## Why scope split

The original plan was to bundle all remaining gap work (#74 + #75 + #78) plus README into one PR. After starting, the realistic effort estimate came in at 7-10 hours across heterogeneous concerns (event-shape API changes, transaction-lifecycle changes, README). Split into two PRs:

- **This PR (v1.14.0)** — JSON/embed serialization surface + README. Coherent, smaller review.
- **Follow-up (v1.15.0)** — `YArrayEvent.Delta` + `YMapEvent.Keys{action, oldValue}` + transaction-end housekeeping (auto-GC + split re-merge).

Both PRs together still close the audit in one fewer release events than the original 4-PR plan.

## Verification

- Full test suite green (including `TestCompat_*` JS fixtures)
- `go vet ./...` clean
- 6 new tests across two new test files; all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
