### PR TITLE
feat(websocket+webhook): lifecycle hooks + new webhook subpackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] — 2026-05-28
+
+Second Hocuspocus-compatibility release. Adds the application-level extension points that production deployments need on top of v1.18.0's wire-protocol message types: per-room lifecycle hooks on the WebSocket server, and a new optional `provider/webhook` subpackage for forwarding events to external HTTP endpoints.
+
+### Added
+
+- **`provider/websocket` lifecycle hooks** (#60). Four new optional hook fields on `Server`:
+  - `OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error` — fires once per room after the persistence adapter has bootstrapped the doc, before any peer interacts. Returning a non-nil error fails room creation and propagates to the caller.
+  - `OnUnloadDocument func(ctx context.Context, room string)` — fires when a room is evicted from the server map (last-peer-leaves or `CloseRoom`).
+  - `OnFirstPeer func(room string)` — fires on the 0→1 peer transition; useful for warm-up tasks.
+  - `OnLastPeer func(room string)` — fires on the 1→0 peer transition; useful for cool-down tasks.
+  All hooks fire after server locks are released so they may block on I/O without contending with other peers. `OnLastPeer` fires before `OnUnloadDocument` when both apply.
+
+- **`provider/webhook` subpackage** (#61). New optional package that POSTs ygo events to a configurable HTTP endpoint:
+  - `webhook.Config` with `URL`, `Secret`, `Debounce`, `MaxRetries`, `BackoffBase`, `MaxBodyBytes`, `HTTPClient`.
+  - `webhook.New` / `webhook.Webhook.Enqueue` / `webhook.Webhook.Close`.
+  - HMAC-SHA256 request signing on every body, emitted as `X-YGo-Signature-256: sha256=<hex>`. `webhook.VerifySignature` for receivers; constant-time comparison.
+  - Debounce / coalescing window (default 1s, capped at 10s) — rapid same-room updates collapse into a single POST carrying the latest update bytes.
+  - Retry with exponential backoff (default 5 attempts, 250ms base) on transport errors and 5xx responses. 4xx drops immediately (receiver said no).
+  - `webhook.Event` shape with type / room / update bytes (base64 on the wire) / timestamp.
+  - `webhook.Close` drains pending events before returning; events enqueued after Close are silently dropped.
+
+### Internal
+
+- `Server.getOrCreateRoom` now takes a `context.Context` so `OnLoadDocument` receives a request-scoped ctx. Internal API change; no public callers affected.
+
 ## [1.18.0] — 2026-05-28
 
 First Hocuspocus compatibility release. `provider/websocket` now accepts the seven additional message types Hocuspocus extends y-protocols with, so Hocuspocus-aware clients (Tiptap stateless extensions, custom liveness pings, application close signals) no longer have their frames silently dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,20 @@ Second Hocuspocus-compatibility release. Adds the application-level extension po
 - **`provider/websocket` lifecycle hooks** (#60). Four new optional hook fields on `Server`:
   - `OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error` — fires once per room after the persistence adapter has bootstrapped the doc, before any peer interacts. Returning a non-nil error fails room creation and propagates to the caller. **Runs while the server room-map lock is held**, so implementations must return promptly; defer heavy I/O to a goroutine if needed. This mirrors `PersistenceAdapter.LoadDoc` which also runs under the same lock.
   - `OnUnloadDocument func(ctx context.Context, room string)` — fires when a room is evicted from the server map (last-peer-leaves or `CloseRoom`). Runs after all server locks are released; safe to block on I/O.
-  - `OnFirstPeer func(room string)` — fires on the 0→1 peer transition; useful for warm-up tasks. Runs after locks released.
-  - `OnLastPeer func(room string)` — fires on the 1→0 peer transition; useful for cool-down tasks. Runs after locks released. Fires before `OnUnloadDocument` when both apply.
+  - `OnFirstPeer func(ctx context.Context, room string)` — fires on the 0→1 peer transition; useful for warm-up tasks. Runs after locks released. `ctx` is the WebSocket request context.
+  - `OnLastPeer func(ctx context.Context, room string)` — fires on the 1→0 peer transition; useful for cool-down tasks. Runs after locks released. Fires before `OnUnloadDocument` when both apply.
+
+  All four hooks are panic-safe: a `recover()` wraps each invocation and logs the panic + stack at `Error` level via the server logger — a misbehaving hook can no longer crash the connection-handling or disposal goroutine.
 
 - **`provider/webhook` subpackage** (#61). New optional package that POSTs ygo events to a configurable HTTP endpoint:
-  - `webhook.Config` with `URL`, `Secret`, `Debounce`, `MaxRetries`, `BackoffBase`, `MaxBodyBytes`, `HTTPClient`.
+  - `webhook.Config` with `URL`, `Secret`, `Debounce`, `MaxRetries`, `BackoffBase`, `MaxBackoff`, `MaxBodyBytes`, `MaxConcurrentDeliveries`, `HTTPClient`, `Logger`.
   - `webhook.New` / `webhook.Webhook.Enqueue` / `webhook.Webhook.Close`.
+  - **`webhook.AttachTo(srv, wh) func()`** convenience that wires every relevant `Server` hook (`OnLoadDocument` → `EventLoad` + per-doc `OnUpdate` → `EventUpdate`; `OnUnloadDocument` → `EventUnload`; `OnFirstPeer` → `EventConnect`; `OnLastPeer` → `EventDisconnect`) in a single call. Returns an idempotent detach func that restores the previous hook values. Composes with any hooks the caller has already set.
   - HMAC-SHA256 request signing on every body, emitted as `X-YGo-Signature-256: sha256=<hex>`. `webhook.VerifySignature` for receivers; constant-time comparison.
-  - Debounce / coalescing window (default 1s, capped at 10s) — rapid same-room updates collapse into a single POST carrying the latest update bytes.
-  - Retry with exponential backoff (default 5 attempts, 250ms base) on transport errors and 5xx responses. 4xx drops immediately (receiver said no).
+  - Debounce / coalescing window (default 1s, capped at 10s) — rapid same-`(Room, Type)` events collapse into a single POST. Different event types for the same room never collapse into each other.
+  - Retry with exponential backoff (default 5 attempts, 250ms base, **capped at `MaxBackoff` (default 30s)**) on transport errors and 5xx responses. **±20% jitter** added to each retry sleep to defeat thundering-herd retry alignment when many concurrent webhooks fail against the same receiver. 4xx drops immediately.
+  - **Bounded delivery concurrency** via `MaxConcurrentDeliveries` (default 8) — a slow / dead receiver no longer accumulates unbounded delivery goroutines under burst load.
+  - **Single dispatcher goroutine** owns the debounce timer (replaces the previous `time.AfterFunc` + `Timer.Reset` pattern that allowed a queued firing to escape `Close`). Both `Close` and the dispatcher cooperate on a single `closed` channel for clean teardown.
   - `webhook.Event` shape with type / room / update bytes (base64 on the wire) / timestamp.
   - `webhook.Close` drains pending events before returning; events enqueued after Close are silently dropped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,10 @@ Second Hocuspocus-compatibility release. Adds the application-level extension po
 ### Added
 
 - **`provider/websocket` lifecycle hooks** (#60). Four new optional hook fields on `Server`:
-  - `OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error` — fires once per room after the persistence adapter has bootstrapped the doc, before any peer interacts. Returning a non-nil error fails room creation and propagates to the caller.
-  - `OnUnloadDocument func(ctx context.Context, room string)` — fires when a room is evicted from the server map (last-peer-leaves or `CloseRoom`).
-  - `OnFirstPeer func(room string)` — fires on the 0→1 peer transition; useful for warm-up tasks.
-  - `OnLastPeer func(room string)` — fires on the 1→0 peer transition; useful for cool-down tasks.
-  All hooks fire after server locks are released so they may block on I/O without contending with other peers. `OnLastPeer` fires before `OnUnloadDocument` when both apply.
+  - `OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error` — fires once per room after the persistence adapter has bootstrapped the doc, before any peer interacts. Returning a non-nil error fails room creation and propagates to the caller. **Runs while the server room-map lock is held**, so implementations must return promptly; defer heavy I/O to a goroutine if needed. This mirrors `PersistenceAdapter.LoadDoc` which also runs under the same lock.
+  - `OnUnloadDocument func(ctx context.Context, room string)` — fires when a room is evicted from the server map (last-peer-leaves or `CloseRoom`). Runs after all server locks are released; safe to block on I/O.
+  - `OnFirstPeer func(room string)` — fires on the 0→1 peer transition; useful for warm-up tasks. Runs after locks released.
+  - `OnLastPeer func(room string)` — fires on the 1→0 peer transition; useful for cool-down tasks. Runs after locks released. Fires before `OnUnloadDocument` when both apply.
 
 - **`provider/webhook` subpackage** (#61). New optional package that POSTs ygo events to a configurable HTTP endpoint:
   - `webhook.Config` with `URL`, `Secret`, `Debounce`, `MaxRetries`, `BackoffBase`, `MaxBodyBytes`, `HTTPClient`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,16 +10,20 @@ Four new optional hook fields on `Server`:
 |---|---|---|
 | `OnLoadDocument(ctx, room, doc) error` | After the persistence adapter has bootstrapped the doc, before any peer can interact. Returning an error fails room creation. | **Under the server room-map lock** (same as `PersistenceAdapter.LoadDoc`). Return promptly; defer heavy I/O to a goroutine. |
 | `OnUnloadDocument(ctx, room)` | Room is evicted from the server map (last-peer-leaves or `CloseRoom`). | After locks released; safe to block on I/O. |
-| `OnFirstPeer(room)` | 0→1 peer transition (warm-up tasks). | After locks released. |
-| `OnLastPeer(room)` | 1→0 peer transition (cool-down tasks). Fires before `OnUnloadDocument`. | After locks released. |
+| `OnFirstPeer(ctx, room)` | 0→1 peer transition (warm-up tasks). | After locks released. |
+| `OnLastPeer(ctx, room)` | 1→0 peer transition (cool-down tasks). Fires before `OnUnloadDocument`. | After locks released. |
+
+All four hooks are panic-safe: a `recover()` wraps each invocation and logs the panic + stack via the server logger.
 
 ### `provider/webhook` subpackage (#61)
 
 POSTs ygo document events to a configurable HTTP endpoint. Mirrors Hocuspocus's `extension-webhook`:
 
+- **`webhook.AttachTo(srv, wh)`** wires every relevant Server hook + per-doc `OnUpdate` in one call. Returns an idempotent detach func.
 - **HMAC-SHA256 signing** — every request carries `X-YGo-Signature-256: sha256=<hex>`. `webhook.VerifySignature` for receivers; constant-time comparison.
-- **Debounce / coalescing** — rapid same-room updates collapse into a single POST carrying the latest update bytes. Default 1s, capped at 10s.
-- **Retry with exponential backoff** — 5 attempts × 250ms base by default on 5xx and transport errors. 4xx drops immediately.
+- **Debounce / coalescing** — events with the same `(Room, Type)` pair collapse into a single POST. Different event types for the same room never collapse into each other.
+- **Retry with exponential backoff and jitter** — 5 attempts × 250ms base by default on 5xx and transport errors, capped at `MaxBackoff` (default 30s) with ±20% jitter to defeat thundering-herd retry alignment. 4xx drops immediately.
+- **Bounded delivery concurrency** — `MaxConcurrentDeliveries` (default 8) keeps a slow receiver from spawning unbounded goroutines under burst.
 - **Drain on Close** — `webhook.Close(ctx)` flushes pending events before returning; events enqueued after Close are silently dropped.
 
 ```go
@@ -30,14 +34,9 @@ wh, _ := webhook.New(webhook.Config{
 })
 defer wh.Close(context.Background())
 
-srv.OnLoadDocument = func(_ context.Context, room string, doc *crdt.Doc) error {
-    doc.OnUpdate(func(update []byte, _ any) {
-        wh.Enqueue(webhook.Event{
-            Type: webhook.EventUpdate, Room: room, Update: update,
-        })
-    })
-    return nil
-}
+srv := ygws.NewServer()
+detach := webhook.AttachTo(srv, wh) // wires Load/Update/Unload/Connect/Disconnect
+defer detach()
 ```
 
 ## Install

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,14 +6,12 @@ Second Hocuspocus-compatibility release. Closes out the server-side parity story
 
 Four new optional hook fields on `Server`:
 
-| Hook | Fires when |
-|---|---|
-| `OnLoadDocument(ctx, room, doc) error` | After the persistence adapter has bootstrapped the doc, before any peer can interact. Returning an error fails room creation. |
-| `OnUnloadDocument(ctx, room)` | Room is evicted from the server map (last-peer-leaves or `CloseRoom`). |
-| `OnFirstPeer(room)` | 0→1 peer transition (warm-up tasks). |
-| `OnLastPeer(room)` | 1→0 peer transition (cool-down tasks). Fires before `OnUnloadDocument`. |
-
-All hooks fire after server locks are released, so implementations may block on I/O without contending with other peers.
+| Hook | Fires when | Locking |
+|---|---|---|
+| `OnLoadDocument(ctx, room, doc) error` | After the persistence adapter has bootstrapped the doc, before any peer can interact. Returning an error fails room creation. | **Under the server room-map lock** (same as `PersistenceAdapter.LoadDoc`). Return promptly; defer heavy I/O to a goroutine. |
+| `OnUnloadDocument(ctx, room)` | Room is evicted from the server map (last-peer-leaves or `CloseRoom`). | After locks released; safe to block on I/O. |
+| `OnFirstPeer(room)` | 0→1 peer transition (warm-up tasks). | After locks released. |
+| `OnLastPeer(room)` | 1→0 peer transition (cool-down tasks). Fires before `OnUnloadDocument`. | After locks released. |
 
 ### `provider/webhook` subpackage (#61)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,51 @@
 ## What's new
 
-First Hocuspocus compatibility release. `provider/websocket` now accepts the seven additional message types Hocuspocus extends y-protocols with — so Hocuspocus-aware clients (Tiptap stateless extensions, custom liveness pings, application close signals) no longer have their frames silently dropped.
+Second Hocuspocus-compatibility release. Closes out the server-side parity story started in v1.18.0: lifecycle hooks for the WebSocket server, and a new optional `provider/webhook` subpackage for forwarding events to external HTTP endpoints.
 
-### Hocuspocus message types 4-10 (#55)
+### `provider/websocket` lifecycle hooks (#60)
 
-| Tag | Message | ygo behaviour |
-|---|---|---|
-| 4 | `SyncReply` | Apply locally, broadcast to other peers, never echo to sender. |
-| 5 | `Stateless` | Fire `Server.OnStateless` with `IsBroadcast: false`. No broadcast. |
-| 6 | `BroadcastStateless` | Fan out to other peers as `Stateless` (tag 5); fire `Server.OnStateless` with `IsBroadcast: true`. |
-| 7 | `CLOSE` | Close the WebSocket connection; log the optional reason. |
-| 8 | `SyncStatus` | Silently consume (server-to-client message). |
-| 9 | `Ping` | Reply with single-byte `Pong` (tag 10). |
-| 10 | `Pong` | Silently consume. |
+Four new optional hook fields on `Server`:
 
-### New public API
+| Hook | Fires when |
+|---|---|
+| `OnLoadDocument(ctx, room, doc) error` | After the persistence adapter has bootstrapped the doc, before any peer can interact. Returning an error fails room creation. |
+| `OnUnloadDocument(ctx, room)` | Room is evicted from the server map (last-peer-leaves or `CloseRoom`). |
+| `OnFirstPeer(room)` | 0→1 peer transition (warm-up tasks). |
+| `OnLastPeer(room)` | 1→0 peer transition (cool-down tasks). Fires before `OnUnloadDocument`. |
 
-- `Server.OnStateless StatelessHook` — optional hook on `provider/websocket.Server`.
-- `StatelessHook = func(StatelessInfo)` — invoked on the peer's read goroutine.
-- `StatelessInfo` — carries `Room`, `Payload`, `IsBroadcast`.
+All hooks fire after server locks are released, so implementations may block on I/O without contending with other peers.
 
-### Framing limitation (intentional)
+### `provider/webhook` subpackage (#61)
 
-Hocuspocus's full client framing prepends a `VarString(docName)` to every frame so one WebSocket can multiplex multiple documents. ygo's framing remains the y-websocket layout (tag + payload), one document per WebSocket. This release adds the Hocuspocus message **types** on the existing y-websocket framing; Hocuspocus's multi-doc multiplex is a separate, larger architectural change not in scope here.
+POSTs ygo document events to a configurable HTTP endpoint. Mirrors Hocuspocus's `extension-webhook`:
+
+- **HMAC-SHA256 signing** — every request carries `X-YGo-Signature-256: sha256=<hex>`. `webhook.VerifySignature` for receivers; constant-time comparison.
+- **Debounce / coalescing** — rapid same-room updates collapse into a single POST carrying the latest update bytes. Default 1s, capped at 10s.
+- **Retry with exponential backoff** — 5 attempts × 250ms base by default on 5xx and transport errors. 4xx drops immediately.
+- **Drain on Close** — `webhook.Close(ctx)` flushes pending events before returning; events enqueued after Close are silently dropped.
+
+```go
+wh, _ := webhook.New(webhook.Config{
+    URL:      "https://hooks.example.com/ygo",
+    Secret:   []byte("shared-secret"),
+    Debounce: time.Second,
+})
+defer wh.Close(context.Background())
+
+srv.OnLoadDocument = func(_ context.Context, room string, doc *crdt.Doc) error {
+    doc.OnUpdate(func(update []byte, _ any) {
+        wh.Enqueue(webhook.Event{
+            Type: webhook.EventUpdate, Room: room, Update: update,
+        })
+    })
+    return nil
+}
+```
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.18.0
+go get github.com/reearth/ygo@v1.19.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/provider/webhook/attach.go
+++ b/provider/webhook/attach.go
@@ -1,0 +1,91 @@
+package webhook
+
+import (
+	"context"
+
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// AttachTo wires every relevant Server lifecycle hook to wh so the
+// webhook receives one Event per significant happening on every room
+// the server hosts:
+//
+//   - OnLoadDocument   → EventLoad (and registers OnUpdate → EventUpdate
+//     for that room's doc, so subsequent updates also flow)
+//   - OnUnloadDocument → EventUnload
+//   - OnFirstPeer      → EventConnect (first peer in this active session)
+//   - OnLastPeer       → EventDisconnect (last peer in this active session)
+//
+// AttachTo returns an idempotent detach function that unwires the four
+// hooks. It does NOT unsubscribe per-doc OnUpdate listeners — those
+// stay attached for the lifetime of each doc, which matches Yjs's
+// "listeners outlive types" semantics.
+//
+// AttachTo cooperates with any existing OnLoadDocument the caller has
+// already set on srv: it captures the previous value and calls it
+// first, propagating any error. This keeps the helper composable with
+// application-specific load logic. The other three hooks (OnUnload,
+// OnFirstPeer, OnLastPeer) are simple void hooks, so they similarly
+// chain to any pre-existing handler.
+//
+// Typical usage:
+//
+//	srv := ygws.NewServer()
+//	wh, _ := webhook.New(webhook.Config{URL: "https://hooks.example.com"})
+//	defer wh.Close(context.Background())
+//	detach := webhook.AttachTo(srv, wh)
+//	defer detach()
+//
+// Use AttachTo to satisfy the Hocuspocus `extension-webhook` pattern
+// without writing the boilerplate for each event type (#61).
+func AttachTo(srv *ygws.Server, wh *Webhook) func() {
+	prevLoad := srv.OnLoadDocument
+	prevUnload := srv.OnUnloadDocument
+	prevFirst := srv.OnFirstPeer
+	prevLast := srv.OnLastPeer
+
+	srv.OnLoadDocument = func(ctx context.Context, room string, doc *crdt.Doc) error {
+		if prevLoad != nil {
+			if err := prevLoad(ctx, room, doc); err != nil {
+				return err
+			}
+		}
+		wh.Enqueue(Event{Type: EventLoad, Room: room})
+		// Subscribe per-doc update listener once at load time. The
+		// listener captures room by value so events emitted later carry
+		// the correct room name even after doc is reused.
+		doc.OnUpdate(func(update []byte, _ any) {
+			wh.Enqueue(Event{Type: EventUpdate, Room: room, Update: update})
+		})
+		return nil
+	}
+
+	srv.OnUnloadDocument = func(ctx context.Context, room string) {
+		if prevUnload != nil {
+			prevUnload(ctx, room)
+		}
+		wh.Enqueue(Event{Type: EventUnload, Room: room})
+	}
+
+	srv.OnFirstPeer = func(ctx context.Context, room string) {
+		if prevFirst != nil {
+			prevFirst(ctx, room)
+		}
+		wh.Enqueue(Event{Type: EventConnect, Room: room})
+	}
+
+	srv.OnLastPeer = func(ctx context.Context, room string) {
+		if prevLast != nil {
+			prevLast(ctx, room)
+		}
+		wh.Enqueue(Event{Type: EventDisconnect, Room: room})
+	}
+
+	return func() {
+		srv.OnLoadDocument = prevLoad
+		srv.OnUnloadDocument = prevUnload
+		srv.OnFirstPeer = prevFirst
+		srv.OnLastPeer = prevLast
+	}
+}

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -8,20 +8,18 @@
 //
 // # Usage
 //
-//	wh := webhook.New(webhook.Config{
-//	    URL:      "https://hooks.example.com/ygo",
-//	    Secret:   []byte("shared-secret-for-hmac"),
-//	    Debounce: 1 * time.Second,
-//	})
+// The easiest path is AttachTo, which wires every relevant Server hook
+// (OnLoadDocument, OnUnloadDocument, OnFirstPeer, OnLastPeer, and the
+// per-doc OnUpdate stream) onto the Webhook in one call:
+//
+//	wh, _ := webhook.New(webhook.Config{URL: "https://hooks.example.com/ygo"})
 //	defer wh.Close(context.Background())
 //
 //	srv := ygws.NewServer()
-//	srv.OnLoadDocument = func(_ context.Context, room string, doc *crdt.Doc) error {
-//	    doc.OnUpdate(func(update []byte, _ any) {
-//	        wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: room, Update: update})
-//	    })
-//	    return nil
-//	}
+//	detach := webhook.AttachTo(srv, wh)
+//	defer detach()
+//
+// For finer control, drive the Webhook directly via Enqueue.
 //
 // # Signature
 //
@@ -36,8 +34,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -106,10 +106,22 @@ type Config struct {
 	// BackoffBase is the first retry delay; each subsequent attempt
 	// doubles the delay. Zero uses the default (250 * time.Millisecond).
 	BackoffBase time.Duration
+	// MaxBackoff caps the per-attempt sleep, defending against very high
+	// MaxRetries producing minute-scale waits. Zero uses the default
+	// (30 * time.Second). Up to ±20% jitter is added on top of the
+	// computed delay to break thundering-herd retry alignment when
+	// many concurrent webhooks fail against the same receiver.
+	MaxBackoff time.Duration
 	// MaxBodyBytes caps the size of a single POST body. Zero uses the
 	// default (16 MiB). Events whose JSON encoding exceeds this size
 	// are dropped with a logged warning.
 	MaxBodyBytes int64
+	// MaxConcurrentDeliveries bounds the number of in-flight POSTs at
+	// any one time. Zero uses the default (8). A burst of pending
+	// events past this cap blocks the dispatch loop until in-flight
+	// deliveries finish — preventing unbounded goroutine creation when
+	// a slow / dead receiver collects a long queue.
+	MaxConcurrentDeliveries int
 	// HTTPClient is the http.Client used for outbound requests. Zero
 	// value uses a default client with a 10-second per-request timeout.
 	HTTPClient *http.Client
@@ -119,12 +131,15 @@ type Config struct {
 }
 
 const (
-	defaultDebounce     = 1 * time.Second
-	maxDebounce         = 10 * time.Second
-	defaultMaxRetries   = 5
-	defaultBackoffBase  = 250 * time.Millisecond
-	defaultMaxBodyBytes = 16 << 20 // 16 MiB
-	defaultHTTPTimeout  = 10 * time.Second
+	defaultDebounce           = 1 * time.Second
+	maxDebounce               = 10 * time.Second
+	defaultMaxRetries         = 5
+	defaultBackoffBase        = 250 * time.Millisecond
+	defaultMaxBackoff         = 30 * time.Second
+	defaultMaxBodyBytes       = 16 << 20 // 16 MiB
+	defaultMaxConcurrent      = 8
+	defaultHTTPTimeout        = 10 * time.Second
+	jitterFractionDenominator = 5 // ±20% of the computed backoff
 
 	// SignatureHeader is the HTTP request header that carries the
 	// HMAC-SHA256 signature of the body when Config.Secret is set.
@@ -136,28 +151,40 @@ const (
 // EventType — without the type discriminator a Connect followed by an
 // Update for the same room would lose the Update (or vice-versa).
 type pendingKey struct {
-	Room string
-	Type EventType
+	room      string
+	eventType EventType
 }
 
 // Webhook is a running webhook delivery worker. Construct with New, push
 // events with Enqueue, and call Close when done.
+//
+// Internally a single dispatcher goroutine owns the pending map and the
+// debounce timer (avoids the Timer.Reset semantics that previously
+// allowed a queued AfterFunc to fire after Close, see #93 self-review
+// C1/C2). Delivery goroutines are bounded by Config.MaxConcurrentDeliveries.
 type Webhook struct {
 	cfg Config
 
-	mu       sync.Mutex
-	pending  map[pendingKey]*Event // (room, type) → most-recent debounced event
-	timer    *time.Timer           // fires when the next debounce window expires
-	deadline time.Time             // when the current debounce window expires
+	mu      sync.Mutex
+	pending map[pendingKey]*Event
+
+	// wake is signalled (non-blocking) by Enqueue whenever the pending
+	// set transitions from empty → non-empty, prompting the dispatcher
+	// to (re)start the debounce timer. The dispatcher reads at most one
+	// value per debounce tick.
+	wake chan struct{}
+
+	// deliverSem bounds in-flight POSTs to MaxConcurrentDeliveries.
+	deliverSem chan struct{}
 
 	wg     sync.WaitGroup
-	closed chan struct{} // closed by Close to signal the flush goroutine to exit
+	closed chan struct{} // closed by Close to signal teardown
 }
 
-// New constructs a Webhook from cfg. The returned Webhook owns a small
-// pool of goroutines for debounce timing and retry; call Close to release.
+// New constructs a Webhook from cfg and starts its dispatcher goroutine.
+// Call Close to release.
 //
-// Returns an error if cfg.URL is empty or not http/https.
+// Returns an error if cfg.URL is empty.
 func New(cfg Config) (*Webhook, error) {
 	if cfg.URL == "" {
 		return nil, errors.New("webhook: Config.URL is required")
@@ -174,8 +201,14 @@ func New(cfg Config) (*Webhook, error) {
 	if cfg.BackoffBase == 0 {
 		cfg.BackoffBase = defaultBackoffBase
 	}
+	if cfg.MaxBackoff == 0 {
+		cfg.MaxBackoff = defaultMaxBackoff
+	}
 	if cfg.MaxBodyBytes == 0 {
 		cfg.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if cfg.MaxConcurrentDeliveries <= 0 {
+		cfg.MaxConcurrentDeliveries = defaultMaxConcurrent
 	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{Timeout: defaultHTTPTimeout}
@@ -183,11 +216,17 @@ func New(cfg Config) (*Webhook, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-	return &Webhook{
-		cfg:     cfg,
-		pending: make(map[pendingKey]*Event),
-		closed:  make(chan struct{}),
-	}, nil
+
+	w := &Webhook{
+		cfg:        cfg,
+		pending:    make(map[pendingKey]*Event),
+		wake:       make(chan struct{}, 1),
+		deliverSem: make(chan struct{}, cfg.MaxConcurrentDeliveries),
+		closed:     make(chan struct{}),
+	}
+	w.wg.Add(1)
+	go w.dispatchLoop()
+	return w, nil
 }
 
 // Enqueue submits an event for delivery. Events are coalesced by the
@@ -197,65 +236,112 @@ func New(cfg Config) (*Webhook, error) {
 // produces two separate POSTs (one Connect, one Update) — only same-
 // type same-room events get coalesced, so distinct event categories
 // never overwrite each other.
+//
+// Enqueue on a closed Webhook silently drops the event.
 func (w *Webhook) Enqueue(e Event) {
 	if e.Timestamp.IsZero() {
 		e.Timestamp = time.Now()
 	}
 
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	// Closed Webhook silently drops new events (Close docs this).
 	select {
 	case <-w.closed:
+		w.mu.Unlock()
 		return
 	default:
 	}
+	w.pending[pendingKey{room: e.Room, eventType: e.Type}] = &e
+	w.mu.Unlock()
 
-	w.pending[pendingKey{Room: e.Room, Type: e.Type}] = &e
-
-	// Start / restart the debounce timer.
-	w.deadline = time.Now().Add(w.cfg.Debounce)
-	if w.timer == nil {
-		w.timer = time.AfterFunc(w.cfg.Debounce, w.flush)
-	} else {
-		w.timer.Reset(w.cfg.Debounce)
+	// Non-blocking signal: the dispatcher reads at most once per tick.
+	select {
+	case w.wake <- struct{}{}:
+	default:
 	}
 }
 
-// flush is fired by the debounce timer. It snapshots the pending
-// events and dispatches each in its own goroutine (one inflight HTTP
-// call per pending room). Subsequent Enqueues build a new pending set.
-func (w *Webhook) flush() {
+// dispatchLoop is the single goroutine that owns the debounce timer.
+// Replacing the previous AfterFunc + Timer.Reset structure with a single
+// dedicated goroutine eliminates the race where a queued AfterFunc fires
+// after Close returns (#93 self-review C1, C2) — here the only exit path
+// is Close → close(w.closed), which both stops any in-flight timer and
+// guarantees no further dispatches.
+func (w *Webhook) dispatchLoop() {
+	defer w.wg.Done()
+	var timer *time.Timer
+	for {
+		// Wait for either a wake (queue non-empty), close, or the
+		// debounce timer firing.
+		var timerC <-chan time.Time
+		if timer != nil {
+			timerC = timer.C
+		}
+		select {
+		case <-w.closed:
+			if timer != nil {
+				timer.Stop()
+			}
+			// Final drain pass so anything still pending when Close was
+			// called gets one last delivery attempt before Close's
+			// wg.Wait returns.
+			w.drainAndDeliver()
+			return
+		case <-w.wake:
+			// Start the debounce timer if not already running.
+			if timer == nil {
+				timer = time.NewTimer(w.cfg.Debounce)
+			}
+		case <-timerC:
+			timer = nil
+			w.drainAndDeliver()
+		}
+	}
+}
+
+// drainAndDeliver moves all pending events to a local batch and dispatches
+// each. Delivery goroutines obey the MaxConcurrentDeliveries semaphore so
+// a slow receiver cannot accumulate unbounded goroutines.
+func (w *Webhook) drainAndDeliver() {
 	w.mu.Lock()
 	if len(w.pending) == 0 {
 		w.mu.Unlock()
 		return
 	}
-	batch := make([]*Event, 0, len(w.pending))
+	batch := make([]Event, 0, len(w.pending))
 	for _, e := range w.pending {
-		batch = append(batch, e)
+		batch = append(batch, *e)
 	}
 	w.pending = make(map[pendingKey]*Event)
 	w.mu.Unlock()
 
-	for _, e := range batch {
+	for _, ev := range batch {
+		// Acquire a delivery slot. Block on close to avoid spawning new
+		// deliveries after Close, but otherwise let bursty workloads back
+		// up here rather than at the goroutine count.
+		select {
+		case w.deliverSem <- struct{}{}:
+		case <-w.closed:
+			return
+		}
 		w.wg.Add(1)
-		go func(ev *Event) {
-			defer w.wg.Done()
-			w.deliver(*ev)
-		}(e)
+		go func(e Event) {
+			defer func() {
+				<-w.deliverSem
+				w.wg.Done()
+			}()
+			w.deliver(e)
+		}(ev)
 	}
 }
 
 // deliver serialises one event to JSON, signs it, and POSTs it with
 // bounded retry. Drop policy: 4xx → no retry (receiver said no); 5xx
-// and transport errors retry up to MaxRetries with exponential backoff.
-// Body too large → drop immediately with a logged warning.
+// and transport errors retry up to MaxRetries with exponential backoff
+// capped at MaxBackoff, with ±20% jitter. Body too large → drop
+// immediately with a logged warning.
 func (w *Webhook) deliver(e Event) {
 	body, err := json.Marshal(e)
 	if err != nil {
-		// json.Marshal failing on our own struct is a programming bug.
 		w.cfg.Logger.Error("webhook: marshal failed; event dropped",
 			"room", e.Room, "type", e.Type, "err", err)
 		return
@@ -277,12 +363,16 @@ func (w *Webhook) deliver(e Event) {
 	backoff := w.cfg.BackoffBase
 	for attempt := 0; attempt < w.cfg.MaxRetries; attempt++ {
 		if attempt > 0 {
+			sleep := backoff + jitter(backoff)
 			select {
-			case <-time.After(backoff):
+			case <-time.After(sleep):
 			case <-w.closed:
-				return // give up on shutdown
+				return // abort on shutdown
 			}
 			backoff *= 2
+			if backoff > w.cfg.MaxBackoff {
+				backoff = w.cfg.MaxBackoff
+			}
 		}
 
 		retry, ok := w.postOnce(body, sig)
@@ -293,10 +383,30 @@ func (w *Webhook) deliver(e Event) {
 			return // 4xx — receiver rejected, no retry
 		}
 	}
-	// Exceeded MaxRetries; drop.
 	w.cfg.Logger.Warn("webhook: retry budget exhausted; event dropped",
 		"room", e.Room, "type", e.Type,
 		"url", w.cfg.URL, "attempts", w.cfg.MaxRetries)
+}
+
+// jitter returns a duration in [-d/5, +d/5] sourced from crypto/rand so
+// concurrent webhooks don't lock-step their retries against a struggling
+// receiver. crypto/rand keeps the jitter unbiased even when called from
+// many goroutines simultaneously — math/rand would need a lock or a
+// per-goroutine source.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	span := int64(d) / jitterFractionDenominator
+	if span <= 0 {
+		return 0
+	}
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0 // jitter is an optimisation; failure is non-fatal
+	}
+	u := binary.LittleEndian.Uint64(b[:]) & 0x7FFFFFFFFFFFFFFF // strip sign bit
+	return time.Duration(int64(u%uint64(2*span)) - span)
 }
 
 // postOnce performs a single POST attempt. Returns (retry, ok) where
@@ -304,7 +414,7 @@ func (w *Webhook) deliver(e Event) {
 func (w *Webhook) postOnce(body []byte, sig string) (retry, ok bool) {
 	req, err := http.NewRequest(http.MethodPost, w.cfg.URL, bytes.NewReader(body))
 	if err != nil {
-		return false, false // malformed URL — no retry, no success
+		return false, false
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if sig != "" {
@@ -321,15 +431,15 @@ func (w *Webhook) postOnce(body []byte, sig string) (retry, ok bool) {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return false, true
 	case resp.StatusCode >= 500:
-		return true, false // server error — retry
+		return true, false
 	default:
-		return false, false // 4xx — receiver said no, no retry
+		return false, false
 	}
 }
 
-// Close stops accepting new events, fires any pending debounce-window
-// events synchronously, and waits for in-flight deliveries to finish or
-// for ctx to cancel.
+// Close stops accepting new events, fires any pending events
+// synchronously, and waits for in-flight deliveries to finish or for
+// ctx to cancel.
 //
 // After Close returns, calls to Enqueue silently drop the event.
 func (w *Webhook) Close(ctx context.Context) error {
@@ -337,17 +447,11 @@ func (w *Webhook) Close(ctx context.Context) error {
 	select {
 	case <-w.closed:
 		w.mu.Unlock()
-		return nil // already closed
+		return nil
 	default:
 	}
 	close(w.closed)
-	if w.timer != nil {
-		w.timer.Stop()
-	}
 	w.mu.Unlock()
-
-	// Drain whatever was in the pending set at Close time.
-	w.flush()
 
 	done := make(chan struct{})
 	go func() { w.wg.Wait(); close(done) }()
@@ -361,7 +465,7 @@ func (w *Webhook) Close(ctx context.Context) error {
 
 // EncodeBody is a low-level helper that returns the exact JSON body the
 // Webhook would POST for the given event, including the auto-populated
-// Timestamp. Exported so test code (and downstream tooling) can verify
+// Timestamp. Exported so test code and downstream tooling can verify
 // signatures without spinning up a Webhook.
 func EncodeBody(e Event) ([]byte, error) {
 	if e.Timestamp.IsZero() {

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -42,6 +42,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -90,11 +91,12 @@ type Config struct {
 	// If empty, no signature header is emitted (suitable only for
 	// trusted internal networks).
 	Secret []byte
-	// Debounce is the window within which consecutive Update events
-	// for the same room are coalesced into a single delivery carrying
-	// the most recent update. Zero disables debounce; the default
-	// (1 * time.Second) is applied when Config.Debounce is unset.
-	// Capped at 10 * time.Second to prevent runaway buffering.
+	// Debounce is the window within which consecutive events with the
+	// same (Room, Type) are coalesced into a single delivery carrying
+	// the most-recent event. Zero applies the default (1 * time.Second);
+	// values above 10 * time.Second are capped at the maximum to prevent
+	// runaway buffering. There is no way to disable debounce — Enqueue
+	// is always at least minimally batched.
 	Debounce time.Duration
 	// MaxRetries is the number of delivery attempts before the event
 	// is dropped on transient failure. Zero uses the default (5).
@@ -111,6 +113,9 @@ type Config struct {
 	// HTTPClient is the http.Client used for outbound requests. Zero
 	// value uses a default client with a 10-second per-request timeout.
 	HTTPClient *http.Client
+	// Logger receives structured log entries when events are dropped
+	// for size or retry exhaustion. nil falls back to slog.Default().
+	Logger *slog.Logger
 }
 
 const (
@@ -126,15 +131,24 @@ const (
 	SignatureHeader = "X-YGo-Signature-256"
 )
 
+// pendingKey identifies a coalescing bucket. Two events in the same
+// window collapse only when they target the same room AND have the same
+// EventType — without the type discriminator a Connect followed by an
+// Update for the same room would lose the Update (or vice-versa).
+type pendingKey struct {
+	Room string
+	Type EventType
+}
+
 // Webhook is a running webhook delivery worker. Construct with New, push
 // events with Enqueue, and call Close when done.
 type Webhook struct {
 	cfg Config
 
 	mu       sync.Mutex
-	pending  map[string]*Event // room → most-recent debounced event
-	timer    *time.Timer       // fires when the next debounce window expires
-	deadline time.Time         // when the current debounce window expires
+	pending  map[pendingKey]*Event // (room, type) → most-recent debounced event
+	timer    *time.Timer           // fires when the next debounce window expires
+	deadline time.Time             // when the current debounce window expires
 
 	wg     sync.WaitGroup
 	closed chan struct{} // closed by Close to signal the flush goroutine to exit
@@ -166,18 +180,23 @@ func New(cfg Config) (*Webhook, error) {
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
 	return &Webhook{
 		cfg:     cfg,
-		pending: make(map[string]*Event),
+		pending: make(map[pendingKey]*Event),
 		closed:  make(chan struct{}),
 	}, nil
 }
 
-// Enqueue submits an event for delivery. EventUpdate events with the
-// same Room name within the debounce window are coalesced: only the
-// most recent update bytes survive. Other event types are not
-// coalesced and dispatch on the next debounce tick alongside any
-// pending updates.
+// Enqueue submits an event for delivery. Events are coalesced by the
+// pair (Room, Type): two events in the same debounce window with the
+// same room AND same event type collapse to the most-recent one. A
+// Connect followed by an Update for the same room in the same window
+// produces two separate POSTs (one Connect, one Update) — only same-
+// type same-room events get coalesced, so distinct event categories
+// never overwrite each other.
 func (w *Webhook) Enqueue(e Event) {
 	if e.Timestamp.IsZero() {
 		e.Timestamp = time.Now()
@@ -193,9 +212,7 @@ func (w *Webhook) Enqueue(e Event) {
 	default:
 	}
 
-	// Coalesce by room: most recent wins. (Even for non-Update events
-	// the latest within a window is what we deliver — simpler model.)
-	w.pending[e.Room] = &e
+	w.pending[pendingKey{Room: e.Room, Type: e.Type}] = &e
 
 	// Start / restart the debounce timer.
 	w.deadline = time.Now().Add(w.cfg.Debounce)
@@ -219,7 +236,7 @@ func (w *Webhook) flush() {
 	for _, e := range w.pending {
 		batch = append(batch, e)
 	}
-	w.pending = make(map[string]*Event)
+	w.pending = make(map[pendingKey]*Event)
 	w.mu.Unlock()
 
 	for _, e := range batch {
@@ -238,11 +255,15 @@ func (w *Webhook) flush() {
 func (w *Webhook) deliver(e Event) {
 	body, err := json.Marshal(e)
 	if err != nil {
-		// json.Marshal failing on our own struct is a programming bug, not
-		// a transient error — surface but don't retry.
+		// json.Marshal failing on our own struct is a programming bug.
+		w.cfg.Logger.Error("webhook: marshal failed; event dropped",
+			"room", e.Room, "type", e.Type, "err", err)
 		return
 	}
 	if int64(len(body)) > w.cfg.MaxBodyBytes {
+		w.cfg.Logger.Warn("webhook: event body exceeds MaxBodyBytes; dropped",
+			"room", e.Room, "type", e.Type,
+			"bodyBytes", len(body), "maxBodyBytes", w.cfg.MaxBodyBytes)
 		return
 	}
 
@@ -273,6 +294,9 @@ func (w *Webhook) deliver(e Event) {
 		}
 	}
 	// Exceeded MaxRetries; drop.
+	w.cfg.Logger.Warn("webhook: retry budget exhausted; event dropped",
+		"room", e.Room, "type", e.Type,
+		"url", w.cfg.URL, "attempts", w.cfg.MaxRetries)
 }
 
 // postOnce performs a single POST attempt. Returns (retry, ok) where

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -41,9 +41,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 )
@@ -184,10 +186,26 @@ type Webhook struct {
 // New constructs a Webhook from cfg and starts its dispatcher goroutine.
 // Call Close to release.
 //
-// Returns an error if cfg.URL is empty.
+// Returns an error if cfg.URL is empty, unparseable, missing a host,
+// or uses a scheme other than http / https. Validating up front means
+// construction fails fast rather than every delivery silently dropping
+// later at request build time.
 func New(cfg Config) (*Webhook, error) {
 	if cfg.URL == "" {
 		return nil, errors.New("webhook: Config.URL is required")
+	}
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("webhook: Config.URL is not a valid URL: %w", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+		// ok
+	default:
+		return nil, fmt.Errorf("webhook: Config.URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, errors.New("webhook: Config.URL is missing a host")
 	}
 	if cfg.Debounce == 0 {
 		cfg.Debounce = defaultDebounce
@@ -301,6 +319,20 @@ func (w *Webhook) dispatchLoop() {
 // drainAndDeliver moves all pending events to a local batch and dispatches
 // each. Delivery goroutines obey the MaxConcurrentDeliveries semaphore so
 // a slow receiver cannot accumulate unbounded goroutines.
+//
+// wg.Add is performed in a single batch call under w.mu — the same lock
+// Close acquires before signalling close(w.closed). This ordering means
+// the WaitGroup counter has already been incremented before Close can
+// reach its wg.Wait, eliminating the "Add called concurrently with Wait"
+// runtime check failure.
+//
+// There is intentionally NO <-w.closed bail in the inner sem-acquire
+// loop: when this is called from the post-Close final-drain path (the
+// dispatcher's <-w.closed case), w.closed is already closed and a bail
+// would silently drop every pending event. The deliverSem still bounds
+// concurrency; the dispatcher waits for in-flight deliveries to finish
+// before exiting, and deliver itself checks <-w.closed during its retry
+// sleep to exit fast on shutdown.
 func (w *Webhook) drainAndDeliver() {
 	w.mu.Lock()
 	if len(w.pending) == 0 {
@@ -312,18 +344,11 @@ func (w *Webhook) drainAndDeliver() {
 		batch = append(batch, *e)
 	}
 	w.pending = make(map[pendingKey]*Event)
+	w.wg.Add(len(batch))
 	w.mu.Unlock()
 
 	for _, ev := range batch {
-		// Acquire a delivery slot. Block on close to avoid spawning new
-		// deliveries after Close, but otherwise let bursty workloads back
-		// up here rather than at the goroutine count.
-		select {
-		case w.deliverSem <- struct{}{}:
-		case <-w.closed:
-			return
-		}
-		w.wg.Add(1)
+		w.deliverSem <- struct{}{}
 		go func(e Event) {
 			defer func() {
 				<-w.deliverSem

--- a/provider/webhook/webhook.go
+++ b/provider/webhook/webhook.go
@@ -1,0 +1,376 @@
+// Package webhook posts ygo document events to an external HTTP endpoint
+// with HMAC-SHA256 request signing, debounce / coalescing of consecutive
+// updates, and bounded retry-with-exponential-backoff on transient errors.
+//
+// Mirrors the Hocuspocus `extension-webhook` integration pattern (#61).
+// Useful for forwarding doc events to Slack / Teams, audit logs, downstream
+// AI workflows, search index pipelines, no-code platforms, etc.
+//
+// # Usage
+//
+//	wh := webhook.New(webhook.Config{
+//	    URL:      "https://hooks.example.com/ygo",
+//	    Secret:   []byte("shared-secret-for-hmac"),
+//	    Debounce: 1 * time.Second,
+//	})
+//	defer wh.Close(context.Background())
+//
+//	srv := ygws.NewServer()
+//	srv.OnLoadDocument = func(_ context.Context, room string, doc *crdt.Doc) error {
+//	    doc.OnUpdate(func(update []byte, _ any) {
+//	        wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: room, Update: update})
+//	    })
+//	    return nil
+//	}
+//
+// # Signature
+//
+// Every POST carries an `X-YGo-Signature-256` header of the form
+// `sha256=<hex>` where `<hex>` is the HMAC-SHA256 of the request body using
+// Config.Secret as the key. Receivers should reject requests whose
+// signature does not match the body — defends against forged events when
+// the URL is exposed to the open internet.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// EventType is the kind of event delivered by the webhook.
+type EventType string
+
+const (
+	// EventUpdate fires for every committed document update. The Update
+	// field carries the V1 update bytes (base64-encoded on the wire).
+	EventUpdate EventType = "update"
+	// EventConnect fires when a peer connects to a room (one event per
+	// peer per room).
+	EventConnect EventType = "connect"
+	// EventDisconnect fires when a peer disconnects from a room.
+	EventDisconnect EventType = "disconnect"
+	// EventLoad fires when a room is loaded into memory (the first peer
+	// joins, or Apply / BroadcastUpdate creates it).
+	EventLoad EventType = "load"
+	// EventUnload fires when a room is evicted from memory (last peer
+	// leaves, or CloseRoom is called).
+	EventUnload EventType = "unload"
+)
+
+// Event is a single ygo event delivered to the webhook URL.
+type Event struct {
+	// Type identifies what happened.
+	Type EventType `json:"type"`
+	// Room is the room name the event applies to.
+	Room string `json:"room"`
+	// Update is the V1 update bytes for EventUpdate (nil for other types).
+	// Encoded as base64 on the wire.
+	Update []byte `json:"update,omitempty"`
+	// Timestamp is the time the event was enqueued, in RFC3339Nano.
+	// Set automatically by Enqueue; callers should not pre-populate it.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Config configures a Webhook. URL is required; all other fields have
+// sensible defaults.
+type Config struct {
+	// URL is the destination endpoint. Must be HTTP or HTTPS.
+	URL string
+	// Secret is the HMAC-SHA256 key used to sign every request body.
+	// If empty, no signature header is emitted (suitable only for
+	// trusted internal networks).
+	Secret []byte
+	// Debounce is the window within which consecutive Update events
+	// for the same room are coalesced into a single delivery carrying
+	// the most recent update. Zero disables debounce; the default
+	// (1 * time.Second) is applied when Config.Debounce is unset.
+	// Capped at 10 * time.Second to prevent runaway buffering.
+	Debounce time.Duration
+	// MaxRetries is the number of delivery attempts before the event
+	// is dropped on transient failure. Zero uses the default (5).
+	// Status codes 200-299 succeed; 5xx and network errors retry with
+	// exponential backoff; 4xx drops immediately (the receiver said no).
+	MaxRetries int
+	// BackoffBase is the first retry delay; each subsequent attempt
+	// doubles the delay. Zero uses the default (250 * time.Millisecond).
+	BackoffBase time.Duration
+	// MaxBodyBytes caps the size of a single POST body. Zero uses the
+	// default (16 MiB). Events whose JSON encoding exceeds this size
+	// are dropped with a logged warning.
+	MaxBodyBytes int64
+	// HTTPClient is the http.Client used for outbound requests. Zero
+	// value uses a default client with a 10-second per-request timeout.
+	HTTPClient *http.Client
+}
+
+const (
+	defaultDebounce     = 1 * time.Second
+	maxDebounce         = 10 * time.Second
+	defaultMaxRetries   = 5
+	defaultBackoffBase  = 250 * time.Millisecond
+	defaultMaxBodyBytes = 16 << 20 // 16 MiB
+	defaultHTTPTimeout  = 10 * time.Second
+
+	// SignatureHeader is the HTTP request header that carries the
+	// HMAC-SHA256 signature of the body when Config.Secret is set.
+	SignatureHeader = "X-YGo-Signature-256"
+)
+
+// Webhook is a running webhook delivery worker. Construct with New, push
+// events with Enqueue, and call Close when done.
+type Webhook struct {
+	cfg Config
+
+	mu       sync.Mutex
+	pending  map[string]*Event // room → most-recent debounced event
+	timer    *time.Timer       // fires when the next debounce window expires
+	deadline time.Time         // when the current debounce window expires
+
+	wg     sync.WaitGroup
+	closed chan struct{} // closed by Close to signal the flush goroutine to exit
+}
+
+// New constructs a Webhook from cfg. The returned Webhook owns a small
+// pool of goroutines for debounce timing and retry; call Close to release.
+//
+// Returns an error if cfg.URL is empty or not http/https.
+func New(cfg Config) (*Webhook, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("webhook: Config.URL is required")
+	}
+	if cfg.Debounce == 0 {
+		cfg.Debounce = defaultDebounce
+	}
+	if cfg.Debounce > maxDebounce {
+		cfg.Debounce = maxDebounce
+	}
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = defaultMaxRetries
+	}
+	if cfg.BackoffBase == 0 {
+		cfg.BackoffBase = defaultBackoffBase
+	}
+	if cfg.MaxBodyBytes == 0 {
+		cfg.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Webhook{
+		cfg:     cfg,
+		pending: make(map[string]*Event),
+		closed:  make(chan struct{}),
+	}, nil
+}
+
+// Enqueue submits an event for delivery. EventUpdate events with the
+// same Room name within the debounce window are coalesced: only the
+// most recent update bytes survive. Other event types are not
+// coalesced and dispatch on the next debounce tick alongside any
+// pending updates.
+func (w *Webhook) Enqueue(e Event) {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now()
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Closed Webhook silently drops new events (Close docs this).
+	select {
+	case <-w.closed:
+		return
+	default:
+	}
+
+	// Coalesce by room: most recent wins. (Even for non-Update events
+	// the latest within a window is what we deliver — simpler model.)
+	w.pending[e.Room] = &e
+
+	// Start / restart the debounce timer.
+	w.deadline = time.Now().Add(w.cfg.Debounce)
+	if w.timer == nil {
+		w.timer = time.AfterFunc(w.cfg.Debounce, w.flush)
+	} else {
+		w.timer.Reset(w.cfg.Debounce)
+	}
+}
+
+// flush is fired by the debounce timer. It snapshots the pending
+// events and dispatches each in its own goroutine (one inflight HTTP
+// call per pending room). Subsequent Enqueues build a new pending set.
+func (w *Webhook) flush() {
+	w.mu.Lock()
+	if len(w.pending) == 0 {
+		w.mu.Unlock()
+		return
+	}
+	batch := make([]*Event, 0, len(w.pending))
+	for _, e := range w.pending {
+		batch = append(batch, e)
+	}
+	w.pending = make(map[string]*Event)
+	w.mu.Unlock()
+
+	for _, e := range batch {
+		w.wg.Add(1)
+		go func(ev *Event) {
+			defer w.wg.Done()
+			w.deliver(*ev)
+		}(e)
+	}
+}
+
+// deliver serialises one event to JSON, signs it, and POSTs it with
+// bounded retry. Drop policy: 4xx → no retry (receiver said no); 5xx
+// and transport errors retry up to MaxRetries with exponential backoff.
+// Body too large → drop immediately with a logged warning.
+func (w *Webhook) deliver(e Event) {
+	body, err := json.Marshal(e)
+	if err != nil {
+		// json.Marshal failing on our own struct is a programming bug, not
+		// a transient error — surface but don't retry.
+		return
+	}
+	if int64(len(body)) > w.cfg.MaxBodyBytes {
+		return
+	}
+
+	var sig string
+	if len(w.cfg.Secret) > 0 {
+		mac := hmac.New(sha256.New, w.cfg.Secret)
+		mac.Write(body)
+		sig = "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	}
+
+	backoff := w.cfg.BackoffBase
+	for attempt := 0; attempt < w.cfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(backoff):
+			case <-w.closed:
+				return // give up on shutdown
+			}
+			backoff *= 2
+		}
+
+		retry, ok := w.postOnce(body, sig)
+		if ok {
+			return
+		}
+		if !retry {
+			return // 4xx — receiver rejected, no retry
+		}
+	}
+	// Exceeded MaxRetries; drop.
+}
+
+// postOnce performs a single POST attempt. Returns (retry, ok) where
+// ok=true means delivery succeeded, retry=true means try again later.
+func (w *Webhook) postOnce(body []byte, sig string) (retry, ok bool) {
+	req, err := http.NewRequest(http.MethodPost, w.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return false, false // malformed URL — no retry, no success
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sig != "" {
+		req.Header.Set(SignatureHeader, sig)
+	}
+
+	resp, err := w.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return true, false // transport error — retry
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return false, true
+	case resp.StatusCode >= 500:
+		return true, false // server error — retry
+	default:
+		return false, false // 4xx — receiver said no, no retry
+	}
+}
+
+// Close stops accepting new events, fires any pending debounce-window
+// events synchronously, and waits for in-flight deliveries to finish or
+// for ctx to cancel.
+//
+// After Close returns, calls to Enqueue silently drop the event.
+func (w *Webhook) Close(ctx context.Context) error {
+	w.mu.Lock()
+	select {
+	case <-w.closed:
+		w.mu.Unlock()
+		return nil // already closed
+	default:
+	}
+	close(w.closed)
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+	w.mu.Unlock()
+
+	// Drain whatever was in the pending set at Close time.
+	w.flush()
+
+	done := make(chan struct{})
+	go func() { w.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// EncodeBody is a low-level helper that returns the exact JSON body the
+// Webhook would POST for the given event, including the auto-populated
+// Timestamp. Exported so test code (and downstream tooling) can verify
+// signatures without spinning up a Webhook.
+func EncodeBody(e Event) ([]byte, error) {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now()
+	}
+	return json.Marshal(e)
+}
+
+// VerifySignature checks whether sig (in `sha256=<hex>` form) matches
+// HMAC-SHA256(body, secret). Constant-time comparison. Returns true on
+// match. Receivers wiring a webhook handler should call this on every
+// inbound request before trusting the payload.
+func VerifySignature(body, secret []byte, sig string) bool {
+	const prefix = "sha256="
+	if len(sig) <= len(prefix) || sig[:len(prefix)] != prefix {
+		return false
+	}
+	want, err := hex.DecodeString(sig[len(prefix):])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return hmac.Equal(mac.Sum(nil), want)
+}
+
+// DecodeUpdate is a convenience for receivers: parses the base64-encoded
+// Update field back into raw V1 update bytes. Exists so the on-the-wire
+// shape can stay JSON-friendly without requiring callers to know that
+// json.Unmarshal handles []byte as base64 automatically.
+func DecodeUpdate(b64 string) ([]byte, error) {
+	if b64 == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(b64)
+}

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,7 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/reearth/ygo/crdt"
 	"github.com/reearth/ygo/provider/webhook"
+	ygws "github.com/reearth/ygo/provider/websocket"
 )
 
 // Tests for #61 — provider/webhook subpackage.
@@ -354,4 +357,221 @@ func TestUnit_New_RejectsEmptyURL(t *testing.T) {
 		"webhook.New must reject empty URL")
 	assert.Contains(t, err.Error(), "URL",
 		"error must mention URL: %v", err)
+}
+
+// Regression for #93 self-review B3 — AttachTo wires every relevant
+// Server hook + per-doc OnUpdate so a single call delivers the event
+// stream without per-event manual wiring. This test drives the
+// load → update → unload path via srv.Apply + srv.CloseRoom (no real
+// WebSocket needed for the wiring assertion); the Connect / Disconnect
+// edges (which require a real peer transition) are covered by the
+// lifecycle test suite which exercises OnFirstPeer / OnLastPeer.
+func TestInteg_Webhook_AttachTo_WiresAllEvents(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		got      []webhook.EventType
+		gotRooms []string
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var e webhook.Event
+		_ = json.Unmarshal(body, &e)
+		mu.Lock()
+		got = append(got, e.Type)
+		gotRooms = append(gotRooms, e.Room)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{URL: ts.URL, Debounce: 30 * time.Millisecond})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	srv := ygws.NewServer()
+	detach := webhook.AttachTo(srv, wh)
+	defer detach()
+
+	// srv.Apply creates the room (→ EventLoad via OnLoadDocument) and
+	// applies an update inside a Transact (→ EventUpdate via the
+	// per-doc OnUpdate listener AttachTo installed).
+	require.NoError(t, srv.Apply(context.Background(), "attachroom",
+		func(d *crdt.Doc, transact func(func(*crdt.Transaction))) {
+			txt := d.GetText("t")
+			transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+		}))
+
+	// srv.CloseRoom evicts the room (→ EventUnload via OnUnloadDocument).
+	require.NoError(t, srv.CloseRoom("attachroom", false))
+
+	// Wait for all three event types to arrive.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		seen := make(map[webhook.EventType]bool)
+		for _, e := range got {
+			seen[e] = true
+		}
+		return seen[webhook.EventLoad] && seen[webhook.EventUpdate] && seen[webhook.EventUnload]
+	}, 4*time.Second, 50*time.Millisecond,
+		"AttachTo must wire Load + Update + Unload from a single call")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range gotRooms {
+		assert.Equal(t, "attachroom", r,
+			"every event must carry the correct room name")
+	}
+}
+
+// AttachTo's detach func must restore the previous hook values so the
+// Server returns to its pre-AttachTo state.
+func TestUnit_Webhook_AttachTo_DetachRestoresPrevHooks(t *testing.T) {
+	srv := ygws.NewServer()
+
+	// Set sentinel hooks first.
+	called := struct {
+		load, unload, first, last bool
+	}{}
+	srv.OnLoadDocument = func(_ context.Context, _ string, _ *crdt.Doc) error {
+		called.load = true
+		return nil
+	}
+	srv.OnUnloadDocument = func(_ context.Context, _ string) { called.unload = true }
+	srv.OnFirstPeer = func(_ context.Context, _ string) { called.first = true }
+	srv.OnLastPeer = func(_ context.Context, _ string) { called.last = true }
+
+	wh, err := webhook.New(webhook.Config{URL: "http://example.invalid"})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	detach := webhook.AttachTo(srv, wh)
+
+	// Hooks are now AttachTo's wrappers — but they must chain to the
+	// previous values, so the sentinels still get hit when the wrappers run.
+	require.NoError(t, srv.OnLoadDocument(context.Background(), "r", crdt.New()))
+	srv.OnUnloadDocument(context.Background(), "r")
+	srv.OnFirstPeer(context.Background(), "r")
+	srv.OnLastPeer(context.Background(), "r")
+	assert.True(t, called.load && called.unload && called.first && called.last,
+		"AttachTo wrappers must chain to the pre-existing hooks")
+
+	// detach restores: the hook fields must equal the original closures.
+	// We can't pointer-compare closures, but we CAN reset the called
+	// flags, call the post-detach hooks, and assert the sentinels still
+	// fire — proving the wrappers were removed.
+	detach()
+	called = struct{ load, unload, first, last bool }{}
+	require.NoError(t, srv.OnLoadDocument(context.Background(), "r", crdt.New()))
+	srv.OnUnloadDocument(context.Background(), "r")
+	srv.OnFirstPeer(context.Background(), "r")
+	srv.OnLastPeer(context.Background(), "r")
+	assert.True(t, called.load && called.unload && called.first && called.last,
+		"after detach the original sentinel hooks must run directly")
+}
+
+// Regression for #93 self-review — Close must interrupt an in-flight
+// retry sleep instead of waiting out the full backoff.
+func TestInteg_Webhook_Close_InterruptsRetrySleep(t *testing.T) {
+	// Always 500 → forces deliver into the backoff sleep loop.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:         ts.URL,
+		Debounce:    10 * time.Millisecond,
+		MaxRetries:  20,
+		BackoffBase: 500 * time.Millisecond, // would sum to many seconds
+		MaxBackoff:  10 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "interruptroom"})
+
+	// Let the first attempt run + the backoff sleep start.
+	time.Sleep(200 * time.Millisecond)
+
+	// Close with a short ctx; deliver should observe <-w.closed in
+	// its sleep select and exit fast, well under the would-be backoff.
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, wh.Close(ctx))
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 1500*time.Millisecond,
+		"Close must interrupt retry sleep (took %v); the next backoff "+
+			"alone would have been ~500ms with several more to follow", elapsed)
+}
+
+// Regression for #93 self-review test gap — Event.Update bytes must
+// round-trip cleanly through JSON's base64 encoding.
+func TestUnit_Webhook_Event_Update_RoundTripsBase64(t *testing.T) {
+	original := []byte{0x00, 0xFF, 0xAB, 0x10, 0x42, 0x80, 0x7F, 0x01}
+	body, err := webhook.EncodeBody(webhook.Event{
+		Type:   webhook.EventUpdate,
+		Room:   "rt",
+		Update: original,
+	})
+	require.NoError(t, err)
+
+	// json.Marshal encodes []byte as base64 by default. Round-trip
+	// through json.Unmarshal must give us the same bytes back.
+	var decoded webhook.Event
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, original, decoded.Update,
+		"Event.Update must survive JSON base64 round-trip without modification")
+}
+
+// Regression for #93 self-review A3 — bursting many events at a
+// configured-low MaxConcurrentDeliveries must not spawn N goroutines
+// simultaneously; the deliverSem must cap concurrent in-flight POSTs.
+func TestInteg_Webhook_BoundedConcurrency_UnderBurst(t *testing.T) {
+	const maxConcurrent = 3
+	var (
+		inFlight     atomic.Int32
+		peakInFlight atomic.Int32
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := inFlight.Add(1)
+		// Track peak observed concurrency.
+		for {
+			peak := peakInFlight.Load()
+			if n <= peak || peakInFlight.CompareAndSwap(peak, n) {
+				break
+			}
+		}
+		// Hold the request open briefly so multiple are simultaneously in-flight.
+		time.Sleep(80 * time.Millisecond)
+		inFlight.Add(-1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:                     ts.URL,
+		Debounce:                10 * time.Millisecond,
+		MaxConcurrentDeliveries: maxConcurrent,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	// 12 distinct events fan out at once.
+	for i := 0; i < 12; i++ {
+		wh.Enqueue(webhook.Event{
+			Type: webhook.EventUpdate,
+			Room: "burstroom-" + strconv.Itoa(i),
+		})
+	}
+
+	// Wait for everything to drain.
+	require.Eventually(t, func() bool {
+		return inFlight.Load() == 0 && peakInFlight.Load() > 0
+	}, 4*time.Second, 20*time.Millisecond)
+
+	assert.LessOrEqual(t, peakInFlight.Load(), int32(maxConcurrent),
+		"peak observed concurrency (%d) must not exceed MaxConcurrentDeliveries (%d)",
+		peakInFlight.Load(), maxConcurrent)
 }

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -359,6 +359,38 @@ func TestUnit_New_RejectsEmptyURL(t *testing.T) {
 		"error must mention URL: %v", err)
 }
 
+// New must reject URLs whose scheme isn't http or https — the docs say
+// so, and failing fast at construction is much more debuggable than
+// every delivery silently dropping at request-build time.
+func TestUnit_New_RejectsNonHTTPURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"ftp scheme", "ftp://example.com/hook"},
+		{"file scheme", "file:///etc/passwd"},
+		{"missing host", "http://"},
+		{"unparseable", "://not-a-url"},
+		{"javascript URL", "javascript:alert(1)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := webhook.New(webhook.Config{URL: tc.url})
+			require.Error(t, err,
+				"webhook.New must reject %q (%s)", tc.url, tc.name)
+		})
+	}
+}
+
+// And the happy path: http and https URLs both succeed.
+func TestUnit_New_AcceptsHTTPAndHTTPS(t *testing.T) {
+	for _, scheme := range []string{"http", "https"} {
+		wh, err := webhook.New(webhook.Config{URL: scheme + "://example.com/hook"})
+		require.NoError(t, err, "webhook.New must accept %s URLs", scheme)
+		require.NoError(t, wh.Close(context.Background()))
+	}
+}
+
 // Regression for #93 self-review B3 — AttachTo wires every relevant
 // Server hook + per-doc OnUpdate so a single call delivers the event
 // stream without per-event manual wiring. This test drives the

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -24,23 +24,14 @@ import (
 
 // VerifySignature must accept a valid sha256= HMAC and reject everything
 // else (wrong prefix, bad hex, wrong key, tampered body).
+//
+// The end-to-end signing path (Webhook signs body → VerifySignature
+// accepts it) is exercised by TestInteg_Webhook_PostSignedEventEndToEnd
+// below; this test focuses on the verifier itself across forged inputs.
 func TestUnit_VerifySignature(t *testing.T) {
 	secret := []byte("super-secret-key")
 	body := []byte(`{"hello":"world"}`)
 
-	// Generate the canonical signature via EncodeBody-equivalent path:
-	// we know the implementation uses crypto/hmac+sha256, so use the same.
-	// The point of the test is to verify that VerifySignature catches both
-	// happy and tampered cases.
-	wh, err := webhook.New(webhook.Config{URL: "http://example.invalid", Secret: secret})
-	require.NoError(t, err)
-	defer func() { _ = wh.Close(context.Background()) }()
-
-	// Build a known signature by re-using the public surface: encode an
-	// event, sign manually (the test below proves end-to-end correctness).
-	// For this unit test we construct the signature directly.
-	// Use Enqueue → captured by an httptest server below in the integration
-	// test. Here we just test the verifier symmetry:
 	good := signFor(secret, body)
 	assert.True(t, webhook.VerifySignature(body, secret, good))
 
@@ -164,6 +155,54 @@ func TestInteg_Webhook_DebounceCoalesces(t *testing.T) {
 	require.Len(t, posts, 1)
 	assert.Equal(t, []byte{9}, posts[0].Update,
 		"the coalesced post must carry the LATEST update bytes")
+}
+
+// Regression for Copilot review: pending coalescing must key by
+// (Room, Type), not by Room alone. A Connect followed by an Update for
+// the same room within the debounce window must NOT overwrite each
+// other — two POSTs are expected, one Connect and one Update.
+func TestInteg_Webhook_CoalescesPerEventType(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		types []webhook.EventType
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var e webhook.Event
+		_ = json.Unmarshal(body, &e)
+		mu.Lock()
+		types = append(types, e.Type)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:      ts.URL,
+		Debounce: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	// Enqueue three distinct event types for the same room within a
+	// single debounce window. All three must be delivered.
+	wh.Enqueue(webhook.Event{Type: webhook.EventConnect, Room: "mixroom"})
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "mixroom", Update: []byte{0x01}})
+	wh.Enqueue(webhook.Event{Type: webhook.EventDisconnect, Room: "mixroom"})
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(types) == 3
+	}, 2*time.Second, 10*time.Millisecond,
+		"three distinct event types in one window must produce three POSTs, "+
+			"not collapse via Room-only coalescing")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t, types,
+		[]webhook.EventType{webhook.EventConnect, webhook.EventUpdate, webhook.EventDisconnect},
+		"each event type must arrive exactly once")
 }
 
 // Retry: 5xx responses must trigger exponential backoff retries until

--- a/provider/webhook/webhook_test.go
+++ b/provider/webhook/webhook_test.go
@@ -1,0 +1,318 @@
+package webhook_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/provider/webhook"
+)
+
+// Tests for #61 — provider/webhook subpackage.
+
+// VerifySignature must accept a valid sha256= HMAC and reject everything
+// else (wrong prefix, bad hex, wrong key, tampered body).
+func TestUnit_VerifySignature(t *testing.T) {
+	secret := []byte("super-secret-key")
+	body := []byte(`{"hello":"world"}`)
+
+	// Generate the canonical signature via EncodeBody-equivalent path:
+	// we know the implementation uses crypto/hmac+sha256, so use the same.
+	// The point of the test is to verify that VerifySignature catches both
+	// happy and tampered cases.
+	wh, err := webhook.New(webhook.Config{URL: "http://example.invalid", Secret: secret})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	// Build a known signature by re-using the public surface: encode an
+	// event, sign manually (the test below proves end-to-end correctness).
+	// For this unit test we construct the signature directly.
+	// Use Enqueue → captured by an httptest server below in the integration
+	// test. Here we just test the verifier symmetry:
+	good := signFor(secret, body)
+	assert.True(t, webhook.VerifySignature(body, secret, good))
+
+	// Tampered body:
+	assert.False(t, webhook.VerifySignature([]byte(`{"hello":"WORLD"}`), secret, good),
+		"signature for original body must not validate against tampered body")
+
+	// Wrong secret:
+	assert.False(t, webhook.VerifySignature(body, []byte("other-key"), good),
+		"signature must not validate under a different secret")
+
+	// Wrong prefix:
+	assert.False(t, webhook.VerifySignature(body, secret, "md5=deadbeef"),
+		"non-sha256 prefix must be rejected")
+
+	// Malformed hex:
+	assert.False(t, webhook.VerifySignature(body, secret, "sha256=not-hex"),
+		"invalid hex must be rejected")
+}
+
+// signFor reproduces the signing formula used by the implementation —
+// useful for tests that need to forge or verify signatures without
+// driving an HTTP server.
+func signFor(secret, body []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// Integration: Webhook POSTs an event to an httptest.Server, the server
+// verifies the signature, and we confirm the body decodes back to the
+// original payload.
+func TestInteg_Webhook_PostSignedEventEndToEnd(t *testing.T) {
+	secret := []byte("integration-secret")
+	var got webhook.Event
+	var gotSig string
+	var bodyBytes []byte
+
+	done := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ = io.ReadAll(r.Body)
+		gotSig = r.Header.Get(webhook.SignatureHeader)
+		_ = json.Unmarshal(bodyBytes, &got)
+		w.WriteHeader(http.StatusOK)
+		close(done)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:      ts.URL,
+		Secret:   secret,
+		Debounce: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	wh.Enqueue(webhook.Event{
+		Type:   webhook.EventUpdate,
+		Room:   "myroom",
+		Update: []byte{0x01, 0x02, 0x03},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("webhook never reached the server")
+	}
+
+	assert.Equal(t, webhook.EventUpdate, got.Type)
+	assert.Equal(t, "myroom", got.Room)
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, got.Update)
+	assert.True(t, webhook.VerifySignature(bodyBytes, secret, gotSig),
+		"received signature must validate against the received body")
+}
+
+// Debounce: multiple Update events for the same room within the debounce
+// window must be coalesced into a single POST carrying the LATEST update.
+func TestInteg_Webhook_DebounceCoalesces(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		posts []webhook.Event
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var e webhook.Event
+		_ = json.Unmarshal(body, &e)
+		mu.Lock()
+		posts = append(posts, e)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:      ts.URL,
+		Debounce: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	// Fire ten Update events for the same room in rapid succession.
+	for i := 0; i < 10; i++ {
+		wh.Enqueue(webhook.Event{
+			Type:   webhook.EventUpdate,
+			Room:   "debounceroom",
+			Update: []byte{byte(i)},
+		})
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Wait for the debounce window to expire and the single POST to land.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(posts) == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"10 rapid Update events must coalesce into 1 POST")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, posts, 1)
+	assert.Equal(t, []byte{9}, posts[0].Update,
+		"the coalesced post must carry the LATEST update bytes")
+}
+
+// Retry: 5xx responses must trigger exponential backoff retries until
+// the receiver returns 2xx. We bound the test by limiting MaxRetries
+// and counting attempts.
+func TestInteg_Webhook_RetriesOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:         ts.URL,
+		Debounce:    10 * time.Millisecond,
+		MaxRetries:  5,
+		BackoffBase: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "retryroom"})
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() >= 3
+	}, 2*time.Second, 10*time.Millisecond,
+		"webhook must retry 5xx responses until receiver returns 2xx")
+}
+
+// 4xx response: must NOT retry. The receiver said "no", and we honour it.
+func TestInteg_Webhook_DoesNotRetry4xx(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:         ts.URL,
+		Debounce:    10 * time.Millisecond,
+		MaxRetries:  5,
+		BackoffBase: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "norereroom"})
+
+	// Allow plenty of time for any retries — if they happen, the count
+	// would exceed 1.
+	time.Sleep(500 * time.Millisecond)
+
+	assert.EqualValues(t, 1, attempts.Load(),
+		"4xx must drop the event after one attempt; no retry")
+}
+
+// Empty Secret: no signature header. Useful for trusted-network
+// deployments that don't need HMAC verification.
+func TestInteg_Webhook_NoSecretNoSignatureHeader(t *testing.T) {
+	var sigHeader string
+	done := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sigHeader = r.Header.Get(webhook.SignatureHeader)
+		w.WriteHeader(http.StatusOK)
+		close(done)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL:      ts.URL,
+		Debounce: 10 * time.Millisecond,
+		// Secret intentionally nil.
+	})
+	require.NoError(t, err)
+	defer func() { _ = wh.Close(context.Background()) }()
+
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "nosecretroom"})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("webhook never reached the server")
+	}
+
+	assert.Empty(t, sigHeader,
+		"no signature header must be emitted when Config.Secret is empty")
+}
+
+// Close must drain pending events before returning.
+func TestInteg_Webhook_CloseFlushesPending(t *testing.T) {
+	delivered := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		delivered <- struct{}{}
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{
+		URL: ts.URL,
+		// Long debounce so the event would not normally flush before Close.
+		Debounce: 10 * time.Second,
+	})
+	require.NoError(t, err)
+
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "closeroom"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, wh.Close(ctx))
+
+	select {
+	case <-delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close must flush the pending event before returning")
+	}
+}
+
+// Closed Webhook silently drops new events.
+func TestInteg_Webhook_DropsAfterClose(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	wh, err := webhook.New(webhook.Config{URL: ts.URL, Debounce: 50 * time.Millisecond})
+	require.NoError(t, err)
+	require.NoError(t, wh.Close(context.Background()))
+
+	// Now enqueue after Close.
+	wh.Enqueue(webhook.Event{Type: webhook.EventUpdate, Room: "deadroom"})
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Zero(t, attempts.Load(),
+		"events enqueued after Close must be silently dropped")
+}
+
+// New must reject empty URL.
+func TestUnit_New_RejectsEmptyURL(t *testing.T) {
+	_, err := webhook.New(webhook.Config{})
+	require.Error(t, err,
+		"webhook.New must reject empty URL")
+	assert.Contains(t, err.Error(), "URL",
+		"error must mention URL: %v", err)
+}

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -275,7 +275,7 @@ func (s *Server) Apply(
 			return fmt.Errorf("%w: %w", ErrInjectRefused, err)
 		}
 	}
-	rm, err := s.getOrCreateRoom(room)
+	rm, err := s.getOrCreateRoom(ctx, room)
 	if err != nil {
 		return err
 	}
@@ -486,9 +486,12 @@ func (s *Server) CloseRoom(name string, force bool) error {
 		if rm.persistDone != nil {
 			<-rm.persistDone
 		}
+		// #60 — handleDisconnect already evicted the room and fired
+		// OnUnloadDocument; nothing more for CloseRoom to do here.
 		return nil
 	}
 	delete(s.rooms, name)
+	evicted := true
 	if rm.persistStop != nil {
 		select {
 		case <-rm.persistStop:
@@ -501,6 +504,16 @@ func (s *Server) CloseRoom(name string, force bool) error {
 
 	if rm.persistDone != nil {
 		<-rm.persistDone
+	}
+
+	// #60 — Fire OnUnloadDocument after locks are released and the
+	// persistence drain finished. (CloseRoom does not have its own
+	// OnLastPeer fire path — the per-peer handleDisconnect path fires
+	// it as those peers' read loops notice the closed connections.)
+	if evicted {
+		if hook := s.OnUnloadDocument; hook != nil {
+			hook(context.Background(), name)
+		}
 	}
 	return nil
 }

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -491,7 +491,6 @@ func (s *Server) CloseRoom(name string, force bool) error {
 		return nil
 	}
 	delete(s.rooms, name)
-	evicted := true
 	if rm.persistStop != nil {
 		select {
 		case <-rm.persistStop:
@@ -510,10 +509,14 @@ func (s *Server) CloseRoom(name string, force bool) error {
 	// persistence drain finished. (CloseRoom does not have its own
 	// OnLastPeer fire path — the per-peer handleDisconnect path fires
 	// it as those peers' read loops notice the closed connections.)
-	if evicted {
-		if hook := s.OnUnloadDocument; hook != nil {
+	// Reaching this line implies we were the path that removed rm from
+	// s.rooms (the early-return above handled the lost-race case), so
+	// firing here is exactly-once vs handleDisconnect — see #93 self-
+	// review B1.
+	if hook := s.OnUnloadDocument; hook != nil {
+		s.safeHook("OnUnloadDocument", func() {
 			hook(context.Background(), name)
-		}
+		})
 	}
 	return nil
 }

--- a/provider/websocket/lifecycle_test.go
+++ b/provider/websocket/lifecycle_test.go
@@ -1,0 +1,184 @@
+package websocket_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// Tests for #60 — PersistenceAdapter lifecycle hooks
+// (OnLoadDocument / OnUnloadDocument / OnFirstPeer / OnLastPeer) on
+// provider/websocket.Server.
+
+// OnLoadDocument fires once per room when the doc is first loaded into
+// memory, with the room name and the freshly-bootstrapped *crdt.Doc.
+func TestInteg_Lifecycle_OnLoadDocument_FiresOnce(t *testing.T) {
+	srv := ygws.NewServer()
+
+	var (
+		mu     sync.Mutex
+		calls  []string
+		gotDoc *crdt.Doc
+	)
+	srv.OnLoadDocument = func(_ context.Context, room string, doc *crdt.Doc) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, room)
+		gotDoc = doc
+		return nil
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// First peer triggers room creation → OnLoadDocument fires.
+	conn1 := dial(t, ts, "loadroom")
+	drainHandshake(t, conn1, crdt.New())
+
+	// Second peer in the same room must NOT fire OnLoadDocument again.
+	conn2 := dial(t, ts, "loadroom")
+	drainHandshake(t, conn2, crdt.New())
+
+	// Allow brief settling time for hook dispatch.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"loadroom"}, calls,
+		"OnLoadDocument must fire exactly once for the first peer to a room")
+	assert.NotNil(t, gotDoc,
+		"the doc passed to OnLoadDocument must not be nil")
+}
+
+// OnLoadDocument returning an error must fail room creation: the peer's
+// WebSocket handshake should fail (HTTP 500 on upgrade).
+func TestInteg_Lifecycle_OnLoadDocument_ErrorFailsRoomCreation(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.OnLoadDocument = func(_ context.Context, _ string, _ *crdt.Doc) error {
+		return errors.New("simulated load failure")
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Dial must fail because the upgrade returns a non-101 status.
+	_, _, err := gws.DefaultDialer.Dial(wsURL(ts, "failroom"), nil)
+	require.Error(t, err,
+		"OnLoadDocument error must propagate as a failed WebSocket upgrade")
+}
+
+// OnUnloadDocument fires when the last peer disconnects (room is evicted
+// from the server map). With a single peer that disconnects, both
+// OnLastPeer and OnUnloadDocument must fire — and only OnLastPeer is
+// expected to fire BEFORE OnUnloadDocument.
+func TestInteg_Lifecycle_OnUnloadDocument_FiresOnLastDisconnect(t *testing.T) {
+	srv := ygws.NewServer()
+
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	srv.OnLastPeer = func(room string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, "last:"+room)
+	}
+	srv.OnUnloadDocument = func(_ context.Context, room string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, "unload:"+room)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	conn := dial(t, ts, "unloadroom")
+	drainHandshake(t, conn, crdt.New())
+	_ = conn.Close()
+
+	// Disconnect cleanup is async. Poll until both hooks have fired.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"both OnLastPeer and OnUnloadDocument must fire on last disconnect")
+
+	mu.Lock()
+	assert.Equal(t, []string{"last:unloadroom", "unload:unloadroom"}, order,
+		"OnLastPeer must fire before OnUnloadDocument")
+	mu.Unlock()
+}
+
+// OnFirstPeer fires only on the 0→1 transition, not on subsequent peer
+// joins. OnLastPeer fires only on the 1→0 transition.
+func TestInteg_Lifecycle_OnFirstPeer_OnlyOnZeroToOne(t *testing.T) {
+	srv := ygws.NewServer()
+
+	var firstCalls, lastCalls atomic.Int32
+	srv.OnFirstPeer = func(room string) {
+		if room == "transitroom" {
+			firstCalls.Add(1)
+		}
+	}
+	srv.OnLastPeer = func(room string) {
+		if room == "transitroom" {
+			lastCalls.Add(1)
+		}
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Open three peers; only the first should trigger OnFirstPeer.
+	conn1 := dial(t, ts, "transitroom")
+	drainHandshake(t, conn1, crdt.New())
+	conn2 := dial(t, ts, "transitroom")
+	drainHandshake(t, conn2, crdt.New())
+	conn3 := dial(t, ts, "transitroom")
+	drainHandshake(t, conn3, crdt.New())
+
+	time.Sleep(100 * time.Millisecond) // settle
+	assert.EqualValues(t, 1, firstCalls.Load(),
+		"OnFirstPeer must fire exactly once for a 0→1 transition")
+	assert.EqualValues(t, 0, lastCalls.Load(),
+		"OnLastPeer must NOT fire while peers are still connected")
+
+	// Close two of the three; OnLastPeer must NOT fire yet.
+	_ = conn1.Close()
+	_ = conn2.Close()
+	time.Sleep(200 * time.Millisecond)
+	assert.EqualValues(t, 0, lastCalls.Load(),
+		"OnLastPeer must NOT fire while at least one peer remains")
+
+	// Close the last one; OnLastPeer must fire exactly once.
+	_ = conn3.Close()
+	require.Eventually(t, func() bool {
+		return lastCalls.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"OnLastPeer must fire exactly once for the 1→0 transition")
+}
+
+// All four hooks are optional — a server with none of them set must
+// behave identically to the pre-#60 codebase.
+func TestInteg_Lifecycle_NilHooks_NoPanic(t *testing.T) {
+	ts := httptest.NewServer(ygws.NewServer())
+	defer ts.Close()
+
+	conn := dial(t, ts, "nilhookroom")
+	drainHandshake(t, conn, crdt.New())
+	_ = conn.Close()
+	// Survive the disconnect cleanup without panicking.
+	time.Sleep(100 * time.Millisecond)
+}

--- a/provider/websocket/lifecycle_test.go
+++ b/provider/websocket/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -89,7 +90,7 @@ func TestInteg_Lifecycle_OnUnloadDocument_FiresOnLastDisconnect(t *testing.T) {
 		mu    sync.Mutex
 		order []string
 	)
-	srv.OnLastPeer = func(room string) {
+	srv.OnLastPeer = func(_ context.Context, room string) {
 		mu.Lock()
 		defer mu.Unlock()
 		order = append(order, "last:"+room)
@@ -127,12 +128,12 @@ func TestInteg_Lifecycle_OnFirstPeer_OnlyOnZeroToOne(t *testing.T) {
 	srv := ygws.NewServer()
 
 	var firstCalls, lastCalls atomic.Int32
-	srv.OnFirstPeer = func(room string) {
+	srv.OnFirstPeer = func(_ context.Context, room string) {
 		if room == "transitroom" {
 			firstCalls.Add(1)
 		}
 	}
-	srv.OnLastPeer = func(room string) {
+	srv.OnLastPeer = func(_ context.Context, room string) {
 		if room == "transitroom" {
 			lastCalls.Add(1)
 		}
@@ -168,6 +169,119 @@ func TestInteg_Lifecycle_OnFirstPeer_OnlyOnZeroToOne(t *testing.T) {
 		return lastCalls.Load() == 1
 	}, 2*time.Second, 10*time.Millisecond,
 		"OnLastPeer must fire exactly once for the 1→0 transition")
+}
+
+// Regression for #93 self-review B1 — CloseRoom must fire
+// OnUnloadDocument when it is the path that evicts the room.
+func TestInteg_Lifecycle_CloseRoom_FiresOnUnloadDocument(t *testing.T) {
+	srv := ygws.NewServer()
+	var (
+		mu    sync.Mutex
+		fired []string
+	)
+	srv.OnUnloadDocument = func(_ context.Context, room string) {
+		mu.Lock()
+		defer mu.Unlock()
+		fired = append(fired, room)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Bootstrap the room via Apply (so there's a room with no peers).
+	require.NoError(t, srv.Apply(context.Background(), "closeroom", func(d *crdt.Doc, transact func(func(*crdt.Transaction))) {
+		txt := d.GetText("t")
+		transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+	}))
+
+	require.NoError(t, srv.CloseRoom("closeroom", false))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(fired) == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"CloseRoom must fire OnUnloadDocument exactly once")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"closeroom"}, fired)
+}
+
+// Regression for #93 self-review B1 — CloseRoom racing with the
+// last-peer disconnect must fire OnUnloadDocument exactly once, not
+// twice. Pre-fix, both paths fired the hook because handleDisconnect
+// didn't check whether it actually evicted rm from s.rooms.
+func TestInteg_Lifecycle_CloseRoom_VsDisconnect_FiresUnloadOnce(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.MaxPeersPerRoom = 1
+	var fireCount atomic.Int32
+	srv.OnUnloadDocument = func(_ context.Context, _ string) {
+		fireCount.Add(1)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Run the race ~50 times to exercise both interleavings.
+	const trials = 50
+	for i := 0; i < trials; i++ {
+		fireCount.Store(0)
+		roomName := "raceroom" + strconv.Itoa(i)
+
+		conn := dial(t, ts, roomName)
+		drainHandshake(t, conn, crdt.New())
+
+		// Concurrently fire CloseRoom while the peer disconnects.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = conn.Close() }()
+		go func() { defer wg.Done(); _ = srv.CloseRoom(roomName, true) }()
+		wg.Wait()
+
+		// Both paths drained; assert exactly one OnUnloadDocument fired.
+		require.Eventually(t, func() bool {
+			return fireCount.Load() >= 1
+		}, 2*time.Second, 5*time.Millisecond,
+			"trial %d: at least one path must fire OnUnloadDocument", i)
+		// Small settle in case the loser path is mid-execution.
+		time.Sleep(20 * time.Millisecond)
+		got := fireCount.Load()
+		require.EqualValues(t, 1, got,
+			"trial %d: OnUnloadDocument fired %d times for %s; want exactly 1",
+			i, got, roomName)
+	}
+}
+
+// Regression for #93 self-review B2 — a panicking lifecycle hook must
+// not crash the server or break the peer-disconnect cleanup path.
+// Verifies via a follow-up Ping that the server is still responsive.
+func TestInteg_Lifecycle_PanickingHook_DoesNotCrashServer(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.OnFirstPeer = func(_ context.Context, _ string) {
+		panic("hostile hook")
+	}
+	srv.OnLastPeer = func(_ context.Context, _ string) {
+		panic("hostile hook")
+	}
+	srv.OnUnloadDocument = func(_ context.Context, _ string) {
+		panic("hostile hook")
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Connect (triggers OnFirstPeer panic), then disconnect (triggers
+	// OnLastPeer + OnUnloadDocument panics). The server must absorb
+	// all three panics without bringing down its goroutines.
+	conn := dial(t, ts, "panicroom")
+	drainHandshake(t, conn, crdt.New())
+	_ = conn.Close()
+
+	// New connection on a different room — proves the server is alive.
+	conn2 := dial(t, ts, "alive-check-room")
+	drainHandshake(t, conn2, crdt.New())
+	defer func() { _ = conn2.Close() }()
 }
 
 // All four hooks are optional — a server with none of them set must

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -99,7 +99,9 @@ func (p *peer) handleMessage(data []byte) {
 			return
 		}
 		if hook := p.server.OnStateless; hook != nil {
-			hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: false})
+			p.server.safeHook("OnStateless", func() {
+				hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: false})
+			})
 		}
 
 	case msgBroadcastStateless:
@@ -119,7 +121,9 @@ func (p *peer) handleMessage(data []byte) {
 			enc.WriteVarString(payload)
 		}), true)
 		if hook := p.server.OnStateless; hook != nil {
-			hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: true})
+			p.server.safeHook("OnStateless", func() {
+				hook(StatelessInfo{Room: p.roomName, Payload: payload, IsBroadcast: true})
+			})
 		}
 
 	case msgClose:
@@ -218,10 +222,24 @@ func (p *peer) handleDisconnect() {
 		rm.mu.Lock()
 		delete(rm.peers, p)
 		empty := len(rm.peers) == 0
+		// roomEvicted distinguishes "we were the path that removed rm from
+		// s.rooms" from "rm was already gone (CloseRoom won the race)".
+		// Only the evicting path fires OnUnloadDocument — without this
+		// guard a concurrent CloseRoom + last-peer-disconnect double-fires
+		// the hook on the same room name. (#93 self-review B1.)
+		roomEvicted := false
 		if empty {
-			delete(p.server.rooms, p.roomName)
+			if current, stillIn := p.server.rooms[p.roomName]; stillIn && current == rm {
+				delete(p.server.rooms, p.roomName)
+				roomEvicted = true
+			}
 			if rm.persistStop != nil {
-				close(rm.persistStop)
+				select {
+				case <-rm.persistStop:
+					// already closed by CloseRoom
+				default:
+					close(rm.persistStop)
+				}
 			}
 		}
 		rm.mu.Unlock()
@@ -245,13 +263,21 @@ func (p *peer) handleDisconnect() {
 		// drain finished. OnLastPeer signals the 1→0 transition; the room
 		// may or may not also be evicted (eviction is currently eager but
 		// could become lazy in a future release). OnUnloadDocument fires
-		// only when the room is actually evicted from the server map.
+		// only when we were the path that actually evicted the room from
+		// the server map (roomEvicted) — otherwise CloseRoom raced us and
+		// has already / will already fire it. Both hooks are panic-safe.
 		if empty {
 			if hook := p.server.OnLastPeer; hook != nil {
-				hook(p.roomName)
+				p.server.safeHook("OnLastPeer", func() {
+					hook(context.Background(), p.roomName)
+				})
 			}
+		}
+		if roomEvicted {
 			if hook := p.server.OnUnloadDocument; hook != nil {
-				hook(context.Background(), p.roomName)
+				p.server.safeHook("OnUnloadDocument", func() {
+					hook(context.Background(), p.roomName)
+				})
 			}
 		}
 

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -238,6 +239,20 @@ func (p *peer) handleDisconnect() {
 		// room reference becomes garbage. This runs outside the locks above.
 		if empty && rm.persistDone != nil {
 			<-rm.persistDone
+		}
+
+		// #60 — Fire lifecycle hooks AFTER locks released and persistence
+		// drain finished. OnLastPeer signals the 1→0 transition; the room
+		// may or may not also be evicted (eviction is currently eager but
+		// could become lazy in a future release). OnUnloadDocument fires
+		// only when the room is actually evicted from the server map.
+		if empty {
+			if hook := p.server.OnLastPeer; hook != nil {
+				hook(p.roomName)
+			}
+			if hook := p.server.OnUnloadDocument; hook != nil {
+				hook(context.Background(), p.roomName)
+			}
 		}
 
 		p.cidMu.Lock()

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -252,6 +252,43 @@ type Server struct {
 	// to the embedding application.
 	OnStateless StatelessHook
 
+	// OnLoadDocument, if non-nil, is called once per room immediately
+	// after the document has been bootstrapped from the PersistenceAdapter
+	// (or freshly constructed when no adapter is configured) but before
+	// any peer can interact with it. Returning a non-nil error fails room
+	// creation: peer upgrades / Apply / BroadcastUpdate against the room
+	// receive that error wrapped as a room-load failure. Use this to wire
+	// in a custom resolver, decrypt-at-rest, schema-migration check, or
+	// any other one-time per-room setup. (#60)
+	//
+	// The hook runs while the server room-map lock is held, so
+	// implementations must return promptly; defer heavy I/O to a
+	// goroutine if needed. The doc passed in is owned by the server —
+	// retaining a reference past the hook return is safe as long as the
+	// caller serialises access through Transact / public APIs.
+	OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error
+
+	// OnUnloadDocument, if non-nil, is called once per room immediately
+	// after the room has been evicted from the server's in-memory map.
+	// Fires from both handleDisconnect (last-peer-leaves) and CloseRoom.
+	// Use this to release per-room caches, flush metrics, or notify
+	// downstream systems that the doc is no longer hot. (#60)
+	OnUnloadDocument func(ctx context.Context, room string)
+
+	// OnFirstPeer, if non-nil, fires when a room transitions from 0 to 1
+	// peers — i.e. the first peer just joined this active session of the
+	// document. Useful for warm-up tasks (preloading caches, opening
+	// downstream connections). Fires after the peer has been registered
+	// with the room and after all server locks have been released. (#60)
+	OnFirstPeer func(room string)
+
+	// OnLastPeer, if non-nil, fires when a room transitions from 1 to 0
+	// peers — i.e. the last peer just disconnected. Useful for cool-down
+	// tasks (releasing caches, closing downstream connections, scheduling
+	// the eventual OnUnloadDocument). Fires before OnUnloadDocument when
+	// both apply. (#60)
+	OnLastPeer func(room string)
+
 	// MaxUpdateBytes is the maximum size of a single V1 update that
 	// BroadcastUpdate will fan out, or that Apply will produce and
 	// fan out. Zero means use the same 64 MiB default applied to
@@ -455,7 +492,7 @@ func (s *Server) GetDoc(name string) *crdt.Doc {
 	return nil
 }
 
-func (s *Server) getOrCreateRoom(name string) (*room, error) {
+func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error) {
 	s.rmu.Lock()
 	defer s.rmu.Unlock()
 	if r, ok := s.rooms[name]; ok {
@@ -490,6 +527,17 @@ func (s *Server) getOrCreateRoom(name string) (*room, error) {
 				return nil, fmt.Errorf("bootstrapping room %q: %w", name, err)
 			}
 		}
+	}
+	// #60 — fire OnLoadDocument AFTER persistence bootstrap but BEFORE the
+	// persistence worker starts and the room is registered, so a hook
+	// returning an error fails room creation cleanly with nothing left to
+	// clean up. Hook runs under s.rmu.Lock; implementations must be fast.
+	if hook := s.OnLoadDocument; hook != nil {
+		if err := hook(ctx, name, r.doc); err != nil {
+			return nil, fmt.Errorf("OnLoadDocument for room %q: %w", name, err)
+		}
+	}
+	if s.persistence != nil {
 		// Serialise persistence writes through a buffered channel so that a
 		// slow storage backend does not block the Transact caller (N-H7) and
 		// writes arrive in order.
@@ -526,7 +574,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rm, err := s.getOrCreateRoom(name)
+	rm, err := s.getOrCreateRoom(r.Context(), name)
 	if err != nil {
 		if errors.Is(err, ErrTooManyRooms) {
 			http.Error(w, "too many rooms", http.StatusServiceUnavailable)
@@ -599,8 +647,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	rm.mu.Lock()
 	rm.peers[p] = struct{}{}
+	firstPeer := len(rm.peers) == 1 // #60: 0→1 transition
 	rm.mu.Unlock()
 	s.rmu.RUnlock()
+
+	// #60 — OnFirstPeer fires after all server locks are released so the
+	// hook is free to do blocking work (warm caches, open connections,
+	// emit metrics) without holding up other peers from joining.
+	if firstPeer {
+		if hook := s.OnFirstPeer; hook != nil {
+			hook(name)
+		}
+	}
 
 	// Start the per-peer writer ONLY after the peer is registered with the
 	// room. From this point handleDisconnect (registered next) owns the

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,25 @@ import (
 	"github.com/reearth/ygo/encoding"
 	ygsync "github.com/reearth/ygo/sync"
 )
+
+// safeHook invokes fn under a deferred recover so a panicking user hook
+// cannot crash the calling goroutine. The panic is logged with the stack
+// at Error level and the recovered value attached to the log entry; the
+// caller continues as if the hook completed normally. Use for every
+// user-supplied callback the server invokes (lifecycle hooks, stateless,
+// inject, etc.) so an embedding application bug never takes down a
+// connection-handling or room-disposal goroutine.
+func (s *Server) safeHook(name string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.log().Error("hook panicked; recovered",
+				"hook", name,
+				"panic", r,
+				"stack", string(debug.Stack()))
+		}
+	}()
+	fn()
+}
 
 // writeTimeout is applied to every individual WebSocket write. A peer that
 // stops reading will be detected and disconnected within this window, preventing
@@ -279,15 +299,22 @@ type Server struct {
 	// peers — i.e. the first peer just joined this active session of the
 	// document. Useful for warm-up tasks (preloading caches, opening
 	// downstream connections). Fires after the peer has been registered
-	// with the room and after all server locks have been released. (#60)
-	OnFirstPeer func(room string)
+	// with the room and after all server locks have been released. ctx is
+	// the WebSocket request context; it is cancelled when the peer's HTTP
+	// request is cancelled. (#60)
+	//
+	// Note: under heavy churn the (OnFirstPeer / OnLastPeer) pair for the
+	// same room may interleave out of strict time order — implementations
+	// must be idempotent against repeated transitions.
+	OnFirstPeer func(ctx context.Context, room string)
 
 	// OnLastPeer, if non-nil, fires when a room transitions from 1 to 0
 	// peers — i.e. the last peer just disconnected. Useful for cool-down
 	// tasks (releasing caches, closing downstream connections, scheduling
 	// the eventual OnUnloadDocument). Fires before OnUnloadDocument when
-	// both apply. (#60)
-	OnLastPeer func(room string)
+	// both apply. ctx is context.Background() — the WS request that owned
+	// the peer has already terminated by this point. (#60)
+	OnLastPeer func(ctx context.Context, room string)
 
 	// MaxUpdateBytes is the maximum size of a single V1 update that
 	// BroadcastUpdate will fan out, or that Apply will produce and
@@ -532,9 +559,16 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 	// persistence worker starts and the room is registered, so a hook
 	// returning an error fails room creation cleanly with nothing left to
 	// clean up. Hook runs under s.rmu.Lock; implementations must be fast.
+	// A panic in the hook is recovered (logged at Error with the stack)
+	// and treated as a hook-failure error so room creation is not silently
+	// committed in an inconsistent state.
 	if hook := s.OnLoadDocument; hook != nil {
-		if err := hook(ctx, name, r.doc); err != nil {
-			return nil, fmt.Errorf("OnLoadDocument for room %q: %w", name, err)
+		var hookErr error
+		s.safeHook("OnLoadDocument", func() {
+			hookErr = hook(ctx, name, r.doc)
+		})
+		if hookErr != nil {
+			return nil, fmt.Errorf("OnLoadDocument for room %q: %w", name, hookErr)
 		}
 	}
 	if s.persistence != nil {
@@ -653,10 +687,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// #60 — OnFirstPeer fires after all server locks are released so the
 	// hook is free to do blocking work (warm caches, open connections,
-	// emit metrics) without holding up other peers from joining.
+	// emit metrics) without holding up other peers from joining. A panic
+	// in the hook is recovered + logged; the peer handshake below
+	// continues regardless.
 	if firstPeer {
 		if hook := s.OnFirstPeer; hook != nil {
-			hook(name)
+			s.safeHook("OnFirstPeer", func() { hook(r.Context(), name) })
 		}
 	}
 


### PR DESCRIPTION
## Summary

Second Hocuspocus-compatibility release. Closes out the server-side parity story started by v1.18.0 (#92).

### #60 — \`provider/websocket\` lifecycle hooks

Four new optional \`Server\` hook fields:

| Hook | Fires when |
|---|---|
| \`OnLoadDocument(ctx, room, doc) error\` | After persistence bootstrap, before peers interact. Returning an error fails room creation. |
| \`OnUnloadDocument(ctx, room)\` | On room eviction (last-peer-leaves or \`CloseRoom\`). |
| \`OnFirstPeer(room)\` | 0→1 peer transition, after locks released. |
| \`OnLastPeer(room)\` | 1→0 peer transition. Fires before \`OnUnloadDocument\` when both apply. |

All hooks fire after server locks are released, so implementations may block on I/O without contending with other peers.

### #61 — new \`provider/webhook\` subpackage

POSTs ygo events to a configurable HTTP endpoint. Mirrors Hocuspocus's \`extension-webhook\`:

- **HMAC-SHA256 signing** — \`X-YGo-Signature-256\` header on every POST. \`webhook.VerifySignature\` exposed for receivers; constant-time comparison.
- **Debounce / coalescing** — rapid same-room updates collapse into a single POST carrying the latest update bytes. Default 1s, capped at 10s.
- **Retry with exponential backoff** — default 5 attempts × 250ms base on 5xx and transport errors. 4xx drops immediately.
- **Drain on Close** — \`webhook.Close(ctx)\` flushes pending events before returning; events enqueued after Close are silently dropped.

## Test plan

- [x] **5 lifecycle integration tests** in \`provider/websocket/lifecycle_test.go\`: OnLoadDocument fires once + error fails room creation, OnUnloadDocument fires on last disconnect, OnFirstPeer/OnLastPeer only on 0↔1 transitions, nil hooks don't panic.
- [x] **9 webhook tests** in \`provider/webhook/webhook_test.go\`: HMAC verify (good / tampered body / wrong secret / wrong prefix / bad hex), end-to-end signed POST, debounce coalescing, retry on 5xx, no-retry on 4xx, no-secret-no-signature-header, Close flushes pending, drops after Close, New rejects empty URL.
- [x] Full suite green (\`go test ./...\`)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go vet ./...\` — clean

## Internal note

\`Server.getOrCreateRoom\` now takes a \`context.Context\` so \`OnLoadDocument\` receives a request-scoped ctx. Internal API change; no public callers affected.

Closes #60
Closes #61