### PR TITLE
feat(awareness): cap client entries + server-side expiry (S-1 DoS hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.0] — 2026-06-11
+
+### Security
+
+- **Bounded awareness memory growth (DoS hardening).** A peer could exhaust a
+  room's memory by sending awareness updates that invent unbounded client IDs —
+  including null-state entries, which bypassed the existing per-room byte cap.
+  `awareness.Awareness` now supports `SetMaxClients(n)`, a cap on the number of
+  distinct tracked client entries (live presence plus removal tombstones); once
+  reached, previously-unseen client IDs are dropped while existing clients keep
+  updating. The websocket `Server` exposes this as `MaxAwarenessClientsPerRoom`.
+
+### Added
+
+- **Server-side awareness expiry.** `Server.AwarenessExpiry` (when > 0) starts a
+  per-room background sweep that reclaims a remote client's presence after the
+  configured idle duration — clearing "ghost" presence left by peers that died
+  silently (mobile sleep, NAT timeout) without a clean disconnect. The sweep
+  goroutine is stopped when the room is evicted.
+- **`cmd/ygo-server` flags** `-max-awareness-clients` (default 10000) and
+  `-awareness-expiry` (default 30s) wire the two protections on by default for
+  the turnkey server.
+
 ## [1.24.0] — 2026-06-09
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,55 +1,40 @@
 ## What's new
 
-Native mobile bindings. This release adds a new `mobile/` package: a
-gomobile-bindable façade over ygo's `crdt` and `awareness` packages, so you can
-embed ygo directly in iOS and Android apps via `gomobile bind` — no JavaScript
-runtime and no CGo. v1 scope is **sync + render**: apply peer updates, encode
-state/diffs, and read the current document and presence; on-device editing
-(mutators) is a planned follow-up.
+Server-side awareness hardening. This release closes a memory-exhaustion DoS in
+the awareness subsystem and reclaims stale presence, with new knobs on the
+websocket server and the `ygo-server` binary. No breaking API changes.
 
-### Added — `mobile/` (gomobile bindings for iOS/Android)
+### Security
 
-The package exposes two bound types with a **gomobile-safe surface** —
-gomobile bind only supports a restricted set of types across the language
-boundary, so every method uses only `string`, `int64`, `bool`, `[]byte`,
-`error`, and the bound pointers `*Doc` / `*Awareness` (no unsigned ints, maps,
-non-byte slices, `any`, variadics, or callbacks; the package translates at the
-boundary):
+- **Bounded awareness memory growth.** A peer could exhaust a room's memory by
+  sending awareness updates that invent unbounded client IDs — including
+  null-state entries, which bypassed the existing per-room byte cap. A new
+  distinct-entry cap stops this: once a room is at capacity, previously-unseen
+  client IDs are dropped while already-tracked clients keep updating.
+  - `awareness.Awareness.SetMaxClients(n)` — library-level cap.
+  - `websocket.Server.MaxAwarenessClientsPerRoom` — per-room cap.
 
-- **`Doc`** — `NewDoc` / `NewDocWithClientID`, `ClientID`, `ApplyUpdate`,
-  `EncodeStateAsUpdate`, `EncodeStateVector`, `EncodeDiff` (incremental sync from
-  a remote state vector), `GetText`, `GetTextJSON`, `GetMapJSON`, `GetArrayJSON`,
-  and `Close`.
-- **`Awareness`** — `NewAwareness`, `ClientID`, `SetLocalState`,
-  `ClearLocalState`, `LocalStateJSON`, `StatesJSON`, `EncodeAll`, `ApplyUpdate`,
-  and `Close`.
+### Added
 
-Build the frameworks with the standard gomobile tooling (a build-time tool, not
-a dependency — `go.mod` is unchanged):
+- **Server-side awareness expiry.** `websocket.Server.AwarenessExpiry` (when
+  > 0) reclaims a remote client's presence after it goes idle, clearing "ghost"
+  presence left by peers that died silently (mobile sleep, NAT timeout) without
+  a clean disconnect. The per-room sweep goroutine is stopped on room eviction.
+- **`ygo-server` flags** `-max-awareness-clients` (default 10000) and
+  `-awareness-expiry` (default 30s) enable both protections out of the box.
 
