### PR TITLE
perf(crdt): hasFormatting gate + firstLive cache — YText_Delete -47%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] — 2026-05-26
+
+First post-audit release. Focused exclusively on `crdt/` internal performance — no public API changes.
+
+### Performance
+
+- **`YText.Delete` O(N²) → O(N) for sequential head-deletes** (#86). Two complementary fixes drive the win, both inspired by a cross-reference comparison against Yjs JS and yrs:
+  1. **`hasFormatting` gating** (mirrors Yjs's `_hasFormatting` flag). `abstractType` now flips a `hasFormatting` bit the first time a `ContentFormat` item is integrated. `YText.Delete` skips the `cleanupDanglingFormatsInRegion` walk entirely on YText types that have never had `Format()` called — the dominant cost on plain-text head-delete workloads.
+  2. **`firstLiveCache` extended to `deleteRange`**. `abstractType` memoises the first live (non-deleted) item from `t.start`; both `deleteRange` and `cleanupDanglingFormatsInRegion` now resume from that pointer instead of re-walking accumulated leading tombstones on every call. The cache advances lazily (tombstoning is monotonic) and is invalidated only when a new item is integrated as the new `t.start`.
+
+  Benchstat n=5 on `BenchmarkYText_Delete`: **-46.77% (2.87ms → 1.53ms per 1000-char delete loop)**. Geomean across the hot-path suite: **-8.09% sec/op**, **0.00% B/op**, **0.00% allocs/op**.
+
+- **`Transaction.changed` pre-sized to 4** (#54 A). Most transactions touch 1-3 types; the zero-hint allocation forced immediate rehashing on the first append.
+
+Two follow-ups from #54 were measured and reverted because they net-regressed other benchmarks:
+- Pre-sizing `Transaction.newItems` added one allocation per transaction even when no `ContentString` was inserted, hurting array/map-only workloads more than it helped text.
+- Reusing the YATA conflict-scan maps via `clear()` slowed `TwoPeerConvergence` (small maps make `clear()` walk slower than a fresh allocation). Conflict-scan map pooling remains a candidate for a future PR once the cost model justifies it.
+
+### Internal refactor
+
+- `abstractType` gains `firstLiveCache *Item` and `hasFormatting bool`, plus helpers `firstLiveFromStart` and `invalidateFirstLiveCache`. All private — no public API surface change.
+- `item.integrate` flips `Parent.hasFormatting = true` whenever the integrated item carries a `ContentFormat`, matching Yjs's `_hasFormatting` once-true-always-true semantics.
+
+### Why not a full Yjs structural port
+
+A cross-reference comparison against Yjs JS revealed that the Yjs `cleanupContextlessFormattingGap` model has different cleanup semantics — it only removes duplicate-key markers in a contiguous gap, not orphan opener/closer pairs whose effect zone has no live content. ygo's existing `cleanupDanglingFormatsInRegion` is intentionally more aggressive and is what closes #71 vector A4. We kept ygo's richer cleanup logic and adopted only Yjs's `_hasFormatting` gating + the `firstLiveCache` optimisation, which together give the YText_Delete win without weakening cleanup semantics.
+
 ## [1.15.0] — 2026-05-26
 
 Closes the cross-reference audit (issues #71-#79). Final correctness-focused minor release of the audit cycle.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,30 @@
 ## What's new
 
-The final correctness PR closing the cross-reference audit. v1.15.0 fully resolves [#74](https://github.com/reearth/ygo/issues/74) and [#78](https://github.com/reearth/ygo/issues/78), wrapping up the [`gaps` label](https://github.com/reearth/ygo/issues?label=gaps) work tracked across v1.9.0–v1.15.0.
+First post-audit release. Focused exclusively on `crdt/` internal performance — no public API changes.
 
-### Observer event shape parity with Yjs (#74)
+### `YText.Delete` -47% on head-delete workloads (#86)
 
-- **`YMapEvent.Keys`** — new `map[string]KeyChange` field carries the per-key change action (`KeyAdded` / `KeyUpdated` / `KeyDeleted`) plus the `OldValue` for updates and deletes. The legacy `KeysChanged` set stays populated for backwards compatibility; new code should prefer `Keys`. Mirrors Yjs JS's `YMapEvent.keys`.
-- **`YArrayEvent.Delta`** — new `[]Delta` field carries Quill-style insert / retain / delete ops with their values, matching the existing `YTextEvent.Delta` shape. Trailing retains are elided per Quill convention. Pre-fix, array observers received only `Target` and `Txn` and had to recompute the diff themselves.
+The `cleanupDanglingFormatsInRegion` walk introduced in v1.12.0 became O(N²) for sequential head-deletes: it started from `txt.start` on every call, re-skipping every accumulated tombstone before reaching live content. The fix combines two complementary optimisations, both inspired by a cross-reference comparison against Yjs JS and yrs:
 
-### Transaction-end housekeeping (#78)
+1. **`hasFormatting` gating** (mirrors Yjs's `_hasFormatting` flag). `abstractType` now flips a `hasFormatting` bit the first time a `ContentFormat` item is integrated. `YText.Delete` skips the cleanup walk entirely on YText types that have never had `Format()` called — the dominant cost on plain-text head-delete workloads.
+2. **`firstLiveCache` extended to `deleteRange`**. `abstractType` memoises the first live item from `t.start`; both `deleteRange` and the cleanup walk now resume from that cached pointer instead of re-walking leading tombstones on every call.
 
-- **Auto-GC at transaction commit (H1)** — with `WithGC(true)` (the default), items tombstoned during a transaction have their content replaced with a length-only `ContentDeleted` placeholder at commit time. Long collaborative sessions no longer accumulate full content for items that have been deleted and will never be observable again. Auto-GC runs *after* the observer-delta computation, so subscribers still see the original content. It is suppressed while an `UndoManager` is attached so undo / redo can still restore deleted items.
-- **Transient-split re-merge (H2)** — when `splitItem` produces a right half and no item ends up integrated between the two halves before commit, the halves are reunited. Prevents linked-list fragmentation in long edit sessions. Mirrors Yjs's `_mergeStructs` / `tryToMergeWithLeft`.
+**Benchstat n=5 on `BenchmarkYText_Delete`: -46.77% (2.87ms → 1.53ms)** per 1000-char delete loop. Geomean across the hot-path suite: **-8.09% sec/op**, **0.00% B/op**, **0.00% allocs/op**.
 
-## Audit complete
+### Transaction allocation hygiene (#54 A)
 
-This release ships the last of the gaps surfaced by the cross-reference audit against Yjs JS and yrs. The full list (#71 through #79) is now closed. See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for the per-release breakdown.
+`Transaction.changed` is now pre-sized to capacity 4 — most transactions touch 1-3 types and the prior zero-hint allocation forced immediate rehashing on the first append.
+
+Two related candidates from #54 (`newItems` pre-sizing and YATA conflict-scan map reuse via `clear()`) were measured and reverted because they net-regressed other benchmarks. They remain candidates for a future PR once the cost model is right.
+
+### Why not a full Yjs structural port
+
+A cross-reference comparison against Yjs JS showed that Yjs's `cleanupContextlessFormattingGap` model has different cleanup semantics — it only removes duplicate-key markers in a contiguous gap, not orphan opener/closer pairs whose effect zone has no live content. ygo's existing `cleanupDanglingFormatsInRegion` is intentionally more aggressive and is what closes #71 vector A4. We kept ygo's richer cleanup and adopted only Yjs's `_hasFormatting` gating + the `firstLiveCache` optimisation, which together give the YText_Delete win without weakening cleanup semantics.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.15.0
+go get github.com/reearth/ygo@v1.16.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -67,6 +67,57 @@ type abstractType struct {
 	// the entire cache, so that entries before the insertion point survive for
 	// subsequent nearby lookups. Zero means "no hint; do a full clear".
 	insertHint int
+
+	// firstLiveCache memoises the first live (non-deleted) item from t.start.
+	// Used by linked-list walks that would otherwise re-skip the same leading
+	// tombstones on every call (deleteRange when many head-deletes accumulate,
+	// per issue #86). Updated lazily by firstLiveFromStart; invalidated on
+	// item.integrate when a new head replaces t.start. Because tombstoning
+	// is monotonic, advancing the cache forward from its current value is
+	// always safe — once we walk past a deleted item we never need to revisit.
+	firstLiveCache *Item
+
+	// hasFormatting becomes true the first time a ContentFormat item is
+	// integrated into this type (locally via YText.Format or remotely via
+	// an update). Mirrors Yjs's _hasFormatting flag. YText.Delete uses this
+	// to skip the (expensive) per-deleted-item cleanup walk on types that
+	// have never had formatting applied — the dominant cost on head-delete
+	// workloads in plain-text documents. Once true, stays true.
+	hasFormatting bool
+}
+
+// firstLiveFromStart returns the first non-deleted item reachable from t.start
+// by walking Right, or nil if every item is tombstoned. The result is memoised
+// in t.firstLiveCache: subsequent calls advance the cache past any tombstones
+// that accumulated since the last call rather than restarting from t.start.
+//
+// Cache invariant: t.firstLiveCache is either nil, the true first-live item,
+// or an earlier item that may or may not still be live. The forward walk from
+// the cache is always correct because tombstoning is monotonic — an item that
+// is currently deleted stays deleted, so once we walk past it we never have
+// to revisit it. The cache MUST be reset (to nil) only when a new item is
+// inserted strictly before the cached pointer, which currently only happens
+// when item.integrate replaces t.start (see item.go).
+//
+// Closes the O(N²) sequential-head-delete behaviour described in issue #86.
+func (t *abstractType) firstLiveFromStart() *Item {
+	node := t.firstLiveCache
+	if node == nil {
+		node = t.start
+	}
+	for node != nil && node.Deleted {
+		node = node.Right
+	}
+	t.firstLiveCache = node
+	return node
+}
+
+// invalidateFirstLiveCache clears the first-live memoisation. Callers must
+// invoke this whenever a new item is inserted at the head of the linked list
+// (i.e. as the new t.start) so the next firstLiveFromStart call resumes its
+// walk from the new head rather than skipping past it.
+func (t *abstractType) invalidateFirstLiveCache() {
+	t.firstLiveCache = nil
 }
 
 // invalidatePosCache clears all cached position entries. Must be called

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -412,8 +412,14 @@ func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction) error,
 		Local:       true,
 		deleteSet:   newDeleteSet(),
 		beforeState: d.store.StateVector(),
-		changed:     make(map[*abstractType]map[string]struct{}),
-		ctx:         ctx,
+		// Pre-size changed to common-case capacity (#54 A): most transactions
+		// touch 1-3 types, and the zero-hint alloc forces immediate rehashing
+		// on the very first append. newItems is left nil — pre-sizing it here
+		// added 1 alloc per txn even when no ContentString was inserted, which
+		// hurt array/map-only workloads more than it helped text workloads
+		// (the squashRuns target).
+		changed: make(map[*abstractType]map[string]struct{}, 4),
+		ctx:     ctx,
 	}
 
 	defer func() {

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -121,6 +121,9 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 	if left == nil {
 		item.Right = item.Parent.start
 		item.Parent.start = item
+		// New head — the firstLive memoisation may point past us; reset it
+		// so the next cleanup walk picks up the new live item (#86).
+		item.Parent.invalidateFirstLiveCache()
 	} else {
 		item.Right = left.Right
 		left.Right = item
@@ -174,6 +177,14 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 	// Track ContentString items for end-of-transaction run squashing.
 	if _, ok := item.Content.(*ContentString); ok {
 		txn.newItems = append(txn.newItems, item)
+	}
+
+	// Yjs parity: once any ContentFormat is integrated into this type, mark
+	// hasFormatting so subsequent YText.Delete calls know they need to run
+	// the contextless cleanup walk. Plain-text types never set this flag,
+	// so their deletes skip the walk entirely (#86 final fix).
+	if _, ok := item.Content.(*ContentFormat); ok && item.Parent != nil {
+		item.Parent.hasFormatting = true
 	}
 
 	// If this item wraps a nested type, set the back-pointer so the type

--- a/crdt/perf_internals_test.go
+++ b/crdt/perf_internals_test.go
@@ -1,0 +1,131 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression guards for the v1.16.0 perf PR (#86 + #54).
+
+// #86 — firstLiveFromStart must correctly skip leading tombstones and
+// remain valid across sequential head-deletes. Pre-fix the cleanup walk
+// rescanned all tombstones each time, producing O(N²) behaviour for the
+// "1000 head-deletes" workload that BenchmarkYText_Delete exercises.
+func TestUnit_FirstLiveFromStart_SkipsLeadingTombstones(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "abcdef", nil) })
+
+	// After 3 sequential head-deletes the live region is "def" — firstLive
+	// must point at the item containing 'd' (or a later live item, depending
+	// on how Delete splits).
+	doc.Transact(func(txn *Transaction) {
+		txt.Delete(txn, 0, 1)
+		txt.Delete(txn, 0, 1)
+		txt.Delete(txn, 0, 1)
+	})
+
+	live := txt.firstLiveFromStart()
+	require.NotNil(t, live, "must find a live item after partial head-delete")
+	assert.False(t, live.Deleted, "firstLive must not be tombstoned")
+	assert.Equal(t, "def", txt.ToString(),
+		"content must round-trip unchanged")
+}
+
+// #86 — inserting at index 0 must invalidate the firstLive cache so the
+// new head is picked up on the next cleanup walk.
+func TestUnit_FirstLiveFromStart_ResetsOnHeadInsert(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "world", nil) })
+
+	// Prime the cache.
+	first := txt.firstLiveFromStart()
+	require.NotNil(t, first)
+
+	// Insert a new head item.
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello ", nil) })
+
+	live := txt.firstLiveFromStart()
+	require.NotNil(t, live)
+	assert.NotEqual(t, first, live,
+		"firstLive must update after a head-insert (cache invalidation)")
+	// The new live item should be the one containing the head of "hello ",
+	// which is now txt.start.
+	assert.Equal(t, txt.start, live)
+}
+
+// #86 — every item tombstoned still returns nil (no infinite loop, no panic).
+func TestUnit_FirstLiveFromStart_AllDeleted(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "abc", nil) })
+	doc.Transact(func(txn *Transaction) { txt.Delete(txn, 0, 3) })
+
+	assert.Nil(t, txt.firstLiveFromStart(),
+		"firstLive must be nil when every item is tombstoned")
+}
+
+// #54 A — Transact must produce a transaction whose pre-sized fields can
+// absorb a typical workload (1-3 types) without rehashing the map.
+// (newItems is intentionally left nil-init since pre-sizing it added one
+// alloc per txn for workloads that never insert ContentString.)
+func TestUnit_Transaction_PresizedFields(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "x", nil)
+		// changed must already record txt's abstractType.
+		assert.Contains(t, txn.changed, &txt.abstractType,
+			"changed map must record modifications during the txn")
+		// newItems must include the just-inserted ContentString.
+		assert.GreaterOrEqual(t, len(txn.newItems), 1,
+			"newItems must collect ContentString inserts")
+	})
+}
+
+// #86 — plain-text YText (never had Format() called) must not set
+// hasFormatting, so YText.Delete skips the cleanup walk entirely.
+func TestUnit_YText_HasFormatting_FalseForPlainText(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello world", nil) })
+
+	assert.False(t, txt.hasFormatting,
+		"hasFormatting must stay false until a ContentFormat is integrated")
+}
+
+// #86 — YText.Format integrates ContentFormat markers, which must flip
+// hasFormatting to true so subsequent Delete calls run the cleanup walk.
+func TestUnit_YText_HasFormatting_TrueAfterFormat(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "hello", nil)
+		txt.Format(txn, 0, 5, Attributes{"bold": true})
+	})
+
+	assert.True(t, txt.hasFormatting,
+		"Format() integrates ContentFormat → hasFormatting must become true")
+}
+
+// #86 — once hasFormatting is true, it stays true even after all format
+// markers are deleted (matches Yjs's _hasFormatting behaviour).
+func TestUnit_YText_HasFormatting_StaysTrueAfterFormatDeleted(t *testing.T) {
+	doc := New(WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "hello", nil)
+		txt.Format(txn, 0, 5, Attributes{"bold": true})
+	})
+	require.True(t, txt.hasFormatting)
+
+	// Delete the whole formatted span (which also tombstones the markers).
+	doc.Transact(func(txn *Transaction) { txt.Delete(txn, 0, txt.Len()) })
+
+	assert.True(t, txt.hasFormatting,
+		"hasFormatting must remain true after all formats are deleted, "+
+			"matching Yjs's once-true-always-true semantics")
+}

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -647,7 +647,13 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 		t.invalidatePosCacheFrom(index)
 	}
 	counted := 0
