### PR TITLE
fix(crdt): five CRDT convergence/interop bugs (v1.23.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] — 2026-06-09
+
+### Fixed
+
+- **Concurrent `YMap`/attribute writes no longer lose a key by apply order.**
+  Last-writer-wins decided the winner from the immediate linked-list right
+  neighbour, so an unrelated-key write landing between two same-key writes made
+  an item falsely consider itself rightmost; receivers diverged and a cross-sync
+  then deleted the key outright. The winner is now the rightmost same-key item in
+  YATA order (itself order-independent), with an `itemMap` fast path that keeps
+  distinct-key population O(N).
+- **Out-of-order updates with a missing `rightOrigin` now park instead of
+  diverging.** An item whose right origin referenced a not-yet-integrated client
+  was integrated at the wrong position (permanent text divergence) because the
+  future-clock check was skipped for root types. It now defers and retries once
+  the missing client arrives, matching Yjs `getMissing`.
+- **A document no longer fails to decode its own full-state encode.** When a
+  lower-clientID peer wrote into a higher-clientID peer's nested type (e.g. an
+  XML attribute), the child's parent-by-ID reference decoded before its parent
+  and hard-failed `ApplyUpdate` (breaking persistence reload and initial sync).
+  Such references are now deferred and resolved once the container integrates,
+  mirroring Yjs `pendingStructs`.
+
+Found by an internal architecture review; each is covered by a new
+order-independence / convergence regression test (`crdt/convergence_p0_test.go`),
+verified against `yjs@13.6.30`.
+
 ## [1.23.0] — 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and hard-failed `ApplyUpdate` (breaking persistence reload and initial sync).
   Such references are now deferred and resolved once the container integrates,
   mirroring Yjs `pendingStructs`.
+- **`RelativePosition` is now wire-compatible with Yjs.** The encoding used the
+  wrong type tags (item/tname were `1`/`2` instead of Yjs's `0`/`1`), so every
+  shared cursor exchanged with a JS peer mis-decoded or crashed lib0. Tags now
+  match Yjs (`0`=item, `1`=tname, `2`=type), the type-anchored variant
+  round-trips, and `assoc` is optional on decode. Verified by encoding in Go and
+  resolving in `yjs@13.6.30`.
+- **`Snapshot` encoding is now wire-compatible with Yjs.** ygo wrote the state
+  vector first with per-block length prefixes; Yjs writes the delete set first,
+  then the state vector, with none. The layout now matches `Y.encodeSnapshot` /
+  `Y.decodeSnapshot`.
 
 Found by an internal architecture review; each is covered by a new
 order-independence / convergence regression test (`crdt/convergence_p0_test.go`),

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,41 +1,40 @@
 ## What's new
 
-Durable storage and a runnable server. This release adds a pure-Go SQLite
-persistence backend and a ready-to-run WebSocket collaboration server binary, so
-you can stand up a restart-surviving, optionally horizontally-scaled Yjs server
-without writing any glue code.
+Correctness hardening. This patch fixes three CRDT convergence/interop defects
+surfaced by an internal architecture review. Each is reproduced by a new
+regression test and verified against `yjs@13.6.30`; there are no API changes.
 
-### Added — `persistence/sqlite` (pure-Go durable backend)
+### Fixed
 
-A `VersionedPersistence` implementation backed by SQLite through
-`modernc.org/sqlite` — **CGo-free**, so it cross-compiles and builds with
-`CGO_ENABLED=0` like the rest of ygo. It runs in WAL mode, keeps full versioned
-history, and prunes old versions with a crash-safe two-phase delete. It passes
-the shared `RunConformance` suite, so it behaves identically to the in-memory
-reference store. Wiring it in is a one-liner:
+- **Concurrent `YMap` / XML-attribute writes no longer lose a key depending on
+  apply order.** Last-writer-wins previously decided the winner from the
+  immediate linked-list right neighbour, so an unrelated-key write landing
+  between two same-key writes could make an item falsely consider itself the
+  current value. Receivers diverged on the key, and a subsequent full-state
+  cross-sync deleted it outright. The winner is now the rightmost same-key item
+  in YATA order — which is order-independent — so all receivers converge.
 
-```go
-store, err := sqlite.Open("data.db")
-```
+- **Out-of-order updates with a missing right origin now park instead of
+  integrating at the wrong position.** An item whose `rightOrigin` referenced a
+  not-yet-integrated client was placed incorrectly (permanent text divergence)
+  because the future-clock dependency check was skipped for root types. It now
+  defers and retries when the missing client arrives, matching Yjs `getMissing`.
 
-### Added — `cmd/ygo-server` (ready-to-run server)
+- **A document no longer fails to decode its own full-state encode.** When a
+  lower-clientID peer wrote into a higher-clientID peer's nested type (e.g. an
+  XML element attribute), the child's parent-by-ID reference decoded before its
+  parent and hard-failed `ApplyUpdate` — breaking persistence reload and the
+  initial sync handshake for such documents. The reference is now deferred and
+  resolved once the container integrates, mirroring Yjs `pendingStructs`.
 
-A single-binary Yjs-compatible WebSocket collaboration server built on
-`provider/websocket`. It exposes flags for the listen address, allowed origins,
-connection / per-room / room-count limits, and max message size; optional Redis
-cluster relay via `-redis` (multiple instances share one logical document per
-room); and SQLite persistence via `-store` (rooms survive restarts). It shuts
-down gracefully on SIGINT/SIGTERM — draining in-flight work, detaching the relay,
-and closing the store. Run it straight from the module:
+### Compatibility
 
-```
-go run github.com/reearth/ygo/cmd/ygo-server -addr :1234 -store data.db
-```
+No API or wire-format changes. Drop-in upgrade from v1.23.0.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.23.0
+go get github.com/reearth/ygo@v1.23.1
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 ## What's new
 
-Correctness hardening. This patch fixes three CRDT convergence/interop defects
+Correctness hardening. This patch fixes five CRDT convergence/interop defects
 surfaced by an internal architecture review. Each is reproduced by a new
-regression test and verified against `yjs@13.6.30`; there are no API changes.
+regression test and verified against `yjs@13.6.30`; there are no public API changes.
 
 ### Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,9 +27,19 @@ regression test and verified against `yjs@13.6.30`; there are no API changes.
   initial sync handshake for such documents. The reference is now deferred and
   resolved once the container integrates, mirroring Yjs `pendingStructs`.
 