-```
-gomobile bind -target=ios     ./mobile   # → Mobile.xcframework
-gomobile bind -target=android -androidapi 21 ./mobile   # → mobile.aar
-```
+### Compatibility
 
-All methods are synchronous and blocking and copy `[]byte` across the boundary,
-so call `ApplyUpdate` / `Encode*` off the UI thread (Kotlin `Dispatchers.IO` /
-a Swift background queue) and prefer incremental `EncodeDiff` over full-state
-encodes on the hot path. Call `Close()` when done (`ViewModel.onCleared` /
-Swift `deinit`) rather than relying on cross-binding finalization.
-
-The package is pure-Go / CGo-free, so it builds with `CGO_ENABLED=0` like the
-rest of ygo (guarded in CI). Note one known caveat: `GetTextJSON` and
-`StatesJSON` currently return ygo's internal struct shapes (Go field names),
-not idiomatic Yjs JSON; stable/idiomatic shapes are a planned follow-up, so
-don't hard-code against them long-term. See [`mobile/README.md`](https://github.com/reearth/ygo/blob/main/mobile/README.md)
-for the full integration guide (threading, lifecycle, binary size / ABI,
-error handling, change notifications, and Kotlin/Swift snippets).
+No breaking API changes — the new fields and methods are additive and default
+to off at the library level (0 = unlimited / disabled), preserving existing
+behavior. The `ygo-server` binary now enables both protections by default;
+pass `-max-awareness-clients 0` / `-awareness-expiry 0` to restore the prior
+unbounded behavior.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.24.0
+go get github.com/reearth/ygo@v1.25.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -123,6 +123,7 @@ type Awareness struct {
 	wireBytes   map[uint64]int
 	activeBytes int64 // sum of wireBytes values
 	maxBytes    int64 // 0 = unlimited (default; backward compatible)
+	maxClients  int   // 0 = unlimited (default; backward compatible)
 }
 
 // New creates an Awareness instance for the given client.
@@ -151,6 +152,26 @@ func New(clientID uint64) *Awareness {
 func (a *Awareness) SetMaxBytes(n int64) {
 	a.mu.Lock()
 	a.maxBytes = n
+	a.mu.Unlock()
+}
+
+// SetMaxClients caps the number of distinct client entries this Awareness will
+// track — live presence plus retained removal tombstones. Once the cap is
+// reached, ApplyUpdate refuses previously-unseen client IDs; clients already
+// tracked can still update and be removed. This bounds memory against a peer
+// that invents unbounded client IDs to exhaust the room — including null-state
+// entries, which are NOT subject to the byte cap (see SetMaxBytes) and so would
+// otherwise grow the states map without limit.
+//
+// A value of 0 (the default) disables the cap. Local state set via
+// SetLocalState is exempt — the local client is always allowed. Suggested
+// production value: a few thousand to tens of thousands per room.
+//
+// Set this once at construction time; changes while concurrent updates are
+// being processed are safe (the field is read under a.mu).
+func (a *Awareness) SetMaxClients(n int) {
+	a.mu.Lock()
+	a.maxClients = n
 	a.mu.Unlock()
 }
 
@@ -449,6 +470,16 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 				a.states[a.clientID] = ClientState{Clock: a.clock, State: current.State}
 				updated = append(updated, a.clientID)
 			}
+			continue
+		}
+
+		// Distinct-entry cap (#48 / S-1 DoS guard): once the room is at
+		// capacity, refuse previously-unseen client IDs. Already-tracked clients
+		// (exists) still update and can be removed. This bounds the states map
+		// against a peer inventing unbounded client IDs — crucially including
+		// null-state entries, which bypass the byte cap above. The local client
+		// is exempt: it is handled by the self-state branch before this point.
+		if !exists && a.maxClients > 0 && len(a.states) >= a.maxClients {
 			continue
 		}
 

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -478,9 +478,17 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 		// (exists) still update and can be removed. This bounds the states map
 		// against a peer inventing unbounded client IDs — crucially including
 		// null-state entries, which bypass the byte cap above. The local client
