### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,26 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ygo
+  namespace: reearth
+  description: A pure-Go implementation of the Yjs CRDT framework. Binary-compatible
+    with yjs@13.x.
+  annotations:
+    github.com/project-slug: reearth/ygo
+  links:
+  - url: https://github.com/reearth/ygo
+    title: GitHub
+    icon: github
+  - url: https://pkg.go.dev/github.com/reearth/ygo
+    title: Website
+    icon: web
+  tags:
+  - go
+  - collaborative-editing
+  - crdt
+  - golang
+  - realtime
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/lib


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `ygo` (namespace `reearth`)
- **Owner:** `reearth/lib`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.