+- **`RelativePosition` and `Snapshot` are now wire-compatible with Yjs.** The
+  `RelativePosition` encoding used the wrong type tags, so shared cursors
+  exchanged with a JS peer mis-decoded or crashed lib0; `Snapshot` wrote its
+  blocks in the wrong order with extra length prefixes. Both now match
+  `Y.encodeRelativePosition` / `Y.encodeSnapshot` and are verified by encoding
+  in Go and decoding/resolving in `yjs@13.6.30`.
+
 ### Compatibility
 
-No API or wire-format changes. Drop-in upgrade from v1.23.0.
+No API changes. The internal `RelativePosition` and `Snapshot` byte formats
+changed to become Yjs-compatible — if you persisted those bytes from v1.23.0
+(uncommon; document updates are unaffected), re-capture them. Document update
+and state-vector formats are unchanged. Drop-in upgrade from v1.23.0.
 
 ## Install
 

--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -1,6 +1,9 @@
 package crdt
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 // These tests reproduce the three P0 CRDT-convergence defects identified in the
 // 2026-06-09 architecture review. Each is written to FAIL against the current
@@ -188,5 +191,109 @@ func TestP0_C3_SelfEncodeReloads(t *testing.T) {
 	fel := fc[0].(*YXmlElement)
 	if v, ok := fel.GetAttribute("class"); !ok || v != "hello" {
 		t.Fatalf("fresh element attribute class=%q ok=%v, want \"hello\"", v, ok)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Order-independence guard (down-payment on the review's #70 recommendation):
+// a set of genuinely-concurrent updates must converge to byte-identical state
+// regardless of the order in which a receiver applies them. This directly
+// guards against regressions of C-1 (map LWW) and C-2 (rightOrigin parking).
+// ---------------------------------------------------------------------------
+
+func TestP0_ConcurrentUpdatesConvergeInAllOrders(t *testing.T) {
+	base := New()
+
+	// Each closure produces one independent update off the shared empty base,
+	// using a distinct client ID. Mix of: same-key map writes (C-1), an
+	// unrelated-key write (the interleaver), and concurrent text inserts at the
+	// same index (C-2 territory once they reference each other on merge).
+	makers := []func() []byte{
+		func() []byte { return mapSet(t, base, 11, "x", "A") },
+		func() []byte { return mapSet(t, base, 22, "y", "B") },
+		func() []byte { return mapSet(t, base, 33, "x", "C") },
+		func() []byte { return textIns(t, base, 44, 0, "Z") },
+	}
+	updates := make([][]byte, len(makers))
+	for i, m := range makers {
+		updates[i] = m()
+	}
+
+	// Reference convergence: apply in index order.
+	ref := New()
+	for _, u := range updates {
+		if err := ApplyUpdateV1(ref, u, nil); err != nil {
+			t.Fatalf("ref apply: %v", err)
+		}
+	}
+	wantState := EncodeStateAsUpdateV1(ref, nil)
+	wantText := ref.GetText("t").ToString()
+	wantX, _ := ref.GetMap("m").Get("x")
+
+	idx := make([]int, len(updates))
+	for i := range idx {
+		idx[i] = i
+	}
+	perms := 0
+	permute(idx, 0, func(order []int) {
+		perms++
+		d := New()
+		for _, i := range order {
+			if err := ApplyUpdateV1(d, updates[i], nil); err != nil {
+				t.Fatalf("perm %v apply: %v", order, err)
+			}
+		}
+		// Same materialized content as the reference.
+		if got := d.GetText("t").ToString(); got != wantText {
+			t.Fatalf("order %v: text=%q want %q", order, got, wantText)
+		}
+		if gx, _ := d.GetMap("m").Get("x"); gx != wantX {
+			t.Fatalf("order %v: map[x]=%v want %v", order, gx, wantX)
+		}
+		// And byte-identical full state (the strongest convergence check:
+		// identical item set AND identical delete set).
+		if got := EncodeStateAsUpdateV1(d, nil); !bytes.Equal(got, wantState) {
+			t.Fatalf("order %v: full-state encode differs from reference (divergent CRDT state)", order)
+		}
+	})
+	if perms != 24 {
+		t.Fatalf("expected 24 permutations, ran %d", perms)
+	}
+}
+
+func mapSet(t *testing.T, base *Doc, id ClientID, key, val string) []byte {
+	t.Helper()
+	d := New(WithClientID(id))
+	if err := ApplyUpdateV1(d, fullState(base), nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	m := d.GetMap("m")
+	d.Transact(func(txn *Transaction) { m.Set(txn, key, val) })
+	return diffFrom(d, base)
+}
+
+func textIns(t *testing.T, base *Doc, id ClientID, idx int, s string) []byte {
+	t.Helper()
+	d := New(WithClientID(id))
+	if err := ApplyUpdateV1(d, fullState(base), nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tx := d.GetText("t")
+	d.Transact(func(txn *Transaction) { tx.Insert(txn, idx, s, nil) })
+	return diffFrom(d, base)
+}
+
+// permute calls fn with every permutation of a (restoring a between calls).
+func permute(a []int, k int, fn func([]int)) {
+	if k == len(a) {
+		cp := make([]int, len(a))
+		copy(cp, a)
+		fn(cp)
+		return
+	}
+	for i := k; i < len(a); i++ {
+		a[k], a[i] = a[i], a[k]
+		permute(a, k+1, fn)
+		a[k], a[i] = a[i], a[k]
 	}
 }

--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -1,0 +1,192 @@
+package crdt
+
+import "testing"
+
+// These tests reproduce the three P0 CRDT-convergence defects identified in the
+// 2026-06-09 architecture review. Each is written to FAIL against the current
+// implementation and pass once the corresponding fix lands.
+//
+//   C-1: concurrent YMap writes lose a key depending on apply order
+//   C-2: a missing rightOrigin integrates immediately instead of parking
+//   C-3: ygo rejects its own full-state encode (parent-by-ID decode hard-fail)
+
+// fullState returns doc's complete state as a V1 update.
+func fullState(d *Doc) []byte { return EncodeStateAsUpdateV1(d, nil) }
+
+// diffFrom returns the part of doc's state not described by base's state vector.
+func diffFrom(doc, base *Doc) []byte {
+	sv, err := DecodeStateVectorV1(EncodeStateVectorV1(base))
+	if err != nil {
+		panic(err)
+	}
+	return EncodeStateAsUpdateV1(doc, sv)
+}
+
+// ---------------------------------------------------------------------------
+// C-1 — concurrent YMap writes must converge regardless of apply order, and a
+// live key must never vanish after cross-sync.
+// ---------------------------------------------------------------------------
+
+func TestP0_C1_MapConvergesRegardlessOfOrder(t *testing.T) {
+	base := New()
+
+	// Three concurrent writes off the same (empty) base: two to key "x", one
+	// to key "y". The "y" write is the unrelated update that interleaves.
+	mk := func(id ClientID, key, val string) []byte {
+		d := New(WithClientID(id))
+		if err := ApplyUpdateV1(d, fullState(base), nil); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		m := d.GetMap("m")
+		d.Transact(func(txn *Transaction) { m.Set(txn, key, val) })
+		return diffFrom(d, base)
+	}
+	u1 := mk(1, "x", "a1")
+	u2 := mk(2, "y", "b2")
+	u3 := mk(3, "x", "c3")
+
+	apply := func(updates ...[]byte) *Doc {
+		d := New()
+		for _, u := range updates {
+			if err := ApplyUpdateV1(d, u, nil); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+		}
+		return d
+	}
+
+	r1 := apply(u1, u2, u3)
+	r2 := apply(u3, u2, u1)
+
+	get := func(d *Doc) string {
+		v, ok := d.GetMap("m").Get("x")
+		if !ok {
+			return "<absent>"
+		}
+		return v.(string)
+	}
+
+	x1, x2 := get(r1), get(r2)
+	if x1 != x2 {
+		t.Fatalf("order-dependent map value: r1 x=%q, r2 x=%q (must converge)", x1, x2)
+	}
+
+	// Cross-sync the two receivers; the key must survive and stay equal.
+	if err := ApplyUpdateV1(r1, fullState(r2), nil); err != nil {
+		t.Fatalf("cross-sync r1<-r2: %v", err)
+	}
+	if err := ApplyUpdateV1(r2, fullState(r1), nil); err != nil {
+		t.Fatalf("cross-sync r2<-r1: %v", err)
+	}
+	if g1, g2 := get(r1), get(r2); g1 != g2 || g1 == "<absent>" {
+		t.Fatalf("after cross-sync key x diverged/vanished: r1=%q r2=%q", g1, g2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C-2 — an item whose rightOrigin references a not-yet-integrated client must
+// park until that client arrives, not integrate at the wrong position.
+// ---------------------------------------------------------------------------
+
+func TestP0_C2_MissingRightOriginParks(t *testing.T) {
+	dA := New(WithClientID(1))
+	tA := dA.GetText("t")
+	dA.Transact(func(txn *Transaction) { tA.Insert(txn, 0, "12", nil) })
+	uA := fullState(dA)
+
+	dB := New(WithClientID(2))
+	if err := ApplyUpdateV1(dB, uA, nil); err != nil {
+		t.Fatalf("B seed: %v", err)
+	}
+	tB := dB.GetText("t")
+	dB.Transact(func(txn *Transaction) { tB.Insert(txn, 1, "b", nil) }) // "1b2"
+	uB := diffFrom(dB, dA)
+
+	dC := New(WithClientID(3))
+	if err := ApplyUpdateV1(dC, uA, nil); err != nil {
+		t.Fatalf("C seed A: %v", err)
+	}
+	if err := ApplyUpdateV1(dC, uB, nil); err != nil {
+		t.Fatalf("C seed B: %v", err)
+	}
+	tC := dC.GetText("t")
+	// Capture C's state vector (A+B) BEFORE C's own insert, so uC is just C's op.
+	svBeforeC := New()
+	if err := ApplyUpdateV1(svBeforeC, uA, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyUpdateV1(svBeforeC, uB, nil); err != nil {
+		t.Fatal(err)
+	}
+	dC.Transact(func(txn *Transaction) { tC.Insert(txn, 1, "c", nil) })
+	uC := diffFrom(dC, svBeforeC) // C's insert; its left/right origins reference B's item
+
+	// Causal order (A, B, C) is the reference result.
+	ref := New()
+	for _, u := range [][]byte{uA, uB, uC} {
+		if err := ApplyUpdateV1(ref, u, nil); err != nil {
+			t.Fatalf("ref apply: %v", err)
+		}
+	}
+	want := ref.GetText("t").ToString()
+
+	// Out-of-order delivery: A, then C (depends on B via rightOrigin), then B.
+	r := New()
+	for _, u := range [][]byte{uA, uC, uB} {
+		if err := ApplyUpdateV1(r, u, nil); err != nil {
+			t.Fatalf("ooo apply: %v", err)
+		}
+	}
+	got := r.GetText("t").ToString()
+
+	if got != want {
+		t.Fatalf("out-of-order delivery diverged: got %q, want %q (causal order)", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C-3 — a full-state encode where a lower-clientID peer wrote into a
+// higher-clientID peer's nested type must decode/apply cleanly (the child's
+// parent-by-ID reference must be queued, not hard-rejected).
+// ---------------------------------------------------------------------------
+
+func TestP0_C3_SelfEncodeReloads(t *testing.T) {
+	// Client 200 creates an XML element; client 100 (after syncing) sets an
+	// attribute on it. The attribute item (client 100) references the element
+	// (client 200) as its parent-by-ID. EncodeStateAsUpdate sorts groups
+	// ascending by client, so the attribute decodes before its parent.
+	d200 := New(WithClientID(200))
+	frag := d200.GetXmlFragment("f")
+	el := NewYXmlElement("div")
+	d200.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+
+	d100 := New(WithClientID(100))
+	if err := ApplyUpdateV1(d100, fullState(d200), nil); err != nil {
+		t.Fatalf("d100 seed: %v", err)
+	}
+	children := d100.GetXmlFragment("f").Children()
+	if len(children) != 1 {
+		t.Fatalf("d100 expected 1 child, got %d", len(children))
+	}
+	el100, ok := children[0].(*YXmlElement)
+	if !ok {
+		t.Fatalf("d100 child is not *YXmlElement: %T", children[0])
+	}
+	d100.Transact(func(txn *Transaction) { el100.SetAttribute(txn, "class", "hello") })
+
+	// d100's full state contains both client groups (100 attr + 200 element).
+	full := fullState(d100)
+
+	fresh := New()
+	if err := ApplyUpdateV1(fresh, full, nil); err != nil {
+		t.Fatalf("applying own full-state encode failed: %v", err)
+	}
+	fc := fresh.GetXmlFragment("f").Children()
+	if len(fc) != 1 {
+		t.Fatalf("fresh expected 1 child, got %d", len(fc))
+	}
+	fel := fc[0].(*YXmlElement)
+	if v, ok := fel.GetAttribute("class"); !ok || v != "hello" {
+		t.Fatalf("fresh element attribute class=%q ok=%v, want \"hello\"", v, ok)
+	}
+}

--- a/crdt/coverage_test.go
+++ b/crdt/coverage_test.go
@@ -1821,5 +1821,11 @@ func TestUnit_DecodeSnapshot_TruncatedAtDeleteSet(t *testing.T) {
 	// Valid empty delete set (0x00), then a state-vector header claiming one
 	// client with no client/clock bytes following.
 	_, err = DecodeSnapshot([]byte{0x00, 0x01})
-	assert.Error(t, err)
+	require.Error(t, err)
+
+	// DoS guard: empty delete set (0x00) then a state-vector count of ~4.3e9
+	// (varuint FF FF FF FF 0F) with no entry bytes. Must be rejected by the
+	// remaining-bytes/maxV2Items bound rather than attempting a huge allocation.
+	_, err = DecodeSnapshot([]byte{0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F})
+	require.Error(t, err)
 }

--- a/crdt/coverage_test.go
+++ b/crdt/coverage_test.go
@@ -1810,17 +1810,16 @@ func TestUnit_RunGC_MergesAdjacentTombstones(t *testing.T) {
 // ── DecodeSnapshot: truncated at delete-set bytes ─────────────────────────────
 
 func TestUnit_DecodeSnapshot_TruncatedAtDeleteSet(t *testing.T) {
-	// Encode a valid snapshot, then truncate it after the SV bytes to force an
-	// error when DecodeSnapshot tries to read the delete-set length prefix.
-	doc := newTestDoc(1)
-	txt := doc.GetText("t")
-	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello", nil) })
+	// In the Yjs snapshot layout the delete set comes FIRST, then the state
+	// vector, with no length prefixes. Feed inputs truncated at each stage and
+	// confirm DecodeSnapshot reports an error rather than silently succeeding.
 
-	full := EncodeSnapshot(CaptureSnapshot(doc))
+	// Delete-set header claims one client but provides no range data.
+	_, err := DecodeSnapshot([]byte{0x01})
+	require.Error(t, err)
 
-	// Truncate to just 4 bytes — too short to contain the full SV varint-length
-	// prefix + SV data + DS varint-length prefix, so the DS read must fail.
-	truncated := full[:4]
-	_, err := DecodeSnapshot(truncated)
+	// Valid empty delete set (0x00), then a state-vector header claiming one
+	// client with no client/clock bytes following.
+	_, err = DecodeSnapshot([]byte{0x00, 0x01})
 	assert.Error(t, err)
 }

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -18,6 +18,12 @@ type Item struct {
 	ParentSub *string
 	Content   Content
 	Deleted   bool
+	// parentID is transient decode state: the ID of the container item when this
+	// item's parent is referenced by item-ID (a nested type) but that container
+	// has not yet been integrated. It lets integration defer the item until the
+	// parent arrives (Yjs pendingStructs parity, review finding C-3) instead of
+	// hard-failing the decode. Resolved to Parent during integration; never encoded.
+	parentID *ID
 	// MovedBy points to the winning ContentMove item that has claimed this item
 	// as its target. When non-nil, this item is rendered at the ContentMove's
 	// position instead of its original linked-list position. Set by integrate()
@@ -227,15 +233,38 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 		ct.Type.item = item
 	}
 
-	// For map-keyed items, maintain last-write-wins semantics.
+	// For map-keyed items, maintain last-write-wins semantics. The winner for a
+	// key is the RIGHTMOST same-key item in YATA order (Yjs's parent._map value).
+	// YATA placement above already orders concurrent same-key writes
+	// deterministically by (origin, clientID), so this resolution is independent
+	// of arrival order. We must scan past items of OTHER keys (and tombstones) to
+	// the right rather than inspecting only the immediate right neighbour: a
+	// different-key item landing between two same-key items would otherwise make
+	// us falsely believe we are the rightmost, permanently diverging the winner
+	// and losing the key on cross-sync (review finding C-1).
 	if item.ParentSub != nil {
 		key := *item.ParentSub
-		if item.Right != nil && parentSubEqual(item.Right.ParentSub, item.ParentSub) {
-			// A same-key item to our right won the concurrent write race — delete ourselves.
+		rightmost := true
+		// Fast path: if no item has ever been recorded for this key, none can be
+		// to our right, so we are trivially the rightmost. This keeps populating a
+		// map with N distinct keys O(N) rather than O(N²). Only when a prior
+		// same-key item exists do we scan right (past other keys / tombstones) to
+		// see whether it sits to our right and supersedes us.
+		if _, exists := item.Parent.itemMap[key]; exists {
+			for r := item.Right; r != nil; r = r.Right {
+				if parentSubEqual(r.ParentSub, item.ParentSub) {
+					// A same-key item (live or tombstone) sits to our right and is
+					// therefore the more-recent value — we are superseded.
+					rightmost = false
+					break
+				}
+			}
+		}
+		if !rightmost {
 			item.delete(txn)
 		} else {
 			// We are the rightmost item for this key; delete the previous winner.
-			if existing, ok := item.Parent.itemMap[key]; ok && !existing.Deleted {
+			if existing, ok := item.Parent.itemMap[key]; ok && existing != item && !existing.Deleted {
 				existing.delete(txn)
 			}
 			item.Parent.itemMap[key] = item

--- a/crdt/relative_position.go
+++ b/crdt/relative_position.go
@@ -27,6 +27,12 @@ type RelativePosition struct {
 	// Tname is the root type name; used when Item is nil.
 	Tname string
 
+	// TypeItem anchors the position to the start of a nested type whose
+	// containing item has this ID (Yjs RelativePosition case 2 / wire tag 2).
+	// ygo does not yet generate these; the field exists so positions received
+	// from a Yjs peer round-trip on the wire rather than being rejected.
+	TypeItem *ID
+
 	// Assoc controls which side of Item this position is on.
 	//   Assoc >= 0: cursor is after Item (default — use for most cursors).
 	//   Assoc <  0: cursor is before Item (use when cursor is at end of type,
@@ -113,6 +119,12 @@ func ToAbsolutePosition(doc *Doc, rp RelativePosition) (AbsolutePosition, bool) 
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
 
+	if rp.TypeItem != nil {
+		// Position anchored to a nested type (Yjs case 2). Not yet resolvable in
+		// ygo — return not-found rather than mis-resolving it as a root start.
+		return AbsolutePosition{}, false
+	}
+
 	if rp.Item == nil {
 		// Null anchor = start of the named type (index 0).
 		return AbsolutePosition{Name: rp.Tname, Index: 0, Assoc: rp.Assoc}, true
@@ -151,21 +163,30 @@ func ToAbsolutePosition(doc *Doc, rp RelativePosition) (AbsolutePosition, bool) 
 	return AbsolutePosition{Name: at.name, Index: index, Assoc: rp.Assoc}, true
 }
 
-// EncodeRelativePosition serialises rp to bytes using the Yjs wire format.
-// The encoding is compatible with Y.encodeRelativePosition in the JS Yjs
-// reference implementation.
+// EncodeRelativePosition serialises rp to bytes using the Yjs wire format,
+// interoperable with Y.encodeRelativePosition / Y.decodeRelativePosition.
 //
-// Wire layout:
-//   - If Item != nil:  VarUint(1) + VarUint(client) + VarUint(clock) + VarInt(assoc)
-//   - If Item == nil:  VarUint(2) + VarString(tname) + VarInt(assoc)
+// Wire layout (matching Yjs writeRelativePosition — note the tag values, which
+// the previous ygo encoding had wrong, breaking all cross-language cursor
+// interop, review finding C-4):
+//   - item-anchored:  VarUint(0) + VarUint(client) + VarUint(clock)
+//   - tname-anchored: VarUint(1) + VarString(tname)
+//   - type-anchored:  VarUint(2) + VarUint(client) + VarUint(clock)
+//
+// followed by VarInt(assoc).
 func EncodeRelativePosition(rp RelativePosition) []byte {
 	enc := encoding.NewEncoder()
-	if rp.Item != nil {
-		enc.WriteVarUint(1)
+	switch {
+	case rp.Item != nil:
+		enc.WriteVarUint(0)
 		enc.WriteVarUint(uint64(rp.Item.Client))
 		enc.WriteVarUint(rp.Item.Clock)
-	} else {
+	case rp.TypeItem != nil:
 		enc.WriteVarUint(2)
+		enc.WriteVarUint(uint64(rp.TypeItem.Client))
+		enc.WriteVarUint(rp.TypeItem.Clock)
+	default:
+		enc.WriteVarUint(1)
 		enc.WriteVarString(rp.Tname)
 	}
 	enc.WriteVarInt(int64(rp.Assoc))
@@ -180,33 +201,50 @@ func DecodeRelativePosition(data []byte) (RelativePosition, error) {
 		return RelativePosition{}, ErrInvalidRelativePosition
 	}
 
-	var rp RelativePosition
-	switch kind {
-	case 1: // anchored to a specific item ID
+	readID := func() (*ID, error) {
 		client, err := dec.ReadVarUint()
 		if err != nil {
-			return RelativePosition{}, ErrInvalidRelativePosition
+			return nil, ErrInvalidRelativePosition
 		}
 		clock, err := dec.ReadVarUint()
 		if err != nil {
-			return RelativePosition{}, ErrInvalidRelativePosition
+			return nil, ErrInvalidRelativePosition
 		}
-		id := ID{Client: ClientID(client), Clock: clock}
-		rp.Item = &id
-	case 2: // start of named type
+		return &ID{Client: ClientID(client), Clock: clock}, nil
+	}
+
+	var rp RelativePosition
+	switch kind {
+	case 0: // anchored to a specific item ID
+		id, err := readID()
+		if err != nil {
+			return RelativePosition{}, err
+		}
+		rp.Item = id
+	case 1: // start of named root type
 		name, err := dec.ReadVarString()
 		if err != nil {
 			return RelativePosition{}, ErrInvalidRelativePosition
 		}
 		rp.Tname = name
+	case 2: // anchored to a nested type by its containing item ID
+		id, err := readID()
+		if err != nil {
+			return RelativePosition{}, err
+		}
+		rp.TypeItem = id
 	default:
 		return RelativePosition{}, ErrInvalidRelativePosition
 	}
 
-	assoc, err := dec.ReadVarInt()
-	if err != nil {
-		return RelativePosition{}, ErrInvalidRelativePosition
+	// assoc is optional on the wire (Yjs reads it only when content remains, so
+	// an older encoding without it decodes as assoc=0).
+	if dec.Remaining() > 0 {
+		assoc, err := dec.ReadVarInt()
+		if err != nil {
+			return RelativePosition{}, ErrInvalidRelativePosition
+		}
+		rp.Assoc = int(assoc)
 	}
-	rp.Assoc = int(assoc)
 	return rp, nil
 }

--- a/crdt/relative_position.go
+++ b/crdt/relative_position.go
@@ -27,11 +27,13 @@ type RelativePosition struct {
 	// Tname is the root type name; used when Item is nil.
 	Tname string
 
-	// TypeItem anchors the position to the start of a nested type whose
+	// typeItem anchors the position to the start of a nested type whose
 	// containing item has this ID (Yjs RelativePosition case 2 / wire tag 2).
-	// ygo does not yet generate these; the field exists so positions received
-	// from a Yjs peer round-trip on the wire rather than being rejected.
-	TypeItem *ID
+	// ygo does not yet generate these; the field is unexported (so the public
+	// struct shape — and positional composite literals — is unchanged) and
+	// exists only so positions received from a Yjs peer round-trip on the wire
+	// rather than being rejected.
+	typeItem *ID
 
 	// Assoc controls which side of Item this position is on.
 	//   Assoc >= 0: cursor is after Item (default — use for most cursors).
@@ -119,7 +121,7 @@ func ToAbsolutePosition(doc *Doc, rp RelativePosition) (AbsolutePosition, bool) 
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
 
-	if rp.TypeItem != nil {
+	if rp.typeItem != nil {
 		// Position anchored to a nested type (Yjs case 2). Not yet resolvable in
 		// ygo — return not-found rather than mis-resolving it as a root start.
 		return AbsolutePosition{}, false
@@ -181,10 +183,10 @@ func EncodeRelativePosition(rp RelativePosition) []byte {
 		enc.WriteVarUint(0)
 		enc.WriteVarUint(uint64(rp.Item.Client))
 		enc.WriteVarUint(rp.Item.Clock)
-	case rp.TypeItem != nil:
+	case rp.typeItem != nil:
 		enc.WriteVarUint(2)
-		enc.WriteVarUint(uint64(rp.TypeItem.Client))
-		enc.WriteVarUint(rp.TypeItem.Clock)
+		enc.WriteVarUint(uint64(rp.typeItem.Client))
+		enc.WriteVarUint(rp.typeItem.Clock)
 	default:
 		enc.WriteVarUint(1)
 		enc.WriteVarString(rp.Tname)
@@ -232,7 +234,7 @@ func DecodeRelativePosition(data []byte) (RelativePosition, error) {
 		if err != nil {
 			return RelativePosition{}, err
 		}
-		rp.TypeItem = id
+		rp.typeItem = id
 	default:
 		return RelativePosition{}, ErrInvalidRelativePosition
 	}

--- a/crdt/relpos_snapshot_js_compat_test.go
+++ b/crdt/relpos_snapshot_js_compat_test.go
@@ -1,0 +1,93 @@
+package crdt_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+// TestCompat_RelPosAndSnapshot_GoToJS proves the v1.23.1 wire-format fixes
+// (review C-4 RelativePosition tags, F-5 Snapshot layout) interoperate with the
+// real Yjs reference implementation: Go encodes, Node/Yjs decodes and resolves.
+// Skipped when node is unavailable (headless CI).
+func TestCompat_RelPosAndSnapshot_GoToJS(t *testing.T) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found on PATH — skipping Go→JS interop test")
+	}
+	yjsPath, err := filepath.Abs(filepath.Join("..", "testutil", "node_modules", "yjs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(yjsPath); err != nil {
+		t.Skip("yjs not installed under testutil/node_modules — skipping")
+	}
+
+	// Build a doc: YText "t" = "hello" (client 1).
+	doc := crdt.New(crdt.WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hello", nil) })
+
+	state := crdt.EncodeStateAsUpdateV1(doc, nil)
+
+	// Item-anchored relative position at index 2; must resolve back to 2 in Yjs.
+	rpItem := crdt.EncodeRelativePosition(crdt.CreateRelativePositionFromIndex(txt, 2, 0))
+	// Tname-anchored position (index past end with assoc<0 → start-of-type anchor).
+	rpTname := crdt.EncodeRelativePosition(crdt.RelativePosition{Tname: "t", Assoc: 0})
+	// Snapshot of the current state (ds empty, sv {1:5}).
+	snap := crdt.EncodeSnapshot(crdt.CaptureSnapshot(doc))
+
+	dir := t.TempDir()
+	writeFile := func(name string, b []byte) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, b, 0644))
+		return p
+	}
+	statePath := writeFile("state.bin", state)
+	rpItemPath := writeFile("rp_item.bin", rpItem)
+	rpTnamePath := writeFile("rp_tname.bin", rpTname)
+	snapPath := writeFile("snap.bin", snap)
+
+	script := `
+const Y = require(process.argv[2]);
+const fs = require('fs');
+const rd = p => new Uint8Array(fs.readFileSync(p));
+const doc = new Y.Doc();
+Y.applyUpdate(doc, rd(process.argv[3]));
+const t = doc.getText('t');
+if (t.toString() !== 'hello') throw new Error('text=' + t.toString());
+
+// C-4: item-anchored relative position resolves back to index 2.
+const rpItem = Y.decodeRelativePosition(rd(process.argv[4]));
+const absItem = Y.createAbsolutePositionFromRelativePosition(rpItem, doc);
+if (!absItem) throw new Error('item abs is null');
+if (absItem.index !== 2) throw new Error('item index=' + absItem.index + ' want 2');
+
+// C-4: tname-anchored relative position decodes to tname='t' and resolves to a
+// valid absolute position. (Yjs resolves a null-item/tname anchor to the end of
+// the type; ygo's ToAbsolutePosition treats it as the start — a resolution
+// semantics difference tracked separately. This test only proves the WIRE
+// format: that Yjs can decode what ygo encoded.)
+const rpTname = Y.decodeRelativePosition(rd(process.argv[5]));
+if (rpTname.tname !== 't') throw new Error('tname=' + rpTname.tname);
+const absTname = Y.createAbsolutePositionFromRelativePosition(rpTname, doc);
+if (!absTname) throw new Error('tname abs is null');
+
+// F-5: snapshot decodes; sv has client 1 -> clock 5; delete set empty.
+const snap = Y.decodeSnapshot(rd(process.argv[6]));
+if (snap.sv.get(1) !== 5) throw new Error('snap sv[1]=' + snap.sv.get(1) + ' want 5');
+if (snap.ds.clients.size !== 0) throw new Error('snap ds not empty: ' + snap.ds.clients.size);
+
+console.log('OK');
+`
+	scriptPath := writeFile("check.js", []byte(script))
+
+	out, err := exec.Command(nodePath, scriptPath, yjsPath, statePath, rpItemPath, rpTnamePath, snapPath).CombinedOutput()
+	t.Logf("node output:\n%s", out)
+	require.NoError(t, err, "yjs failed to decode ygo-encoded RelativePosition/Snapshot — wire-format regression")
+}

--- a/crdt/relpos_snapshot_js_compat_test.go
+++ b/crdt/relpos_snapshot_js_compat_test.go
@@ -37,7 +37,7 @@ func TestCompat_RelPosAndSnapshot_GoToJS(t *testing.T) {
 
 	// Item-anchored relative position at index 2; must resolve back to 2 in Yjs.
 	rpItem := crdt.EncodeRelativePosition(crdt.CreateRelativePositionFromIndex(txt, 2, 0))
-	// Tname-anchored position (index past end with assoc<0 → start-of-type anchor).
+	// Tname-anchored position (no item; assoc=0) — a start-of-type anchor.
 	rpTname := crdt.EncodeRelativePosition(crdt.RelativePosition{Tname: "t", Assoc: 0})
 	// Snapshot of the current state (ds empty, sv {1:5}).
 	snap := crdt.EncodeSnapshot(crdt.CaptureSnapshot(doc))

--- a/crdt/snapshot.go
+++ b/crdt/snapshot.go
@@ -65,6 +65,12 @@ func DecodeSnapshot(data []byte) (*Snapshot, error) {
 	if err != nil {
 		return nil, wrapUpdateErr(err)
 	}
+	// Each entry requires at least 2 bytes (client varuint + clock varuint).
+	// Guard against a crafted count that would force a huge map allocation
+	// before the (then-failing) reads — same protection as DecodeStateVectorV1.
+	if n > uint64(dec.Remaining()/2) || n > maxV2Items {
+		return nil, wrapUpdateErr(ErrInvalidUpdate)
+	}
 	sv := make(StateVector, n)
 	for i := uint64(0); i < n; i++ {
 		client, err := dec.ReadVarUint()

--- a/crdt/snapshot.go
+++ b/crdt/snapshot.go
@@ -25,52 +25,57 @@ func CaptureSnapshot(doc *Doc) *Snapshot {
 	}
 }
 
-// EncodeSnapshot serialises snap to bytes.
-// Wire format: VarBytes(encodedStateVector) + VarBytes(encodedDeleteSet)
-// This format is compatible with Y.encodeSnapshot / Y.decodeSnapshot in the
-// JavaScript Yjs reference implementation.
+// EncodeSnapshot serialises snap to bytes in the Yjs V1 snapshot format,
+// interoperable with Y.encodeSnapshot / Y.decodeSnapshot.
+//
+// Wire layout (matching Yjs encodeSnapshotV2 with a V1 encoder): the delete set
+// FIRST, then the state vector, concatenated into a single stream with NO outer
+// length prefixes — `writeDeleteSet(enc, ds); writeStateVector(enc, sv)`. The
+// previous ygo layout wrote the state vector first, each block wrapped in its own
+// VarBytes length prefix, which no Yjs peer could parse (review finding F-5).
 func EncodeSnapshot(snap *Snapshot) []byte {
 	enc := encoding.NewEncoder()
-
-	// State vector block.
-	svEnc := encoding.NewEncoder()
-	clients := clientsSorted(snap.StateVector)
-	svEnc.WriteVarUint(uint64(len(clients)))
-	for _, c := range clients {
-		svEnc.WriteVarUint(uint64(c))
-		svEnc.WriteVarUint(snap.StateVector[c])
-	}
-	enc.WriteVarBytes(svEnc.Bytes())
-
-	// Delete set block.
-	dsEnc := encoding.NewEncoder()
-	encodeDeleteSet(dsEnc, snap.DeleteSet)
-	enc.WriteVarBytes(dsEnc.Bytes())
-
+	encodeDeleteSet(enc, snap.DeleteSet)
+	encodeSnapshotStateVector(enc, snap.StateVector)
 	return enc.Bytes()
 }
 
-// DecodeSnapshot parses bytes produced by EncodeSnapshot.
+// encodeSnapshotStateVector writes the state vector inline (no length prefix),
+// matching Yjs writeStateVector: count, then (client, clock) pairs.
+func encodeSnapshotStateVector(enc *encoding.Encoder, sv StateVector) {
+	clients := clientsSorted(sv)
+	enc.WriteVarUint(uint64(len(clients)))
+	for _, c := range clients {
+		enc.WriteVarUint(uint64(c))
+		enc.WriteVarUint(sv[c])
+	}
+}
+
+// DecodeSnapshot parses bytes produced by EncodeSnapshot (or Y.encodeSnapshot):
+// delete set first, then the state vector, both inline (no length prefixes).
 func DecodeSnapshot(data []byte) (*Snapshot, error) {
 	dec := encoding.NewDecoder(data)
 
-	svBytes, err := dec.ReadVarBytes()
+	ds, err := decodeDeleteSet(dec)
 	if err != nil {
 		return nil, wrapUpdateErr(err)
-	}
-	sv, err := DecodeStateVectorV1(svBytes)
-	if err != nil {
-		return nil, err
 	}
 
-	dsBytes, err := dec.ReadVarBytes()
+	n, err := dec.ReadVarUint()
 	if err != nil {
 		return nil, wrapUpdateErr(err)
 	}
-	dsDec := encoding.NewDecoder(dsBytes)
-	ds, err := decodeDeleteSet(dsDec)
-	if err != nil {
-		return nil, wrapUpdateErr(err)
+	sv := make(StateVector, n)
+	for i := uint64(0); i < n; i++ {
+		client, err := dec.ReadVarUint()
+		if err != nil {
+			return nil, wrapUpdateErr(err)
+		}
+		clock, err := dec.ReadVarUint()
+		if err != nil {
+			return nil, wrapUpdateErr(err)
+		}
+		sv[ClientID(client)] = clock
 	}
 
 	return &Snapshot{StateVector: sv, DeleteSet: ds}, nil

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -592,6 +592,22 @@ func decodeAndPark(txn *Transaction, dec *encoding.Decoder, sv StateVector, numC
 				continue
 			}
 
+			// OriginRight referencing a not-yet-integrated clock: defer (Yjs
+			// getMissing parity). A root type's parent is resolved by name, so
+			// such an item is NOT caught by the parent==nil defer above; without
+			// this, an item whose right origin is a missing concurrent client
+			// would integrate at the wrong position — permanent divergence
+			// (review finding C-2). Deferral routes it through the within-update
+			// retry and, failing that, store.pending via itemFutureDep. Only at
+			// offset==0: a split (offset>0) overlaps an already-present item, so
+			// its origins are necessarily satisfied.
+			if offset == 0 && item.OriginRight != nil &&
+				item.OriginRight.Clock >= txn.doc.store.NextClock(item.OriginRight.Client) {
+				pending = append(pending, item)
+				clock = itemEnd
+				continue
+			}
+
 			// Resolve left neighbor from the Origin ID so that integrate()
 			// starts its scan from the correct position in the linked list.
 			// (Local inserts set item.Left directly; remote items only have Origin.)
@@ -631,15 +647,36 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 					item.Parent = ori.Parent
 				}
 			}
+			// Parent referenced by container item-ID (review finding C-3): now
+			// that earlier groups in this update have integrated, the container
+			// may exist. Resolve precisely BEFORE the ParentSub fallback below,
+			// which would otherwise graft this keyed item onto an arbitrary map.
+			if item.Parent == nil && item.parentID != nil {
+				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
+					if ct, ok := pi.Content.(*ContentType); ok {
+						item.Parent = ct.Type
+					}
+				}
+			}
 			// If the origin is a GC placeholder (no parent), search the
 			// entire store for an item with the same ParentSub that does
 			// have a parent. This handles the Yjs wire-format case where
 			// deleted YMap entries become GC structs and the parent type
 			// name is lost.
-			if item.Parent == nil && item.ParentSub != nil {
+			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
 				item.Parent = findParentForMapEntry(txn.doc.store)
 			}
 			if item.Parent != nil {
+				// A resolved parent is not sufficient: the item may still depend
+				// on a not-yet-integrated origin/rightOrigin clock (review finding
+				// C-2). Integrating now would place it at the wrong position
+				// (permanent divergence). Defer it to `remaining` so the
+				// no-progress branch below parks it via itemFutureDep for retry
+				// when the missing client arrives.
+				if _, _, isFuture := itemFutureDep(item, txn.doc.store); isFuture {
+					remaining = append(remaining, item)
+					continue
+				}
 				if item.Origin != nil {
 					item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
 				}
@@ -830,6 +867,7 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 
 	var parent *abstractType
 	var parentSub *string
+	var parentByID *ID // set when the parent is referenced by ID but not yet integrated
 
 	if !hasOrigin && !hasRightOrigin {
 		// Explicit parent info.
@@ -856,13 +894,18 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 			}
 			parentItem := doc.store.Find(ID{Client: ClientID(pc), Clock: pk})
 			if parentItem == nil {
-				return nil, fmt.Errorf("parent item {%d,%d} not found", pc, pk)
-			}
-			ct, ok := parentItem.Content.(*ContentType)
-			if !ok {
+				// Container not integrated yet. EncodeStateAsUpdate sorts groups
+				// ascending by client, so a lower-clientID item written into a
+				// higher-clientID peer's nested type decodes before its parent.
+				// Defer instead of hard-failing (Yjs pendingStructs parity,
+				// review finding C-3): record the parent ID and let integration
+				// resolve it once the container arrives.
+				parentByID = &ID{Client: ClientID(pc), Clock: pk}
+			} else if ct, ok := parentItem.Content.(*ContentType); ok {
+				parent = ct.Type
+			} else {
 				return nil, fmt.Errorf("parent item {%d,%d} is not a ContentType", pc, pk)
 			}
-			parent = ct.Type
 		}
 	}
 
@@ -892,6 +935,7 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 		OriginRight: originRight,
 		Parent:      parent,
 		ParentSub:   parentSub,
+		parentID:    parentByID,
 		Content:     content,
 	}
 
@@ -1262,7 +1306,20 @@ func tryIntegrate(txn *Transaction, item *Item) bool {
 				return false
 			}
 		}
-		if item.Parent == nil && item.ParentSub != nil {
+		// Parent referenced by container item-ID (review finding C-3): resolve
+		// precisely if the container has arrived; if it references a future
+		// clock, park (return false) rather than grafting onto an arbitrary map
+		// via the ParentSub fallback below.
+		if item.Parent == nil && item.parentID != nil {
+			if pi := store.Find(*item.parentID); pi != nil {
+				if ct, ok := pi.Content.(*ContentType); ok {
+					item.Parent = ct.Type
+				}
+			} else if item.parentID.Clock >= store.NextClock(item.parentID.Client) {
+				return false
+			}
+		}
+		if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
 			item.Parent = findParentForMapEntry(store)
 		}
 		if item.Parent == nil {
@@ -1274,6 +1331,18 @@ func tryIntegrate(txn *Transaction, item *Item) bool {
 
 	// Origin present but referring to a future clock -> still blocked.
 	if item.Origin != nil && item.Origin.Clock >= store.NextClock(item.Origin.Client) {
+		return false
+	}
+
+	// OriginRight referring to a future clock -> still blocked. Yjs's getMissing
+	// blocks integration on origin, rightOrigin, OR parent; ygo only checked
+	// OriginRight inside the Parent==nil branch above. A root type's parent is
+	// resolved by name, so that branch is skipped and an item whose right origin
+	// is a not-yet-integrated client would otherwise integrate at the wrong
+	// position (permanent divergence, review finding C-2). itemFutureDep already
+	// reports OriginRight as the missing dependency, so the item parks here and
+	// retries once that client's clock advances.
+	if item.OriginRight != nil && item.OriginRight.Clock >= store.NextClock(item.OriginRight.Client) {
 		return false
 	}
 
@@ -1302,6 +1371,14 @@ func itemFutureDep(item *Item, store *StructStore) (ClientID, uint64, bool) {
 		storeClock := store.NextClock(item.OriginRight.Client)
 		if item.OriginRight.Clock >= storeClock {
 			return item.OriginRight.Client, storeClock, true
+		}
+	}
+	// Parent referenced by an as-yet-unintegrated container item (review
+	// finding C-3): park on the container's client until it arrives.
+	if item.Parent == nil && item.parentID != nil {
+		storeClock := store.NextClock(item.parentID.Client)
+		if item.parentID.Clock >= storeClock {
+			return item.parentID.Client, storeClock, true
 		}
 	}
 	return 0, 0, false


### PR DESCRIPTION
Fixes five CRDT correctness/interop defects surfaced by an internal architecture review. Each is reproduced by a failing-then-passing test, and the wire-format fixes are verified against **real `yjs@13.6.30`**. No public API changes.

## Fixes

- **Concurrent `YMap`/attribute writes lost a key by apply order.** LWW picked the winner from the immediate linked-list right neighbour, so an unrelated-key write between two same-key writes made an item falsely rightmost — receivers diverged and cross-sync deleted the key. Winner is now the rightmost same-key item in (order-independent) YATA order; `itemMap`-miss fast path keeps distinct-key population O(N). Closes #110.
- **Out-of-order update with a missing `rightOrigin` integrated at the wrong position (permanent divergence).** The future-clock dependency check was skipped for root types. It now defers and retries once the missing client arrives — Yjs `getMissing` parity. Closes #111.
- **`ApplyUpdate` failed on a document's own full-state encode.** A parent-by-ID reference decoded before its (higher-clientID) parent and hard-failed. Such references are now deferred (`Item.parentID`) and resolved once the container integrates — Yjs `pendingStructs` parity. Closes #112.
- **`RelativePosition` wire format made Yjs-compatible.** Type tags were `1`/`2` instead of Yjs's `0`/`1`; every shared cursor exchanged with a JS peer mis-decoded or crashed lib0. Tags now match (`0`=item, `1`=tname, `2`=type), the type-anchored variant round-trips, `assoc` is optional on decode. Closes #113.
- **`Snapshot` wire format made Yjs-compatible.** ygo wrote the state vector first with per-block length prefixes; Yjs writes the delete set first, then the state vector, with none. Now matches `Y.encodeSnapshot` / `Y.decodeSnapshot`. Closes #114.

## Tests

- `crdt/convergence_p0_test.go` — failing→passing reproducers for the first three, plus `TestP0_ConcurrentUpdatesConvergeInAllOrders` (applies concurrent updates in **all 24 permutations**, asserts byte-identical convergence — a down-payment on a randomized-convergence fuzzer).
- `crdt/relpos_snapshot_js_compat_test.go` — `TestCompat_RelPosAndSnapshot_GoToJS`: Go encodes a RelativePosition + Snapshot, real `yjs@13.6.30` decodes them; the item cursor resolves to the correct index and the snapshot's state vector / delete set match.

## Verification

- `go test -race ./...` green across all packages; all node-executing `TestCompat_*` cross-language tests pass against `yjs@13.6.30`.
- `gofmt` / `go vet` / `golangci-lint` clean.
- Benchstat vs `main` (hot paths): **speed unchanged, allocs/op identical**; B/op +3.7% from the single `parentID` word added to `Item` (a side-map is a possible later optimization).

## Compatibility

No public API changes. The internal `RelativePosition` and `Snapshot` **byte formats** changed to become Yjs-compatible — re-capture any such bytes persisted from v1.23.0 (document update and state-vector formats are unchanged). Targets **v1.23.1**; ships ahead of the mobile bindings (#108, draft).

## Known follow-up (out of scope)

While fixing #113 I found a separate resolution-semantics gap: ygo resolves a null-item (tname) `RelativePosition` to index 0 (start), whereas Yjs resolves it to end-of-type. Distinct from the wire-tag fix; worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)