### PR TITLE
feat(websocket): handle Hocuspocus message types 4-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] — 2026-05-28
+
+First Hocuspocus compatibility release. `provider/websocket` now accepts the seven additional message types Hocuspocus extends y-protocols with, so Hocuspocus-aware clients (Tiptap stateless extensions, custom liveness pings, application close signals) no longer have their frames silently dropped.
+
+### Added
+
+- **Hocuspocus message types 4-10 in `provider/websocket`** (#55):
+  - **`SyncReply`** (tag 4) — applied to the local doc and broadcast to other peers, but never echoed back to the sender (breaks the SyncStep1 ping-pong loop on noisy links).
+  - **`Stateless`** (tag 5) — surfaced to the application via the new `Server.OnStateless` hook with `IsBroadcast: false`. Not broadcast to other peers.
+  - **`BroadcastStateless`** (tag 6) — fanned out to all other peers in the room as plain `Stateless` (tag 5) frames; `OnStateless` fires on the server with `IsBroadcast: true`.
+  - **`CLOSE`** (tag 7) — closes the underlying WebSocket connection; logs the optional reason if present.
+  - **`SyncStatus`** (tag 8) — server→client ack; silently consumed if a client sends it.
+  - **`Ping`** (tag 9) — replied to with a single-byte `Pong` (tag 10) frame.
+  - **`Pong`** (tag 10) — silently consumed.
+
+- **`Server.OnStateless StatelessHook`** and **`StatelessInfo` struct** — new public types in `provider/websocket`. The hook is invoked on the peer's read goroutine after any broadcast fan-out has already happened; long-running work should be dispatched to a separate goroutine.
+
+### Framing limitation
+
+Hocuspocus's full client framing prepends a `VarString(docName)` to every frame so a single connection can multiplex multiple documents. ygo's framing remains the y-websocket layout (tag + payload), one document per WebSocket. This release adds the Hocuspocus message **types** on the existing y-websocket framing — so Hocuspocus-aware **handlers** can be used by clients that speak y-websocket, but Hocuspocus's multi-doc multiplex is a separate architectural change not in scope here.
+
+### Tests
+
+- 7 new integration tests in `provider/websocket/hocuspocus_test.go` exercise each new tag end-to-end (real WebSocket peers via `httptest`): `SyncReply` apply+broadcast+no-echo, `Stateless` hook fires + no broadcast, `BroadcastStateless` fan-out as tag 5 + hook fires with `IsBroadcast: true`, `Ping` → `Pong`, `Pong` silently consumed, `CLOSE` closes the connection, `SyncStatus` silently consumed.
+
 ## [1.17.0] — 2026-05-27
 
 Wire-framing performance pass. Focused on the encoder allocation churn on the WebSocket send path and the redundant copies on the awareness JSON decode path. No public API breaks; one new helper and one decoder-method rename.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,33 @@
 ## What's new
 
-Wire-framing performance pass. Focused on the two largest sources of allocation churn on the WebSocket send / receive paths.
+First Hocuspocus compatibility release. `provider/websocket` now accepts the seven additional message types Hocuspocus extends y-protocols with — so Hocuspocus-aware clients (Tiptap stateless extensions, custom liveness pings, application close signals) no longer have their frames silently dropped.
 
-### sync.Pool for Encoder across all send paths (#52)
+### Hocuspocus message types 4-10 (#55)
 
-Every `sendSync`, `broadcastSync`, `sendAwareness`, `broadcastAwareness`, and update-encoder call site previously allocated a fresh `*Encoder` plus its 64-byte initial buffer. With six call sites in `provider/websocket/peer.go` and the doc-update encoder in `crdt/update.go`, a 100-peer room doing 10 updates/sec/peer paid ~7000 small allocations/sec purely on wire-framing overhead.
+| Tag | Message | ygo behaviour |
+|---|---|---|
+| 4 | `SyncReply` | Apply locally, broadcast to other peers, never echo to sender. |
+| 5 | `Stateless` | Fire `Server.OnStateless` with `IsBroadcast: false`. No broadcast. |
+| 6 | `BroadcastStateless` | Fan out to other peers as `Stateless` (tag 5); fire `Server.OnStateless` with `IsBroadcast: true`. |
+| 7 | `CLOSE` | Close the WebSocket connection; log the optional reason. |
+| 8 | `SyncStatus` | Silently consume (server-to-client message). |
+| 9 | `Ping` | Reply with single-byte `Pong` (tag 10). |
+| 10 | `Pong` | Silently consume. |
 
-New helpers in `encoding/`:
+### New public API
 
-- **`encoding.GetEncoder` / `encoding.PutEncoder`** — pool primitives.
-- **`encoding.EncodeBytes(fn)`** — the recommended wrapper. Gets an encoder from the pool, runs `fn`, copies the result into an independent allocation, and returns the encoder to the pool. Safe to hand the returned bytes to write channels.
+- `Server.OnStateless StatelessHook` — optional hook on `provider/websocket.Server`.
+- `StatelessHook = func(StatelessInfo)` — invoked on the peer's read goroutine.
+- `StatelessInfo` — carries `Room`, `Payload`, `IsBroadcast`.
 
-### Zero-copy decoder paths (#53)
+### Framing limitation (intentional)
 
-- **`Decoder.RemainingBytes`** now returns a sub-slice instead of a copy. The previous behaviour is preserved under the new name `RemainingBytesCopy` for callers that need an independent allocation. Documented contract: treat the result as read-only.
-- **`Awareness.ApplyUpdate`** decodes JSON payloads as `[]byte` end-to-end (via `ReadVarBytes`, which already returned a sub-slice) and passes them directly to `json.Unmarshal`. Pre-fix, every entry incurred two copies: one via `ReadVarString`'s `[]byte→string` conversion, and one via `json.Unmarshal([]byte(s), ...)`. On `BenchmarkApplyUpdate_Many` (100 entries): **-15.97% allocs/op** (626 → 526), **-9.93% sec/op** on the single-entry variant.
-
-## Benchstat n=5 vs main
-
-```
-                   sec/op       vs base
-awareness:
-  SetLocalState        64.90n   -5.34%
-  EncodeUpdate_Single  224.5n   -10.52%
-  EncodeUpdate_Many    13.00µ   -7.85%
-  ApplyUpdate_Single   686.0n   -9.93%   (also -4.35% allocs/op)
-  ApplyUpdate_Many     21.41µ   ~        (-15.97% allocs/op, 100 fewer allocs)
-  geomean                       -7.97% sec/op, -3.58% allocs/op
-encoding:
-  geomean                       -1.81% sec/op, neutral allocs
-```
+Hocuspocus's full client framing prepends a `VarString(docName)` to every frame so one WebSocket can multiplex multiple documents. ygo's framing remains the y-websocket layout (tag + payload), one document per WebSocket. This release adds the Hocuspocus message **types** on the existing y-websocket framing; Hocuspocus's multi-doc multiplex is a separate, larger architectural change not in scope here.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.17.0
+go get github.com/reearth/ygo@v1.18.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/provider/websocket/hocuspocus_test.go
+++ b/provider/websocket/hocuspocus_test.go
@@ -1,0 +1,271 @@
+package websocket_test
+
+import (
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// Tests for #55 — Hocuspocus message types 4-10 routed through
+// peer.handleMessage. Each test exercises one tag end-to-end:
+// peer sends → server dispatches → expected side-effect (hook fires,
+// peer receives broadcast, connection closes, etc.).
+
+// sendStateless sends a Hocuspocus Stateless (tag 5) message.
+func sendStateless(t *testing.T, conn *gws.Conn, payload string) {
+	t.Helper()
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(5) // msgStateless
+		enc.WriteVarString(payload)
+	})))
+}
+
+// sendBroadcastStateless sends a Hocuspocus BroadcastStateless (tag 6).
+func sendBroadcastStateless(t *testing.T, conn *gws.Conn, payload string) {
+	t.Helper()
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(6) // msgBroadcastStateless
+		enc.WriteVarString(payload)
+	})))
+}
+
+// sendPing sends a Hocuspocus Ping (tag 9) frame — a single byte.
+func sendPing(t *testing.T, conn *gws.Conn) {
+	t.Helper()
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, []byte{0x09}))
+}
+
+// #55 — SyncReply (tag 4) must apply the payload locally and broadcast
+// any update to other peers, but must NOT echo a sync reply back to the
+// sender. (Plain Sync tag 0 sends a step-2 reply when the sender sends a
+// step-1; SyncReply exists specifically to break that loop on links that
+// would otherwise ping-pong forever.)
+func TestInteg_Hocuspocus_SyncReply_AppliesAndBroadcastsNoEcho(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	// Two peers in the same room. A will send a SyncReply carrying a
+	// real update; B should receive the broadcast.
+	connA := dial(t, ts, "syncreplyroom")
+	connB := dial(t, ts, "syncreplyroom")
+	docA := crdt.New(crdt.WithClientID(1))
+	docB := crdt.New(crdt.WithClientID(2))
+	drainHandshake(t, connA, docA)
+	drainHandshake(t, connB, docB)
+
+	// A produces a local update and wraps it as a SyncStep2-style payload,
+	// then sends it as msgSyncReply (tag 4) instead of msgSync (tag 0).
+	txt := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	update := crdt.EncodeStateAsUpdateV1(docA, nil)
+
+	require.NoError(t, connA.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(4)       // msgSyncReply
+		enc.WriteVarUint(2)       // syncStep2 marker
+		enc.WriteVarBytes(update) // update bytes
+	})))
+
+	// B must receive the broadcast as a regular Sync (tag 0) frame.
+	outerType, _ := readOne(t, connB, 2*time.Second)
+	assert.Equal(t, uint64(0), outerType,
+		"SyncReply must be broadcast to other peers as a regular Sync (tag 0)")
+
+	// A must NOT receive any echo. Confirm with a short deadline.
+	_ = connA.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	_, _, err := connA.ReadMessage()
+	require.Error(t, err,
+		"SyncReply must NOT trigger an echo back to the sender")
+	_ = connA.SetReadDeadline(time.Time{})
+}
+
+// #55 — Stateless (tag 5) must fire OnStateless with IsBroadcast=false
+// and must NOT broadcast to other peers.
+func TestInteg_Hocuspocus_Stateless_FiresHookNoBroadcast(t *testing.T) {
+	srv := ygws.NewServer()
+
+	var (
+		mu        sync.Mutex
+		seenInfos []ygws.StatelessInfo
+	)
+	srv.OnStateless = func(info ygws.StatelessInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		seenInfos = append(seenInfos, info)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	connA := dial(t, ts, "statelessroom")
+	connB := dial(t, ts, "statelessroom")
+	drainHandshake(t, connA, crdt.New())
+	drainHandshake(t, connB, crdt.New())
+
+	sendStateless(t, connA, "hello from A")
+
+	// Hook must fire on the server. Poll briefly because dispatch is async
+	// (peer read goroutine -> hook call).
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(seenInfos) == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"OnStateless must fire exactly once for tag-5 Stateless")
+
+	mu.Lock()
+	got := seenInfos[0]
+	mu.Unlock()
+	assert.Equal(t, "statelessroom", got.Room)
+	assert.Equal(t, "hello from A", got.Payload)
+	assert.False(t, got.IsBroadcast, "tag 5 must produce IsBroadcast=false")
+
+	// B must NOT receive any broadcast — set a short deadline and confirm
+	// no message arrives. (Read deadline expiry on gorilla returns an
+	// i/o-timeout error, which is what we expect.)
+	_ = connB.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	_, _, err := connB.ReadMessage()
+	require.Error(t, err, "Stateless (tag 5) must NOT broadcast to other peers")
+	_ = connB.SetReadDeadline(time.Time{})
+}
+
+// #55 — BroadcastStateless (tag 6) must fan out to other peers as a
+// plain Stateless (tag 5) frame, AND fire OnStateless with
+// IsBroadcast=true on the server side.
+func TestInteg_Hocuspocus_BroadcastStateless_FanOutAsStateless(t *testing.T) {
+	srv := ygws.NewServer()
+
+	var (
+		mu       sync.Mutex
+		hookCall ygws.StatelessInfo
+		hookHit  bool
+	)
+	srv.OnStateless = func(info ygws.StatelessInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		hookCall = info
+		hookHit = true
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	connA := dial(t, ts, "broadcastroom")
+	connB := dial(t, ts, "broadcastroom")
+	drainHandshake(t, connA, crdt.New())
+	drainHandshake(t, connB, crdt.New())
+
+	sendBroadcastStateless(t, connA, "shouted from A")
+
+	// B must receive a Stateless (tag 5) frame carrying the payload.
+	outerType, payload := readOne(t, connB, 2*time.Second)
+	assert.Equal(t, uint64(5), outerType,
+		"BroadcastStateless must arrive at other peers as tag 5 (Stateless)")
+
+	// payload here is the raw bytes after the tag, which is a
+	// VarString-wrapped string.
+	dec := encoding.NewDecoder(payload)
+	got, err := dec.ReadVarString()
+	require.NoError(t, err)
+	assert.Equal(t, "shouted from A", got)
+
+	// Hook fired with IsBroadcast=true.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return hookHit
+	}, 2*time.Second, 10*time.Millisecond)
+	mu.Lock()
+	assert.True(t, hookCall.IsBroadcast,
+		"tag 6 must produce IsBroadcast=true on OnStateless")
+	assert.Equal(t, "shouted from A", hookCall.Payload)
+	mu.Unlock()
+}
+
+// #55 — Ping (tag 9) must elicit a single-byte Pong (tag 10) reply.
+func TestInteg_Hocuspocus_Ping_RepliesWithPong(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	conn := dial(t, ts, "pingroom")
+	drainHandshake(t, conn, crdt.New())
+
+	sendPing(t, conn)
+
+	outerType, payload := readOne(t, conn, 2*time.Second)
+	assert.Equal(t, uint64(10), outerType, "Ping must trigger a tag-10 Pong reply")
+	assert.Empty(t, payload, "Pong frame carries no payload — just the tag byte")
+}
+
+// #55 — Pong (tag 10) from a peer must be silently consumed (no reply,
+// no broadcast, connection stays open).
+func TestInteg_Hocuspocus_Pong_SilentlyConsumed(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	conn := dial(t, ts, "pongroom")
+	drainHandshake(t, conn, crdt.New())
+
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, []byte{0x0A})) // tag 10
+
+	// No reply expected; the connection must stay open. Confirm by
+	// sending a Ping and getting a Pong back — proves the read loop
+	// hasn't aborted on the Pong.
+	sendPing(t, conn)
+	outerType, _ := readOne(t, conn, 2*time.Second)
+	assert.Equal(t, uint64(10), outerType,
+		"connection must stay open after Pong; subsequent Ping must still elicit Pong")
+}
+
+// #55 — CLOSE (tag 7) from a peer must close the underlying connection.
+// The reason VarString is optional.
+func TestInteg_Hocuspocus_Close_ClosesConnection(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	conn := dial(t, ts, "closeroom")
+	drainHandshake(t, conn, crdt.New())
+
+	// Send tag 7 + a reason VarString.
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(7) // msgClose
+		enc.WriteVarString("client-initiated test close")
+	})))
+
+	// Next read must fail because the server closed the connection.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err,
+		"CLOSE (tag 7) must close the underlying WebSocket; subsequent read must fail")
+}
+
+// #55 — SyncStatus (tag 8) is normally server→client; if a client sends
+// it the server must consume the VarUint flag silently without dropping
+// the connection.
+func TestInteg_Hocuspocus_SyncStatus_SilentlyConsumed(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	conn := dial(t, ts, "statusroom")
+	drainHandshake(t, conn, crdt.New())
+
+	// Send tag 8 with flag=1.
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(8) // msgSyncStatus
+		enc.WriteVarUint(1) // applied
+	})))
+
+	// Connection must stay open — confirm via Ping/Pong round-trip.
+	sendPing(t, conn)
+	outerType, _ := readOne(t, conn, 2*time.Second)
+	assert.Equal(t, uint64(10), outerType,
+		"SyncStatus from a client must not affect liveness")
+}