-	item := t.start
+	// Start the walk at firstLiveFromStart, not t.start: leading tombstones
+	// accumulated by earlier head-deletes are skipped in O(1) via the cache,
+	// turning the previous O(N) per-call leading-skip into O(1) amortized.
+	// firstLiveFromStart returns the first non-deleted item; subsequent
+	// non-countable items (e.g. ContentFormat) are still handled by the
+	// existing skip branch below. Closes the deleteRange half of #86.
+	item := t.firstLiveFromStart()
 	for item != nil && length > 0 {
 		if item.Deleted || !item.Content.IsCountable() {
 			item = item.Right

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -553,9 +553,15 @@ func (txt *YText) InsertEmbed(txn *Transaction, index int, embed any, attrs Attr
 // edits leave orphan markers that bloat the store and inflate the encoded
 // delete-set. See #71 vector A4.
 //
-// The scan is scoped to the region between the item just before the deletion
-// and the first live countable item after it, so the per-Delete cost is
-// O(region size + scope size of any markers found) rather than O(document).
+// The scan is gated on txt.hasFormatting: YText that has never had a
+// ContentFormat integrated (the common plain-text case) skips the walk
+// entirely. This mirrors Yjs's `_hasFormatting` flag gating and is the
+// dominant perf win on head-delete workloads in plain-text documents (#86).
+//
+// When the scan does run it is scoped to the region between the item just
+// before the deletion and the first live countable item after it, so the
+// per-Delete cost is O(region size + scope size of any markers found)
+// rather than O(document).
 func (txt *YText) Delete(txn *Transaction, index, length int) {
 	// Capture the anchor immediately before the deletion start so we can
 	// walk forward from there post-deletion. nil means "start of document."
@@ -566,6 +572,12 @@ func (txt *YText) Delete(txn *Transaction, index, length int) {
 
 	deleteRange(&txt.abstractType, txn, index, length)
 
+	if !txt.hasFormatting {
+		// No ContentFormat has ever been integrated into this type — nothing
+		// to clean up. Skip the walk: this is the head-delete benchmark's
+		// dominant saving (#86).
+		return
+	}
 	txt.cleanupDanglingFormatsInRegion(txn, startAnchor)
 }
 
@@ -587,7 +599,11 @@ func (txt *YText) Delete(txn *Transaction, index, length int) {
 func (txt *YText) cleanupDanglingFormatsInRegion(txn *Transaction, startAnchor *Item) {
 	var node *Item
 	if startAnchor == nil {
-		node = txt.start
+		// Sequential head-deletes (the BenchmarkYText_Delete worst case)
+		// accumulate tombstones at txt.start; without the memoised pointer
+		// every cleanup re-walks all of them and the per-delete cost is
+		// O(deletes-so-far). Use the cache instead — issue #86.
+		node = txt.firstLiveFromStart()
 	} else {
 		node = startAnchor.Right
 	}


### PR DESCRIPTION
## Summary

First post-audit release. Focused exclusively on \`crdt/\` internal performance — no public API changes.

Closes the v1.12.0 \`YText.Delete\` regression via two complementary fixes, both inspired by a cross-reference comparison against **Yjs JS** and **yrs**:

1. **\`hasFormatting\` gating** (mirrors Yjs's \`_hasFormatting\` flag). \`abstractType\` flips a \`hasFormatting\` bit the first time a \`ContentFormat\` is integrated. \`YText.Delete\` skips the cleanup walk entirely for YText types that have never had \`Format()\` called — the dominant cost on plain-text head-delete workloads.
2. **\`firstLiveCache\` extended to \`deleteRange\`**. \`abstractType\` memoises the first live item from \`t.start\`; both \`deleteRange\` and the cleanup walk resume from there instead of re-walking accumulated leading tombstones every call.

Also includes #54 A — \`Transaction.changed\` pre-sized to 4. (#54 B and C were measured and reverted; see the comment trail on the issue.)

## Benchstat n=5 vs main

```
                         sec/op       vs base
YText_Insert-16          627.7n       ~ (p=0.024)
YText_InsertBulk-16      2.584µ       ~ (p=0.690)
YText_Delete-16          1.530m       -46.77% (p=0.008) ← #86 fix
EncodeStateAsUpdateV1-16 43.93µ       -3.27% (p=0.008)
ApplyUpdateV1-16         113.8µ       -6.85% (p=0.008)
YMap_Set-16              21.76µ       ~ (p=0.198)
YArray_Push-16           58.38µ       ~ (p=0.421)
TwoPeerConvergence-16    18.28µ       ~ (p=0.516)
geomean                              -8.09%
```

**Allocs/op and B/op: 0.00% delta across every benchmark.**

## Why not a full Yjs structural port

Comparing against Yjs JS revealed that \`cleanupContextlessFormattingGap\` has **weaker** semantics — it only removes duplicate-key markers in a contiguous gap, not orphan opener/closer pairs whose effect zone has no live content. ygo's existing \`cleanupDanglingFormatsInRegion\` is intentionally more aggressive and is the function that addressed #71 vector A4. We kept ygo's richer cleanup and adopted only Yjs's \`_hasFormatting\` gating + the \`firstLiveCache\` optimisation, which together give the YText_Delete win without weakening cleanup semantics.

## Test plan

- [x] 7 new tests in \`crdt/perf_internals_test.go\` covering: \`firstLiveFromStart\` skip / reset / all-deleted, Transaction pre-sized field smoke check, and \`hasFormatting\` false-for-plain-text / true-after-format / stays-true-after-format-deleted.
- [x] All existing #71/A4 cleanup tests still pass (ygo's aggressive cleanup semantics preserved).
- [x] Full suite green (\`go test ./...\`)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go vet ./...\` — clean
- [x] JS interop (\`TestCompat_GoToJS\` / \`TestCompat_JSToGo\`) — pass

Closes #86