-		// is exempt: it is handled by the self-state branch before this point.
-		if !exists && a.maxClients > 0 && len(a.states) >= a.maxClients {
-			continue
+		// is exempt — it is set by trusted embedder code, not adversarial wire
+		// input — so it does not count toward the cap and is never rejected here
+		// (the self-state branch above already handles a null for our own ID).
+		if !exists && a.maxClients > 0 {
+			remote := len(a.states)
+			if _, hasLocal := a.states[a.clientID]; hasLocal {
+				remote-- // exclude the exempt local entry from the cap
+			}
+			if remote >= a.maxClients {
+				continue
+			}
 		}
 
 		wasActive := exists && current.State != nil
@@ -591,7 +599,15 @@ func (a *Awareness) StartAutoExpiry(timeout time.Duration) func() {
 		prev()
 	}
 
-	ticker := time.NewTicker(timeout / 2)
+	// Tick at half the timeout so an entry is checked at least twice within its
+	// window. Clamp to a positive minimum: time.NewTicker panics on a zero or
+	// negative duration, and timeout is caller- (and CLI-) configurable, so a
+	// sub-2ns value would make timeout/2 round to 0 and crash the room.
+	interval := timeout / 2
+	if interval <= 0 {
+		interval = 1
+	}
+	ticker := time.NewTicker(interval)
 	done := make(chan struct{})
 	go func() {
 		defer ticker.Stop()

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -389,6 +389,15 @@ func TestUnit_Awareness_ApplyUpdate_StateTooLarge_Errors(t *testing.T) {
 	assert.ErrorIs(t, err, awareness.ErrStateTooLarge)
 }
 
+func TestAwareness_StartAutoExpiry_TinyTimeoutDoesNotPanic(t *testing.T) {
+	// A sub-2ns timeout makes timeout/2 round to 0; time.NewTicker(0) panics.
+	// Since the timeout is caller- (and CLI-) configurable, StartAutoExpiry must
+	// clamp the tick interval rather than crash.
+	a := awareness.New(0)
+	stop := a.StartAutoExpiry(1 * time.Nanosecond) // would panic without the clamp
+	stop()
+}
+
 func TestAwareness_StartAutoExpiry_NoLeakOnDoubleCall(t *testing.T) {
 	// Regression for #34: calling StartAutoExpiry twice must not leak
 	// the first goroutine.

--- a/awareness/maxclients_test.go
+++ b/awareness/maxclients_test.go
@@ -1,0 +1,60 @@
+package awareness
+
+import "testing"
+
+// encodeOne builds a single-client awareness update frame for clientID with the
+// given JSON state, at clock 1. Mirrors the wire format ApplyUpdate expects.
+func encodeOneEntry(t *testing.T, clientID uint64, stateJSON string) []byte {
+	t.Helper()
+	a := New(clientID)
+	if stateJSON == "null" {
+		// represent a removal: set then clear so clock advances to a null entry
+		a.SetLocalState(map[string]any{"x": 1})
+		a.SetLocalState(nil)
+	} else {
+		a.SetLocalState(map[string]any{"v": stateJSON})
+	}
+	return a.EncodeUpdate([]uint64{clientID})
+}
+
+func TestApplyUpdate_MaxClients_CapsDistinctEntries(t *testing.T) {
+	a := New(0)
+	a.SetMaxClients(3) // cap incl. any local entry; local id 0 has no state here
+
+	// Invent 10 distinct client IDs with live state. Only up to the cap are kept.
+	for id := uint64(1); id <= 10; id++ {
+		_ = a.ApplyUpdate(encodeOneEntry(t, id, "hi"), nil)
+	}
+	if got := len(a.GetStates()); got > 3 {
+		t.Fatalf("distinct entries = %d, want <= 3 (cap)", got)
+	}
+
+	// Existing clients can still update past the cap (not a new ID).
+	// Pick one accepted id and re-apply a newer clock; must not error/panic.
+	for id := range a.GetStates() {
+		_ = a.ApplyUpdate(encodeOneEntry(t, id, "again"), nil)
+		break
+	}
+}
+
+func TestApplyUpdate_MaxClients_NullEntriesAlsoCapped(t *testing.T) {
+	a := New(0)
+	a.SetMaxClients(2)
+	// Null-state invented IDs are the DoS vector (they bypass the byte cap).
+	for id := uint64(1); id <= 50; id++ {
+		_ = a.ApplyUpdate(encodeOneEntry(t, id, "null"), nil)
+	}
+	if got := len(a.GetStates()); got > 2 {
+		t.Fatalf("null-entry distinct count = %d, want <= 2 (cap)", got)
+	}
+}
+
+func TestApplyUpdate_MaxClients_ZeroIsUnlimited(t *testing.T) {
+	a := New(0) // no SetMaxClients → unlimited (backward compatible)
+	for id := uint64(1); id <= 20; id++ {
+		_ = a.ApplyUpdate(encodeOneEntry(t, id, "hi"), nil)
+	}
+	if got := len(a.GetStates()); got != 20 {
+		t.Fatalf("unlimited: distinct entries = %d, want 20", got)
+	}
+}

--- a/awareness/maxclients_test.go
+++ b/awareness/maxclients_test.go
@@ -2,13 +2,16 @@ package awareness
 
 import "testing"
 
-// encodeOne builds a single-client awareness update frame for clientID with the
-// given JSON state, at clock 1. Mirrors the wire format ApplyUpdate expects.
+// encodeOneEntry builds a single-client awareness update frame for clientID with
+// the given JSON state. For a live state the frame is at clock 1; for the "null"
+// removal case it sets then clears local state, so the frame is at clock 2.
+// Mirrors the wire format ApplyUpdate expects.
 func encodeOneEntry(t *testing.T, clientID uint64, stateJSON string) []byte {
 	t.Helper()
 	a := New(clientID)
 	if stateJSON == "null" {
-		// represent a removal: set then clear so clock advances to a null entry
+		// Represent a removal: set then clear, so the encoded entry is a null
+		// (removed) state carrying clock 2.
 		a.SetLocalState(map[string]any{"x": 1})
 		a.SetLocalState(nil)
 	} else {
@@ -17,22 +20,30 @@ func encodeOneEntry(t *testing.T, clientID uint64, stateJSON string) []byte {
 	return a.EncodeUpdate([]uint64{clientID})
 }
 
+// applyEntry applies a single-client frame and fails the test on error — these
+// helper frames are always valid, so an error means a real regression.
+func applyEntry(t *testing.T, a *Awareness, clientID uint64, stateJSON string) {
+	t.Helper()
+	if err := a.ApplyUpdate(encodeOneEntry(t, clientID, stateJSON), nil); err != nil {
+		t.Fatalf("ApplyUpdate(client %d, %q): %v", clientID, stateJSON, err)
+	}
+}
+
 func TestApplyUpdate_MaxClients_CapsDistinctEntries(t *testing.T) {
 	a := New(0)
-	a.SetMaxClients(3) // cap incl. any local entry; local id 0 has no state here
+	a.SetMaxClients(3) // caps REMOTE entries; the local client (id 0) is exempt
 
-	// Invent 10 distinct client IDs with live state. Only up to the cap are kept.
+	// Invent 10 distinct remote client IDs with live state; only the cap is kept.
 	for id := uint64(1); id <= 10; id++ {
-		_ = a.ApplyUpdate(encodeOneEntry(t, id, "hi"), nil)
+		applyEntry(t, a, id, "hi")
 	}
-	if got := len(a.GetStates()); got > 3 {
+	if got := len(a.states); got > 3 {
 		t.Fatalf("distinct entries = %d, want <= 3 (cap)", got)
 	}
 
-	// Existing clients can still update past the cap (not a new ID).
-	// Pick one accepted id and re-apply a newer clock; must not error/panic.
-	for id := range a.GetStates() {
-		_ = a.ApplyUpdate(encodeOneEntry(t, id, "again"), nil)
+	// An already-tracked client can still update past the cap (not a new ID).
+	for id := range a.states {
+		applyEntry(t, a, id, "again")
 		break
 	}
 }
@@ -40,11 +51,13 @@ func TestApplyUpdate_MaxClients_CapsDistinctEntries(t *testing.T) {
 func TestApplyUpdate_MaxClients_NullEntriesAlsoCapped(t *testing.T) {
 	a := New(0)
 	a.SetMaxClients(2)
-	// Null-state invented IDs are the DoS vector (they bypass the byte cap).
+	// Null-state invented IDs are the DoS vector — they bypass the byte cap and
+	// are stored as tombstones, so assert on the internal states map (tombstones
+	// included), not GetStates (which returns only active clients).
 	for id := uint64(1); id <= 50; id++ {
-		_ = a.ApplyUpdate(encodeOneEntry(t, id, "null"), nil)
+		applyEntry(t, a, id, "null")
 	}
-	if got := len(a.GetStates()); got > 2 {
+	if got := len(a.states); got > 2 {
 		t.Fatalf("null-entry distinct count = %d, want <= 2 (cap)", got)
 	}
 }
@@ -52,9 +65,26 @@ func TestApplyUpdate_MaxClients_NullEntriesAlsoCapped(t *testing.T) {
 func TestApplyUpdate_MaxClients_ZeroIsUnlimited(t *testing.T) {
 	a := New(0) // no SetMaxClients → unlimited (backward compatible)
 	for id := uint64(1); id <= 20; id++ {
-		_ = a.ApplyUpdate(encodeOneEntry(t, id, "hi"), nil)
+		applyEntry(t, a, id, "hi")
 	}
-	if got := len(a.GetStates()); got != 20 {
+	if got := len(a.states); got != 20 {
 		t.Fatalf("unlimited: distinct entries = %d, want 20", got)
+	}
+}
+
+func TestApplyUpdate_MaxClients_LocalClientExempt(t *testing.T) {
+	// The local client must not consume a remote cap slot. Set local state FIRST
+	// so states = {7}, then apply a new remote client with cap=1: it must be
+	// accepted, because the cap counts remote entries only. (Without excluding
+	// the local entry, len(states)=1 >= 1 would wrongly reject the remote.)
+	a := New(7)
+	a.SetMaxClients(1)
+	a.SetLocalState(map[string]any{"me": true}) // states = {7}; local is exempt
+	applyEntry(t, a, 100, "hi")                 // new remote; must be accepted despite cap=1
+	if _, ok := a.states[7]; !ok {
+		t.Fatal("local client (7) missing")
+	}
+	if v, ok := a.GetStates()[100]; !ok || v.State == nil {
+		t.Fatal("remote client 100 was rejected; the local client must not consume a cap slot")
 	}
 }

--- a/cmd/ygo-server/main.go
+++ b/cmd/ygo-server/main.go
@@ -68,6 +68,13 @@ type Config struct {
 	MaxRooms int
 	// MaxMessageBytes is the per-message read cap in bytes.
 	MaxMessageBytes int64
+	// MaxAwarenessClients caps the distinct awareness client entries per room
+	// (live presence plus removal tombstones). Bounds memory against a peer that
+	// invents unbounded client IDs. 0 = unlimited.
+	MaxAwarenessClients int
+	// AwarenessExpiry reclaims a remote client's presence if no update arrives
+	// within this duration (ghost-presence cleanup). 0 = disabled.
+	AwarenessExpiry time.Duration
 	// Redis is the Redis address for the cross-process relay. Empty disables
 	// clustering.
 	Redis string
@@ -92,6 +99,8 @@ func parseFlags(args []string) (Config, error) {
 	fs.IntVar(&cfg.MaxPeersPerRoom, "max-peers-per-room", 0, "per-room peer cap (0 = unlimited)")
 	fs.IntVar(&cfg.MaxRooms, "max-rooms", 0, "cap on total resident rooms (0 = unlimited)")
 	fs.Int64Var(&cfg.MaxMessageBytes, "max-message-bytes", 64<<20, "per-message read cap in bytes")
+	fs.IntVar(&cfg.MaxAwarenessClients, "max-awareness-clients", 10_000, "per-room cap on distinct awareness client entries (0 = unlimited)")
+	fs.DurationVar(&cfg.AwarenessExpiry, "awareness-expiry", 30*time.Second, "reclaim a remote client's presence after this idle duration (0 = disabled)")
 	fs.StringVar(&cfg.Redis, "redis", "", "Redis address for cross-process relay (empty = disabled)")
 	fs.StringVar(&cfg.Path, "path", "/yjs/{room}", "URL path pattern for the WebSocket handler")
 	fs.StringVar(&cfg.Log, "log", "text", `log format: "text" or "json"`)
@@ -166,6 +175,8 @@ func run(ctx context.Context, cfg Config, ready chan<- struct{}) error {
 	srv.MaxPeersPerRoom = cfg.MaxPeersPerRoom
 	srv.MaxRooms = cfg.MaxRooms
 	srv.MaxMessageBytes = cfg.MaxMessageBytes
+	srv.MaxAwarenessClientsPerRoom = cfg.MaxAwarenessClients
+	srv.AwarenessExpiry = cfg.AwarenessExpiry
 	srv.Logger = log
 
 	// Clustering: a non-empty Redis address attaches a Redis-backed relay so

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -525,6 +525,9 @@ func (s *Server) CloseRoom(name string, force bool) error {
 	// s.rooms (the early-return above handled the lost-race case), so
 	// firing here is exactly-once vs handleDisconnect — see #93 self-
 	// review B1.
+	// Stop the awareness auto-expiry goroutine (if any) so it doesn't outlive
+	// the room. Idempotent; no-op when expiry was never started.
+	rm.awareness.Destroy()
 	s.teardownRelayRoom(rm, name)
 	if hook := s.OnUnloadDocument; hook != nil {
 		s.safeHook("OnUnloadDocument", func() {

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -274,6 +274,9 @@ func (p *peer) handleDisconnect() {
 			}
 		}
 		if roomEvicted {
+			// Stop the awareness auto-expiry goroutine (if any) so it doesn't
+			// outlive the room. Idempotent; no-op when expiry was never started.
+			rm.awareness.Destroy()
 			p.server.teardownRelayRoom(rm, p.roomName)
 			if hook := p.server.OnUnloadDocument; hook != nil {
 				p.server.safeHook("OnUnloadDocument", func() {

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -406,6 +406,23 @@ type Server struct {
 	// cap. Suggested production value: 100 MiB. See issue #48 vector B.
 	MaxAwarenessBytesPerRoom int64
 
+	// MaxAwarenessClientsPerRoom caps the number of DISTINCT awareness client
+	// entries tracked in one room (live presence plus retained removal
+	// tombstones). Without it a peer can invent unbounded client IDs — including
+	// null-state entries, which bypass MaxAwarenessBytesPerRoom — to exhaust
+	// memory. Previously-unseen client IDs past this cap are dropped. Zero (the
+	// default) disables the cap. Suggested production value: 10,000.
+	MaxAwarenessClientsPerRoom int
+
+	// AwarenessExpiry, when > 0, starts a per-room background sweep that marks a
+	// remote client's presence as removed if no update for it arrives within this
+	// duration. It reclaims "ghost" presence from peers that died silently
+	// (mobile sleep, NAT timeout, half-open TCP) without a clean disconnect.
+	// Zero (the default) disables auto-expiry. Suggested production value: 30s
+	// (matching y-protocols). The sweep goroutine is stopped when the room is
+	// evicted.
+	AwarenessExpiry time.Duration
+
 	// connSem enforces MaxConnections as a hard cap. Lazily initialised on
 	// first ServeHTTP. nil when MaxConnections == 0 (unlimited).
 	connSem     *semaphore.Weighted
@@ -573,6 +590,13 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 	aw := awareness.New(0)
 	if s.MaxAwarenessBytesPerRoom > 0 {
 		aw.SetMaxBytes(s.MaxAwarenessBytesPerRoom)
+	}
+	if s.MaxAwarenessClientsPerRoom > 0 {
+		aw.SetMaxClients(s.MaxAwarenessClientsPerRoom)
+	}
+	if s.AwarenessExpiry > 0 {
+		// Background sweep; stopped via aw.Destroy() when the room is evicted.
+		aw.StartAutoExpiry(s.AwarenessExpiry)
 	}
 	r := &room{
 		doc:       crdt.New(docOpts...),

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -418,9 +418,16 @@ type Server struct {
 	// remote client's presence as removed if no update for it arrives within this
 	// duration. It reclaims "ghost" presence from peers that died silently
 	// (mobile sleep, NAT timeout, half-open TCP) without a clean disconnect.
-	// Zero (the default) disables auto-expiry. Suggested production value: 30s
-	// (matching y-protocols). The sweep goroutine is stopped when the room is
-	// evicted.
+	// Zero (the default) disables auto-expiry. The sweep goroutine is stopped
+	// when the room is evicted.
+	//
+	// Set this comfortably ABOVE the clients' presence keep-alive interval, or a
+	// still-connected client will be expired between its keep-alives. Yjs clients
+	// re-announce local presence roughly every 15s (half the y-protocols 30s
+	// outdated-timeout), and that re-announce — including for a peer attached to
+	// another cluster node, since awareness is relayed — refreshes the entry's
+	// last-update time here. The default suggested value 30s leaves ample margin;
+	// values at or below ~15s risk flapping live peers offline.
 	AwarenessExpiry time.Duration
 
 	// connSem enforces MaxConnections as a hard cap. Lazily initialised on

--- a/provider/websocket/server_internal_test.go
+++ b/provider/websocket/server_internal_test.go
@@ -2,11 +2,16 @@
 package websocket
 
 import (
+	"context"
 	"io"
 	"log/slog"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/reearth/ygo/awareness"
 )
 
 func TestServer_MaxMessageBytes_ConfigurableDefault(t *testing.T) {
@@ -50,4 +55,62 @@ func TestPeer_RunWriter_ExitsOnChannelClose(t *testing.T) {
 	// Verify runWriter exits cleanly when writeCh is closed.
 	// Requires a fake peer + fake conn.
 	t.Skip("requires fake conn; see implementation comment")
+}
+
+// awarenessUpdateFor builds a one-client awareness update frame (live state) for
+// use in wiring tests.
+func awarenessUpdateFor(id uint64) []byte {
+	a := awareness.New(id)
+	a.SetLocalState(map[string]any{"v": "x"})
+	return a.EncodeUpdate([]uint64{id})
+}
+
+// TestServer_MaxAwarenessClientsPerRoom_IsWired verifies the per-room distinct-
+// entry cap is applied to rooms the server creates (S-1 DoS guard).
+func TestServer_MaxAwarenessClientsPerRoom_IsWired(t *testing.T) {
+	s := NewServer()
+	s.MaxAwarenessClientsPerRoom = 2
+	rm, err := s.getOrCreateRoom(context.Background(), "room")
+	if err != nil {
+		t.Fatalf("getOrCreateRoom: %v", err)
+	}
+	for id := uint64(1); id <= 10; id++ {
+		_ = rm.awareness.ApplyUpdate(awarenessUpdateFor(id), nil)
+	}
+	if got := len(rm.awareness.GetStates()); got > 2 {
+		t.Fatalf("room awareness tracked %d clients, want <= 2 (cap not wired)", got)
+	}
+}
+
+// TestServer_AwarenessExpiry_GoroutineStoppedOnEvict verifies the auto-expiry
+// goroutine started for a room does not outlive the room (CloseRoom -> Destroy).
+func TestServer_AwarenessExpiry_GoroutineStoppedOnEvict(t *testing.T) {
+	s := NewServer()
+	s.AwarenessExpiry = 50 * time.Millisecond
+
+	before := runtime.NumGoroutine()
+	rm, err := s.getOrCreateRoom(context.Background(), "room")
+	if err != nil {
+		t.Fatalf("getOrCreateRoom: %v", err)
+	}
+	if rm.awareness == nil {
+		t.Fatal("room has no awareness")
+	}
+	if err := s.CloseRoom("room", true); err != nil {
+		t.Fatalf("CloseRoom: %v", err)
+	}
+
+	// Poll until the goroutine count returns to baseline (the expiry goroutine
+	// exits when Destroy stops it). Condition-based wait avoids flakiness.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		runtime.Gosched()
+		if runtime.NumGoroutine() <= before+1 { // +1 tolerance for scheduler noise
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expiry goroutine leaked: before=%d after=%d", before, runtime.NumGoroutine())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/provider/websocket/server_internal_test.go
+++ b/provider/websocket/server_internal_test.go
@@ -75,7 +75,9 @@ func TestServer_MaxAwarenessClientsPerRoom_IsWired(t *testing.T) {
 		t.Fatalf("getOrCreateRoom: %v", err)
 	}
 	for id := uint64(1); id <= 10; id++ {
-		_ = rm.awareness.ApplyUpdate(awarenessUpdateFor(id), nil)
+		if err := rm.awareness.ApplyUpdate(awarenessUpdateFor(id), nil); err != nil {
+			t.Fatalf("ApplyUpdate(client %d): %v", id, err)
+		}
 	}
 	if got := len(rm.awareness.GetStates()); got > 2 {
 		t.Fatalf("room awareness tracked %d clients, want <= 2 (cap not wired)", got)


### PR DESCRIPTION
Closes #116. Addresses the **S-1** awareness memory-exhaustion DoS from the internal architecture review. **Draft** — sequenced behind the mobile bindings PR (#108, v1.24.0).

## The bug
`awareness.ApplyUpdate` stored a `ClientState` for every client ID in a frame with no ownership check and no cap on distinct entries. **Null-state entries bypassed `MaxAwarenessBytesPerRoom` entirely**, so a peer inventing unbounded client IDs could grow a room's `states` map without limit until OOM. The server also never expired stale presence.

## Fix
- **`awareness.Awareness.SetMaxClients(n)`** — caps distinct tracked entries (live presence + removal tombstones). Once at capacity, `ApplyUpdate` drops previously-unseen client IDs while already-tracked clients keep updating. `0` = unlimited (default; backward compatible). The local client is exempt.
- **`websocket.Server.MaxAwarenessClientsPerRoom`** — per-room cap, wired into room creation.
- **`websocket.Server.AwarenessExpiry`** — when > 0, starts a per-room sweep (`RemoveExpired`) that reclaims a remote client's presence after the idle timeout, clearing "ghost" presence from peers that died silently (mobile sleep, NAT timeout). The sweep goroutine is stopped via `awareness.Destroy()` at **both** room-eviction sites (`handleDisconnect` roomEvicted path + `CloseRoom`).
- **`cmd/ygo-server`** — `-max-awareness-clients` (default 10000) and `-awareness-expiry` (default 30s) enable both protections out of the box.

## Tests
- `awareness`: distinct-entry cap (live + null-entry DoS vector + unlimited-default).
- `provider/websocket` (white-box): cap applied to server-created rooms; expiry goroutine cleaned up on room eviction (goroutine-leak check).
- Full `go test -race ./...` green; `go vet` + `golangci-lint` clean.

## Compatibility
No breaking API changes — new fields/methods are additive and default to off at the library level (`0` = unlimited/disabled). `cmd/ygo-server` enables both by default; pass `-max-awareness-clients 0` / `-awareness-expiry 0` to restore prior behavior.

## Versioning
Targets **v1.25.0**, assuming #108 (mobile) ships first as v1.24.0. Trivially renumbered if merge order changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)