--- a/provider/websocket/hocuspocus_test.go
+++ b/provider/websocket/hocuspocus_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/reearth/ygo/crdt"
 	"github.com/reearth/ygo/encoding"
 	ygws "github.com/reearth/ygo/provider/websocket"
+	ygsync "github.com/reearth/ygo/sync"
 )
 
 // Tests for #55 — Hocuspocus message types 4-10 routed through
@@ -62,16 +63,19 @@ func TestInteg_Hocuspocus_SyncReply_AppliesAndBroadcastsNoEcho(t *testing.T) {
 	drainHandshake(t, connA, docA)
 	drainHandshake(t, connB, docB)
 
-	// A produces a local update and wraps it as a SyncStep2-style payload,
-	// then sends it as msgSyncReply (tag 4) instead of msgSync (tag 0).
+	// A produces a local update and wraps it as a sync MsgUpdate payload
+	// (VarUint tag + VarBytes(update)), then sends it framed as
+	// msgSyncReply (tag 4) instead of msgSync (tag 0). SyncReply carries
+	// the same inner sync payload shapes as Sync — typically MsgUpdate or
+	// MsgSyncStep2 — but is dispatched without the auto step-1 echo back.
 	txt := docA.GetText("t")
 	docA.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
 	update := crdt.EncodeStateAsUpdateV1(docA, nil)
 
 	require.NoError(t, connA.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
-		enc.WriteVarUint(4)       // msgSyncReply
-		enc.WriteVarUint(2)       // syncStep2 marker
-		enc.WriteVarBytes(update) // update bytes
+		enc.WriteVarUint(4)                        // msgSyncReply
+		enc.WriteVarUint(uint64(ygsync.MsgUpdate)) // inner sync subtype
+		enc.WriteVarBytes(update)
 	})))
 
 	// B must receive the broadcast as a regular Sync (tag 0) frame.

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -62,6 +62,36 @@ type InjectInfo struct {
 // the caller.
 type InjectHook func(ctx context.Context, info InjectInfo) error
 
+// StatelessInfo is passed to Server.OnStateless when a Hocuspocus
+// Stateless (#55, tag 5) or BroadcastStateless (#55, tag 6) message
+// arrives from a peer. Additional fields may be added in future
+// versions; callers must not rely on the struct being fixed-size.
+type StatelessInfo struct {
+	// Room is the room name the message arrived on.
+	Room string
+	// Payload is the UTF-8 string carried by the stateless message.
+	// Empty payloads are valid (Hocuspocus does not require non-empty).
+	Payload string
+	// IsBroadcast reports whether the message arrived as
+	// BroadcastStateless (tag 6) rather than plain Stateless (tag 5).
+	// When true the server has already fanned the payload out to all
+	// other peers in the room as a Stateless (tag 5) frame by the time
+	// the hook fires.
+	IsBroadcast bool
+}
+
+// StatelessHook is called when a peer sends a Hocuspocus Stateless or
+// BroadcastStateless message. The hook is purely informational — it
+// runs after any broadcast fan-out has already happened and its return
+// value has no effect on the server. Use it to surface out-of-band
+// signals (Tiptap comments, custom presence metadata, application
+// heartbeats) to the embedding application.
+//
+// The hook is invoked on the peer's read goroutine; long-running work
+// should be dispatched to a separate goroutine to avoid blocking
+// subsequent message processing for that peer.
+type StatelessHook func(info StatelessInfo)
+
 // Error sentinels returned by BroadcastUpdate, Apply, and CloseRoom.
 // Callers should compare with errors.Is rather than ==.
 var (

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -75,6 +75,83 @@ func (p *peer) handleMessage(data []byte) {
 
 	case msgQueryAwareness:
 		p.sendAwareness(p.room.awareness.EncodeUpdate(nil))
+
+	case msgSyncReply:
+		// Hocuspocus tag 4 (#55). Same payload shape as msgSync but the
+		// sender explicitly does NOT want a reply — used by the original
+		// requester to apply a SyncStep2 without bouncing another step-1
+		// back, which would cause an infinite ping-pong on noisy links.
+		// Apply locally and broadcast updates, but never reply with our
+		// own step-1.
+		payload := dec.RemainingBytes()
+		if _, err := ygsync.ApplySyncMessage(p.room.doc, payload, p); err != nil {
+			return
+		}
+		p.broadcastSync(payload)
+
+	case msgStateless:
+		// Hocuspocus tag 5 (#55). Arbitrary out-of-band signal addressed
+		// to the server only (no broadcast). Surface to the embedding
+		// application via Server.OnStateless if configured.
+		payload, err := dec.ReadVarString()
+		if err != nil {
+			return
+		}
+		if hook := p.server.OnStateless; hook != nil {
+			hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: false})
+		}
+
+	case msgBroadcastStateless:
+		// Hocuspocus tag 6 (#55). Arbitrary out-of-band signal that the
+		// sender wants delivered to all other peers in the room. Re-emit
+		// as a plain Stateless (tag 5) frame so the receiving clients
+		// can dispatch it through the same handler they already use for
+		// server-originated stateless messages — matches Hocuspocus's
+		// behaviour where BroadcastStateless from one connection arrives
+		// at others as Stateless.
+		payload, err := dec.ReadVarString()
+		if err != nil {
+			return
+		}
+		p.broadcast(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+			enc.WriteVarUint(msgStateless)
+			enc.WriteVarString(payload)
+		}), true)
+		if hook := p.server.OnStateless; hook != nil {
+			hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: true})
+		}
+
+	case msgClose:
+		// Hocuspocus tag 7 (#55). Graceful close with an optional VarString
+		// reason. The reason is informational; the canonical Hocuspocus
+		// server discards it. We read it for the log line (best effort)
+		// and close the underlying connection. handleDisconnect will run
+		// when the read loop notices EOF.
+		reason, _ := dec.ReadVarString() // optional; silent on parse error
+		p.server.log().Info("peer requested close",
+			"room", p.roomName, "reason", reason)
+		_ = p.conn.Close()
+
+	case msgSyncStatus:
+		// Hocuspocus tag 8 (#55). Server→client ack carrying a single
+		// VarUint flag (1 = applied, 0 = rejected). If a client sends it
+		// to us, consume the payload silently — we don't track per-update
+		// delivery confirmations.
+		_, _ = dec.ReadVarUint()
+
+	case msgPing:
+		// Hocuspocus tag 9 (#55). Liveness check — reply with a single-byte
+		// Pong frame. (gorilla/websocket's protocol-level ping/pong is
+		// separate; Hocuspocus uses an application-level ping because some
+		// load balancers eat the protocol frames.)
+		p.write(encoding.EncodeBytes(func(enc *encoding.Encoder) {
+			enc.WriteVarUint(msgPong)
+		}))
+
+	case msgPong:
+		// Hocuspocus tag 10 (#55). Reply to a server-sent Ping. ygo does
+		// not currently send Pings, so this is a no-op pass-through that
+		// just keeps the dispatcher from dropping the frame.
 	}
 }
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -26,12 +26,31 @@ import (
 // a slow-reader from blocking the broadcast loop for all other peers.
 const writeTimeout = 10 * time.Second
 
-// Outer message type codes defined by y-protocols / y-websocket.
+// Outer message type codes. Tags 0-3 are the y-protocols / y-websocket
+// core; tags 4-10 are the Hocuspocus protocol extensions ygo accepts
+// from clients (#55). See the StatelessHook godoc for the application-
+// level contract on Stateless and BroadcastStateless.
+//
+// NOTE: Hocuspocus's framing prepends a VarString(docName) to every
+// frame so a single WebSocket connection can multiplex multiple
+// documents. ygo's framing is the y-websocket layout (tag + payload),
+// one document per connection. So ygo accepts the Hocuspocus message
+// TYPES on the existing y-websocket framing but does not implement
+// multi-document multiplexing.
 const (
 	msgSync           = uint64(0)
 	msgAwareness      = uint64(1)
 	msgAuth           = uint64(2) // y-websocket auth; silently ignored
 	msgQueryAwareness = uint64(3)
+
+	// Hocuspocus extensions, accepted on the y-websocket framing.
+	msgSyncReply          = uint64(4)  // SyncStep2 / Update that must NOT trigger a SyncStep1 reply
+	msgStateless          = uint64(5)  // arbitrary VarString payload, surfaced via Server.OnStateless
+	msgBroadcastStateless = uint64(6)  // VarString payload, fanned out to other peers as msgStateless
+	msgClose              = uint64(7)  // peer-requested graceful close (optional VarString reason)
+	msgSyncStatus         = uint64(8)  // server→client update-applied ack; if a client sends it, no-op consume
+	msgPing               = uint64(9)  // liveness check; replies with msgPong
+	msgPong               = uint64(10) // liveness reply to a server-sent Ping; no-op
 )
 
 // maxWSMessageBytes is the maximum size of a single WebSocket frame accepted
@@ -223,6 +242,15 @@ type Server struct {
 	// For BroadcastUpdate, InjectInfo.UpdateSize is len(update); for
 	// Apply it is 0 (the delta has not yet been produced).
 	OnInject InjectHook
+
+	// OnStateless, if non-nil, is called when a peer sends a Hocuspocus
+	// Stateless (tag 5) or BroadcastStateless (tag 6) message. The hook
+	// is purely informational — for BroadcastStateless the server has
+	// already fanned the payload out to other peers in the room by the
+	// time the hook fires. Use this to surface out-of-band signals
+	// (Tiptap comments, custom presence metadata, application heartbeats)
+	// to the embedding application.
+	OnStateless StatelessHook
 
 	// MaxUpdateBytes is the maximum size of a single V1 update that
 	// BroadcastUpdate will fan out, or that Apply will produce and


### PR DESCRIPTION
## Summary

First Hocuspocus-compatibility release. \`provider/websocket\` now accepts the seven additional message types Hocuspocus extends y-protocols with — Hocuspocus-aware clients (Tiptap stateless extensions, custom liveness pings, application close signals) no longer have their frames silently dropped.

## Message type handlers

| Tag | Message | Behaviour |
|---|---|---|
| 4 | \`SyncReply\` | Apply locally + broadcast to other peers, never echo to sender (breaks the SyncStep1 ping-pong loop). |
| 5 | \`Stateless\` | Fire \`Server.OnStateless\` with \`IsBroadcast: false\`. No broadcast. |
| 6 | \`BroadcastStateless\` | Fan out to other peers as \`Stateless\` (tag 5); fire \`Server.OnStateless\` with \`IsBroadcast: true\`. |
| 7 | \`CLOSE\` | Close the WebSocket; log the optional reason. |
| 8 | \`SyncStatus\` | Silently consume (server-to-client message). |
| 9 | \`Ping\` | Reply with single-byte \`Pong\` (tag 10). |
| 10 | \`Pong\` | Silently consume. |

## New public API

- \`Server.OnStateless StatelessHook\` — optional hook field.
- \`StatelessHook = func(StatelessInfo)\` — invoked on the peer's read goroutine.
- \`StatelessInfo\` — carries \`Room\`, \`Payload\`, \`IsBroadcast\`.

## Framing limitation (intentional, documented)

Hocuspocus's full client framing prepends \`VarString(docName)\` to every frame so one WebSocket can multiplex multiple documents. ygo's framing remains the y-websocket layout (tag + payload, one doc per WebSocket). This release adds the message **types** on the existing framing — Hocuspocus's multi-doc multiplex is a separate, larger architectural change not in scope here. Called out in the CHANGELOG and the godoc on the new constants.

## Test plan

- [x] 7 new integration tests in \`provider/websocket/hocuspocus_test.go\`, each exercising one tag end-to-end via real \`httptest\` WebSocket peers:
  - \`SyncReply\` apply + broadcast + no-echo
  - \`Stateless\` hook fires + no broadcast to other peers
  - \`BroadcastStateless\` fan-out as tag 5 + hook fires with \`IsBroadcast: true\`
  - \`Ping\` → \`Pong\` round trip
  - \`Pong\` silently consumed
  - \`CLOSE\` closes the connection
  - \`SyncStatus\` silently consumed
- [x] All existing websocket tests still pass
- [x] Full suite green (\`go test ./...\`)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go vet ./...\` — clean

Closes #55