### PR TITLE
perf(wire): pool the Encoder + zero-copy decoder paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] — 2026-05-27
+
+Wire-framing performance pass. Focused on the encoder allocation churn on the WebSocket send path and the redundant copies on the awareness JSON decode path. No public API breaks; one new helper and one decoder-method rename.
+
+### Added
+
+- **`encoding.GetEncoder` / `encoding.PutEncoder` / `encoding.EncodeBytes`** (#52). A package-level `sync.Pool` for `*Encoder`. `EncodeBytes(fn)` is the recommended wrapper for wire-framing call sites: it gets an encoder from the pool, runs `fn`, copies the resulting bytes into an independent allocation, and returns the encoder to the pool. The returned slice is safe to hand to write channels or other long-lived consumers.
+
+- **`encoding.Decoder.RemainingBytesCopy`** (#53 A). Returns an independently-allocated copy of the unread buffer portion — the previous behaviour of `RemainingBytes`. Use when callers need to retain the bytes across decoder buffer mutations.
+
+### Performance
+
+- **`Decoder.RemainingBytes` is now zero-copy** (#53 A). Returns a sub-slice of the underlying buffer instead of allocating a fresh copy. The documented contract is now: callers must treat the result as read-only and copy if they need a slice with an independent lifetime. The only non-test caller in this repo (`provider/websocket/peer.go:47`) hands the bytes straight to `ApplySyncMessage` and `broadcastSync`, both of which only read or copy.
+
+- **`Awareness.ApplyUpdate` zero-copy JSON decode** (#53 B). The per-entry JSON payload is now held as `[]byte` end-to-end (decoded via `ReadVarBytes`, which already returns a sub-slice of the decoder buffer) and passed directly to `json.Unmarshal`. Pre-fix, the bytes were converted to `string` by `ReadVarString` (one copy) and back to `[]byte` by `json.Unmarshal([]byte(s), ...)` (a second copy). On `BenchmarkApplyUpdate_Many` (100 entries): **-15.97% allocs/op (626 → 526), -9.93% sec/op on `_Single`**.
+
+- **WebSocket send/broadcast paths use the pooled encoder** (#52). All six `encoding.NewEncoder()` call sites in `provider/websocket/peer.go` (`sendSync`, `sendAwareness`, `broadcastSync`, `broadcastAwareness`, `broadcastAwarenessFromRoom`, `encodeAwarenessRemoval`) now go through `EncodeBytes`. `crdt/update.go`'s `encodeV1Locked` and `EncodeStateVectorV1` also switched. The pool keeps the underlying buffer warm across calls, eliminating the growth allocations that occurred on each `WriteVarUint`/`WriteRaw` past the 64-byte initial capacity.
+
+Benchstat n=5 (awareness package geomean): **-7.97% sec/op, -3.58% allocs/op**. Encoding package geomean: -1.81% sec/op, neutral allocs.
+
+### Internal refactor
+
+- `awareness.checkJSONDepth` signature changed from `string` to `[]byte` so it can scan the decoder sub-slice without an intermediate string conversion. Private — no external impact.
+
 ## [1.16.0] — 2026-05-26
 
 First post-audit release. Focused exclusively on `crdt/` internal performance — no public API changes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,30 +1,40 @@
 ## What's new
 
-First post-audit release. Focused exclusively on `crdt/` internal performance — no public API changes.
+Wire-framing performance pass. Focused on the two largest sources of allocation churn on the WebSocket send / receive paths.
 
-### `YText.Delete` -47% on head-delete workloads (#86)
+### sync.Pool for Encoder across all send paths (#52)
 
-The `cleanupDanglingFormatsInRegion` walk introduced in v1.12.0 became O(N²) for sequential head-deletes: it started from `txt.start` on every call, re-skipping every accumulated tombstone before reaching live content. The fix combines two complementary optimisations, both inspired by a cross-reference comparison against Yjs JS and yrs:
+Every `sendSync`, `broadcastSync`, `sendAwareness`, `broadcastAwareness`, and update-encoder call site previously allocated a fresh `*Encoder` plus its 64-byte initial buffer. With six call sites in `provider/websocket/peer.go` and the doc-update encoder in `crdt/update.go`, a 100-peer room doing 10 updates/sec/peer paid ~7000 small allocations/sec purely on wire-framing overhead.
 
-1. **`hasFormatting` gating** (mirrors Yjs's `_hasFormatting` flag). `abstractType` now flips a `hasFormatting` bit the first time a `ContentFormat` item is integrated. `YText.Delete` skips the cleanup walk entirely on YText types that have never had `Format()` called — the dominant cost on plain-text head-delete workloads.
-2. **`firstLiveCache` extended to `deleteRange`**. `abstractType` memoises the first live item from `t.start`; both `deleteRange` and the cleanup walk now resume from that cached pointer instead of re-walking leading tombstones on every call.
+New helpers in `encoding/`:
 
-**Benchstat n=5 on `BenchmarkYText_Delete`: -46.77% (2.87ms → 1.53ms)** per 1000-char delete loop. Geomean across the hot-path suite: **-8.09% sec/op**, **0.00% B/op**, **0.00% allocs/op**.
+- **`encoding.GetEncoder` / `encoding.PutEncoder`** — pool primitives.
+- **`encoding.EncodeBytes(fn)`** — the recommended wrapper. Gets an encoder from the pool, runs `fn`, copies the result into an independent allocation, and returns the encoder to the pool. Safe to hand the returned bytes to write channels.
 
-### Transaction allocation hygiene (#54 A)
+### Zero-copy decoder paths (#53)
 
-`Transaction.changed` is now pre-sized to capacity 4 — most transactions touch 1-3 types and the prior zero-hint allocation forced immediate rehashing on the first append.
+- **`Decoder.RemainingBytes`** now returns a sub-slice instead of a copy. The previous behaviour is preserved under the new name `RemainingBytesCopy` for callers that need an independent allocation. Documented contract: treat the result as read-only.
+- **`Awareness.ApplyUpdate`** decodes JSON payloads as `[]byte` end-to-end (via `ReadVarBytes`, which already returned a sub-slice) and passes them directly to `json.Unmarshal`. Pre-fix, every entry incurred two copies: one via `ReadVarString`'s `[]byte→string` conversion, and one via `json.Unmarshal([]byte(s), ...)`. On `BenchmarkApplyUpdate_Many` (100 entries): **-15.97% allocs/op** (626 → 526), **-9.93% sec/op** on the single-entry variant.
 
-Two related candidates from #54 (`newItems` pre-sizing and YATA conflict-scan map reuse via `clear()`) were measured and reverted because they net-regressed other benchmarks. They remain candidates for a future PR once the cost model is right.
+## Benchstat n=5 vs main
 
-### Why not a full Yjs structural port
-
-A cross-reference comparison against Yjs JS showed that Yjs's `cleanupContextlessFormattingGap` model has different cleanup semantics — it only removes duplicate-key markers in a contiguous gap, not orphan opener/closer pairs whose effect zone has no live content. ygo's existing `cleanupDanglingFormatsInRegion` is intentionally more aggressive and is what closes #71 vector A4. We kept ygo's richer cleanup and adopted only Yjs's `_hasFormatting` gating + the `firstLiveCache` optimisation, which together give the YText_Delete win without weakening cleanup semantics.
+```
+                   sec/op       vs base
+awareness:
+  SetLocalState        64.90n   -5.34%
+  EncodeUpdate_Single  224.5n   -10.52%
+  EncodeUpdate_Many    13.00µ   -7.85%
+  ApplyUpdate_Single   686.0n   -9.93%   (also -4.35% allocs/op)
+  ApplyUpdate_Many     21.41µ   ~        (-15.97% allocs/op, 100 fewer allocs)
+  geomean                       -7.97% sec/op, -3.58% allocs/op
+encoding:
+  geomean                       -1.81% sec/op, neutral allocs
+```
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.16.0
+go get github.com/reearth/ygo@v1.17.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -19,13 +19,16 @@ const DefaultTimeout = 30 * time.Second
 // treated as null (removed).
 const maxJSONDepth = 20
 
-// checkJSONDepth reports whether the JSON string s has at most maxJSONDepth
+// checkJSONDepth reports whether the JSON byte slice s has at most maxJSONDepth
 // levels of nesting. It scans bytes rather than parsing, so it runs in O(n).
 //
 // It tracks string context to avoid counting bracket characters inside JSON
 // string values. Without this, {"key": "[[[["}  would be counted as depth 5
 // instead of the correct depth 1, causing false-positive rejections (N-C3).
-func checkJSONDepth(s string) bool {
+//
+// Takes []byte (not string) so callers can pass a Decoder sub-slice without
+// the []byte→string conversion copy.
+func checkJSONDepth(s []byte) bool {
 	depth := 0
 	inString := false
 	i := 0
@@ -377,7 +380,13 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 	type entry struct {
 		clientID uint64
 		clock    uint64
-		jsonStr  string
+		// jsonBytes aliases the decoder's underlying buffer (zero-copy).
+		// Stable for the duration of ApplyUpdate; callers must not mutate
+		// the input slice while ApplyUpdate is running. Replacing string
+		// with []byte here eliminates two copies per entry: one in
+		// ReadVarString's []byte→string conversion and one in
+		// json.Unmarshal's string→[]byte conversion downstream.
+		jsonBytes []byte
 	}
 	entries := make([]entry, 0, numClients)
 	for i := uint64(0); i < numClients; i++ {
@@ -389,14 +398,14 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 		if err != nil {
 			return err
 		}
-		jsonStr, err := dec.ReadVarString()
+		jsonBytes, err := dec.ReadVarBytes()
 		if err != nil {
 			return err
 		}
-		if len(jsonStr) > maxAwarenessStateBytes {
+		if len(jsonBytes) > maxAwarenessStateBytes {
 			return ErrStateTooLarge
 		}
-		entries = append(entries, entry{clientID, clock, jsonStr})
+		entries = append(entries, entry{clientID, clock, jsonBytes})
 	}
 
 	a.mu.Lock()
@@ -404,7 +413,9 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 
 	for _, e := range entries {
 		current, exists := a.states[e.clientID]
-		isNullEntry := e.jsonStr == "null" || e.jsonStr == ""
+		// string([]byte) == "constant" is optimised by the Go compiler to
+		// length+content comparison without allocating, since Go 1.5.
+		isNullEntry := string(e.jsonBytes) == "null" || len(e.jsonBytes) == 0
 
 		// y-protocols clock gate (#73 vector C2):
 		//   - strictly-older clock → drop
@@ -451,9 +462,9 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 		isNull := isNullEntry
 		var state map[string]any
 		if !isNull {
-			if !checkJSONDepth(e.jsonStr) {
+			if !checkJSONDepth(e.jsonBytes) {
 				isNull = true
-			} else if err := json.Unmarshal([]byte(e.jsonStr), &state); err != nil {
+			} else if err := json.Unmarshal(e.jsonBytes, &state); err != nil {
 				isNull = true
 			}
 			if state == nil {
@@ -473,7 +484,7 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 		// the byte delta this entry would introduce (new size minus the
 		// previously-tracked size for this client) and drop the entry if
 		// applying it would exceed maxBytes.
-		newSize := len(e.jsonStr)
+		newSize := len(e.jsonBytes)
 		oldSize := a.wireBytes[e.clientID]
 		if !isNull && a.maxBytes > 0 {
 			delta := int64(newSize - oldSize)

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -118,14 +118,14 @@ func EncodeStateVectorV1(doc *Doc) []byte {
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
 	sv := doc.store.StateVector()
-	enc := encoding.NewEncoder()
 	clients := clientsSorted(sv)
-	enc.WriteVarUint(uint64(len(clients)))
-	for _, c := range clients {
-		enc.WriteVarUint(uint64(c))
-		enc.WriteVarUint(sv[c])
-	}
-	return enc.Bytes()
+	return encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(uint64(len(clients)))
+		for _, c := range clients {
+			enc.WriteVarUint(uint64(c))
+			enc.WriteVarUint(sv[c])
+		}
+	})
 }
 
 // DecodeStateVectorV1 parses a blob produced by EncodeStateVectorV1.
@@ -158,8 +158,6 @@ func DecodeStateVectorV1(data []byte) (StateVector, error) {
 // ── V1 encoding ───────────────────────────────────────────────────────────────
 
 func encodeV1Locked(doc *Doc, sv StateVector) []byte {
-	enc := encoding.NewEncoder()
-
 	type clientGroup struct {
 		client     ClientID
 		items      []*Item
@@ -181,22 +179,24 @@ func encodeV1Locked(doc *Doc, sv StateVector) []byte {
 	}
 	sort.Slice(groups, func(i, j int) bool { return groups[i].client < groups[j].client })
 
-	enc.WriteVarUint(uint64(len(groups)))
-	for _, g := range groups {
-		enc.WriteVarUint(uint64(len(g.items)))
-		enc.WriteVarUint(uint64(g.client))
-		enc.WriteVarUint(g.startClock)
-		for i, item := range g.items {
-			offset := 0
-			if i == 0 && g.startClock > item.ID.Clock {
-				offset = int(g.startClock - item.ID.Clock)
-			}
-			encodeItem(enc, item, offset, doc.store)
-		}
-	}
+	deleteSet := buildDeleteSet(doc.store)
 
-	encodeDeleteSet(enc, buildDeleteSet(doc.store))
-	return enc.Bytes()
+	return encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(uint64(len(groups)))
+		for _, g := range groups {
+			enc.WriteVarUint(uint64(len(g.items)))
+			enc.WriteVarUint(uint64(g.client))
+			enc.WriteVarUint(g.startClock)
+			for i, item := range g.items {
+				offset := 0
+				if i == 0 && g.startClock > item.ID.Clock {
+					offset = int(g.startClock - item.ID.Clock)
+				}
+				encodeItem(enc, item, offset, doc.store)
+			}
+		}
+		encodeDeleteSet(enc, deleteSet)
+	})
 }
 
 func encodeItem(enc *encoding.Encoder, item *Item, offset int, store *StructStore) {

--- a/encoding/decoder.go
+++ b/encoding/decoder.go
@@ -49,8 +49,24 @@ func (d *Decoder) Remaining() int { return len(d.buf) - d.pos }
 // HasContent reports whether there are unread bytes remaining.
 func (d *Decoder) HasContent() bool { return d.pos < len(d.buf) }
 
-// RemainingBytes returns a copy of the unread portion of the buffer.
+// RemainingBytes returns the unread portion of the buffer as a sub-slice.
+//
+// The returned slice ALIASES the decoder's underlying buffer; mutating it
+// (or extending its length via append beyond cap) corrupts the decoder.
+// Callers must treat it as read-only and copy if they need a slice with
+// an independent lifetime. Most callers in this codebase hand the bytes
+// straight to ApplySyncMessage or json.Unmarshal, both of which read-only,
+// so the zero-copy path is safe.
+//
+// Use RemainingBytesCopy if you need an independent allocation.
 func (d *Decoder) RemainingBytes() []byte {
+	return d.buf[d.pos:]
+}
+
+// RemainingBytesCopy returns an independently-allocated copy of the unread
+// portion of the buffer. Use when the caller needs to retain the bytes
+// across mutations of the decoder's underlying buffer.
+func (d *Decoder) RemainingBytesCopy() []byte {
 	rem := d.buf[d.pos:]
 	cp := make([]byte, len(rem))
 	copy(cp, rem)

--- a/encoding/pool.go
+++ b/encoding/pool.go
@@ -44,12 +44,17 @@ func PutEncoder(e *Encoder) {
 // safe to retain across goroutines and outlive the call. This is the
 // preferred wrapper for wire-framing call sites that hand bytes to a
 // write channel or other long-lived consumer.
-func EncodeBytes(fn func(*Encoder)) []byte {
+//
+// PutEncoder is deferred so a panic from fn still returns the encoder to
+// the pool (GetEncoder calls Reset on the way out, so any partially-
+// written bytes from the panicking call are discarded before the encoder
+// is reused).
+func EncodeBytes(fn func(*Encoder)) (out []byte) {
 	e := GetEncoder()
+	defer PutEncoder(e)
 	fn(e)
 	src := e.Bytes()
-	out := make([]byte, len(src))
+	out = make([]byte, len(src))
 	copy(out, src)
-	PutEncoder(e)
 	return out
 }

--- a/encoding/pool.go
+++ b/encoding/pool.go
@@ -1,0 +1,55 @@
+package encoding
+
+import "sync"
+
+// encoderPool reuses Encoder instances across wire-framing call sites.
+// Every send / broadcast path in provider/websocket and every internal
+// encodeV1Locked call previously allocated a fresh Encoder plus its 64-byte
+// initial buffer, then grew that buffer as fields were appended. The pool
+// keeps the underlying buffer warm so subsequent calls can append without
+// allocating until the previous high-water mark is exceeded.
+//
+// Pooled Encoders are NOT safe to share with consumers that outlive the
+// Get/Put scope — call sites that hand the encoded bytes to another
+// goroutine (e.g. via a write channel) MUST copy the bytes out before
+// PutEncoder, since the underlying buffer is reused by the next Get.
+// EncodeBytes wraps this pattern.
+var encoderPool = sync.Pool{
+	New: func() any { return NewEncoder() },
+}
+
+// GetEncoder returns a Reset Encoder from the pool. The encoder MUST be
+// returned to the pool via PutEncoder once its bytes are no longer needed.
+// The byte slice returned by the encoder's Bytes() method aliases the
+// pooled buffer and becomes invalid after PutEncoder — copy out anything
+// that needs to outlive the Put.
+func GetEncoder() *Encoder {
+	e := encoderPool.Get().(*Encoder)
+	e.Reset()
+	return e
+}
+
+// PutEncoder returns e to the pool for reuse. Callers must not access e
+// or any slice obtained from e.Bytes() after this call returns.
+func PutEncoder(e *Encoder) {
+	if e == nil {
+		return
+	}
+	encoderPool.Put(e)
+}
+
+// EncodeBytes runs fn against a pooled Encoder and returns an
+// independently-allocated copy of the resulting bytes. The encoder is
+// returned to the pool before EncodeBytes returns; the returned slice is
+// safe to retain across goroutines and outlive the call. This is the
+// preferred wrapper for wire-framing call sites that hand bytes to a
+// write channel or other long-lived consumer.
+func EncodeBytes(fn func(*Encoder)) []byte {
+	e := GetEncoder()
+	fn(e)
+	src := e.Bytes()
+	out := make([]byte, len(src))
+	copy(out, src)
+	PutEncoder(e)
+	return out
+}

--- a/encoding/pool_test.go
+++ b/encoding/pool_test.go
@@ -81,6 +81,40 @@ func TestUnit_EncodeBytes_ConcurrentSafe(t *testing.T) {
 	}
 }
 
+// #52 — EncodeBytes must return the encoder to the pool even when fn
+// panics, otherwise the pooled encoder leaks and subsequent callers pay
+// fresh allocations. Verified by panicking inside fn, then confirming the
+// pool still hands out a clean Reset encoder afterwards.
+func TestUnit_EncodeBytes_PanicReturnsEncoderToPool(t *testing.T) {
+	// Drain the pool of any pre-warm entries so the panicking encoder is
+	// the one most likely to be re-handed to the next Get.
+	for i := 0; i < 4; i++ {
+		PutEncoder(GetEncoder())
+	}
+
+	// Fire a panic inside fn. EncodeBytes must propagate it, but the
+	// deferred PutEncoder must still run.
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "panic must propagate through EncodeBytes")
+		}()
+		_ = EncodeBytes(func(enc *Encoder) {
+			enc.WriteVarUint(0xDEADBEEF) // dirty the buffer first
+			panic("simulated encode failure")
+		})
+	}()
+
+	// Subsequent Get must return a Reset encoder. If PutEncoder didn't run
+	// on the panic path the pool would still hold the dirty encoder.
+	for i := 0; i < 8; i++ {
+		e := GetEncoder()
+		assert.Empty(t, e.Bytes(),
+			"encoder %d from pool after panicking EncodeBytes must be Reset", i)
+		PutEncoder(e)
+	}
+}
+
 // #53 A — RemainingBytes is documented to alias the decoder buffer.
 // Verify that explicitly so future maintainers know not to "fix" it by
 // adding a copy.

--- a/encoding/pool_test.go
+++ b/encoding/pool_test.go
@@ -1,0 +1,115 @@
+package encoding
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #52 — pooled encoders must come back Reset, so callers don't have to
+// remember to call Reset themselves and don't inherit stale bytes.
+func TestUnit_GetEncoder_ReturnsResetEncoder(t *testing.T) {
+	// Prime the pool with an encoder carrying bytes.
+	first := GetEncoder()
+	first.WriteVarUint(42)
+	require.NotEmpty(t, first.Bytes(), "setup: encoder must hold bytes")
+	PutEncoder(first)
+
+	// Re-getting from the pool must give back a Reset encoder.
+	second := GetEncoder()
+	defer PutEncoder(second)
+	assert.Empty(t, second.Bytes(),
+		"GetEncoder must Reset the encoder before returning it; "+
+			"otherwise pool consumers inherit previous bytes")
+}
+
+// #52 — EncodeBytes returns a buffer that is independent of the pooled
+// encoder's underlying storage. The next GetEncoder must NOT alias the
+// returned slice.
+func TestUnit_EncodeBytes_ReturnsIndependentCopy(t *testing.T) {
+	out := EncodeBytes(func(enc *Encoder) {
+		enc.WriteVarUint(1)
+		enc.WriteVarUint(2)
+		enc.WriteVarUint(3)
+	})
+	original := bytes.Clone(out)
+
+	// Force the pool to hand back the same encoder for a second use.
+	next := GetEncoder()
+	next.WriteVarUint(0xFFFFFFFF) // big value to ensure buffer reuse mutates same backing
+	PutEncoder(next)
+
+	assert.True(t, bytes.Equal(out, original),
+		"the bytes returned by EncodeBytes must NOT alias the pooled buffer; "+
+			"a subsequent encoder use must not mutate the returned slice")
+}
+
+// #52 — concurrent EncodeBytes calls from many goroutines must produce
+// independent, non-corrupted outputs. This stresses the pool under load.
+func TestUnit_EncodeBytes_ConcurrentSafe(t *testing.T) {
+	const goroutines = 50
+	const valuesPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	results := make([][]byte, goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			results[g] = EncodeBytes(func(enc *Encoder) {
+				for i := 0; i < valuesPerGoroutine; i++ {
+					enc.WriteVarUint(uint64(g*1000 + i))
+				}
+			})
+		}()
+	}
+	wg.Wait()
+
+	// Each goroutine's output must decode back to the values it wrote.
+	for g, out := range results {
+		dec := NewDecoder(out)
+		for i := 0; i < valuesPerGoroutine; i++ {
+			v, err := dec.ReadVarUint()
+			require.NoError(t, err, "goroutine %d output %d: decode must succeed", g, i)
+			require.Equal(t, uint64(g*1000+i), v,
+				"goroutine %d output %d: pool corruption?", g, i)
+		}
+	}
+}
+
+// #53 A — RemainingBytes is documented to alias the decoder buffer.
+// Verify that explicitly so future maintainers know not to "fix" it by
+// adding a copy.
+func TestUnit_RemainingBytes_AliasesUnderlyingBuffer(t *testing.T) {
+	buf := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	dec := NewDecoder(buf)
+	_, _ = dec.ReadUint8() // advance past byte 0
+	rem := dec.RemainingBytes()
+	require.Equal(t, []byte{0x02, 0x03, 0x04, 0x05}, rem)
+
+	// Aliasing: mutating the original buffer must surface in the
+	// returned slice. (The documented contract: callers must treat
+	// the result as read-only.)
+	buf[1] = 0xFF
+	assert.Equal(t, byte(0xFF), rem[0],
+		"RemainingBytes must alias the underlying buffer — this is the "+
+			"zero-copy contract documented on the function")
+}
+
+// #53 A — RemainingBytesCopy returns an independent buffer that callers
+// can retain across decoder buffer mutations.
+func TestUnit_RemainingBytesCopy_IsIndependent(t *testing.T) {
+	buf := []byte{0x01, 0x02, 0x03}
+	dec := NewDecoder(buf)
+	_, _ = dec.ReadUint8()
+	cp := dec.RemainingBytesCopy()
+	require.Equal(t, []byte{0x02, 0x03}, cp)
+
+	buf[1] = 0xFF
+	assert.Equal(t, byte(0x02), cp[0],
+		"RemainingBytesCopy must be independent of the source buffer")
+}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -204,56 +204,56 @@ func encodeAwarenessRemoval(aw *awareness.Awareness, clientIDs []uint64) []byte 
 	if len(toRemove) == 0 {
 		return nil
 	}
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(uint64(len(toRemove)))
-	for _, item := range toRemove {
-		enc.WriteVarUint(item.id)
-		enc.WriteVarUint(item.clock + 1)
-		enc.WriteVarString("null")
-	}
-	return enc.Bytes()
+	return encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(uint64(len(toRemove)))
+		for _, item := range toRemove {
+			enc.WriteVarUint(item.id)
+			enc.WriteVarUint(item.clock + 1)
+			enc.WriteVarString("null")
+		}
+	})
 }
 
 // sendSync writes a sync message (outer type 0, raw payload) to this peer.
 func (p *peer) sendSync(syncMsg []byte) {
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(msgSync)
-	enc.WriteRaw(syncMsg) // sync payload is NOT VarBytes-wrapped
-	p.write(enc.Bytes())
+	p.write(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgSync)
+		enc.WriteRaw(syncMsg) // sync payload is NOT VarBytes-wrapped
+	}))
 }
 
 // sendAwareness writes an awareness message (outer type 1, VarBytes payload)
 // to this peer.
 func (p *peer) sendAwareness(awMsg []byte) {
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(msgAwareness)
-	enc.WriteVarBytes(awMsg) // awareness payload IS VarBytes-wrapped
-	p.write(enc.Bytes())
+	p.write(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgAwareness)
+		enc.WriteVarBytes(awMsg) // awareness payload IS VarBytes-wrapped
+	}))
 }
 
 // broadcastSync sends a sync message to all OTHER peers in the room.
 func (p *peer) broadcastSync(syncMsg []byte) {
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(msgSync)
-	enc.WriteRaw(syncMsg)
-	p.broadcast(enc.Bytes(), true)
+	p.broadcast(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgSync)
+		enc.WriteRaw(syncMsg)
+	}), true)
 }
 
 // broadcastAwareness sends an awareness message to all OTHER peers in the room.
 func (p *peer) broadcastAwareness(awMsg []byte) {
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(msgAwareness)
-	enc.WriteVarBytes(awMsg)
-	p.broadcast(enc.Bytes(), true)
+	p.broadcast(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgAwareness)
+		enc.WriteVarBytes(awMsg)
+	}), true)
 }
 
 // broadcastAwarenessFromRoom sends an awareness message to ALL peers (called
 // from disconnect handler which has already removed itself from the room).
 func (p *peer) broadcastAwarenessFromRoom(awMsg []byte) {
-	enc := encoding.NewEncoder()
-	enc.WriteVarUint(msgAwareness)
-	enc.WriteVarBytes(awMsg)
-	p.broadcast(enc.Bytes(), false)
+	p.broadcast(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgAwareness)
+		enc.WriteVarBytes(awMsg)
+	}), false)
 }
 
 // broadcast enqueues data for delivery to peers in the room. If excludeSelf


### PR DESCRIPTION
## Summary

Wire-framing performance pass. Two correctness-preserving optimisations on the WebSocket wire path:

- **#52** — \`sync.Pool[*Encoder]\` for all WebSocket send/broadcast paths plus \`crdt/update.go\`. New \`encoding.GetEncoder\` / \`PutEncoder\` / \`EncodeBytes\` helpers. \`EncodeBytes\` is the recommended wrapper — gets a pooled encoder, runs the closure, copies the bytes into an independent allocation, returns the encoder to the pool.
- **#53 A** — \`Decoder.RemainingBytes\` is now zero-copy (sub-slice). Previous behaviour preserved as \`RemainingBytesCopy\`.
- **#53 B** — \`Awareness.ApplyUpdate\` decodes per-entry JSON as \`[]byte\` end-to-end via \`ReadVarBytes\` (which already sub-slices). Drops two copies per entry (\`ReadVarString\`'s \`[]byte→string\` + \`json.Unmarshal([]byte(s), ...)\`).

## Benchstat n=5 vs main

```
                          sec/op       allocs/op
awareness:
  SetLocalState           -5.34%       ~
  EncodeUpdate_Single    -10.52%       ~
  EncodeUpdate_Many       -7.85%       ~
  ApplyUpdate_Single      -9.93%      -4.35%
  ApplyUpdate_Many       ~ (p=0.095) -15.97%   (100 fewer allocs)
  RemoveExpired          ~            ~
  geomean                 -7.97%      -3.58%
encoding:
  geomean                 -1.81%      neutral
```

`provider/websocket` doesn't have microbenchmarks so the pool's impact there can't be measured directly here. The pool is exercised by every send/broadcast call; for a 100-peer room doing 10 updates/sec/peer the prior code paid ~7000 small encoder allocations/sec.

## Test plan

- [x] 5 new tests in  `encoding/pool_test.go` covering: `GetEncoder` returns reset state, `EncodeBytes` returns an independent copy, concurrent `EncodeBytes` correctness under load, `RemainingBytes` aliases the buffer (documented contract), `RemainingBytesCopy` is independent.
- [x] All existing awareness, encoding, websocket tests pass
- [x] Full suite green (`go test ./...`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...` — clean

## Notes

- `RemainingBytes` signature is unchanged but its contract is now zero-copy. The previous behaviour is preserved as `RemainingBytesCopy` for callers that need an independent allocation. Documented in the godoc.
- Private function `awareness.checkJSONDepth` signature changed from `string` to `[]byte` — internal, no external impact.

Closes #52
Closes #53