### PR TITLE
ci: test on latest Go, fix fuzz crash-corpus path, refresh action versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23", "1.24"]
+        # Minimum supported (go.mod floor) + latest stable. Keep the upper bound
+        # in step with the govulncheck job below as new Go releases land.
+        go: ["1.23", "1.26"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           cache: true
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: testutil/package-lock.json
       - run: npm ci
@@ -35,7 +37,7 @@ jobs:
       - run: go test -race -timeout 120s -coverprofile=coverage.txt -covermode=atomic ./...
       - name: CGo-free build (pure Go)
         run: CGO_ENABLED=0 go build ./persistence/sqlite/... ./cmd/ygo-server/... ./mobile/...
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: matrix.go == '1.23'
         with:
           files: coverage.txt
@@ -45,20 +47,20 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23"
           cache: true
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   vuln:
     name: Vulnerability scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           # Track the latest 1.26 patch so the scan always runs on a toolchain

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,7 +21,7 @@ jobs:
           - { pkg: "./crdt/",     func: "FuzzApplyUpdateV2" }
           - { pkg: "./sync/",     func: "FuzzApplySyncMessage" }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23"
@@ -33,4 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-crash-${{ matrix.target.func }}
-          path: testdata/fuzz/
+          # Go writes new crash inputs under <package>/testdata/fuzz/<Func>/,
+          # not a repo-root testdata/fuzz/ — match any package's corpus so the
+          # reproducer is actually captured when a fuzzer fails.
+          path: "**/testdata/fuzz/**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v5
@@ -21,7 +21,7 @@ jobs:
           cache: true
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: testutil/package-lock.json
       - run: npm ci


### PR DESCRIPTION
## Summary

CI workflow refresh — the workflows had drifted. Three changes, all
infrastructure-only (no library code touched):

### Functional fixes
- **Test matrix runs on current Go.** `ci.yml` tested `["1.23", "1.24"]`, but the
  vuln job already treats **1.26** as latest — so the suite never ran on the Go
  release most users are on. Now `["1.23", "1.26"]` (min-supported floor +
  latest stable).
- **Fuzz crash reproducers are actually captured.** `fuzz.yml` uploaded
  `testdata/fuzz/` (repo root), but Go writes new crash inputs under
  `<package>/testdata/fuzz/<Func>/` (confirmed: `crdt/testdata/fuzz/`,
  `sync/testdata/fuzz/`). So the day a nightly fuzz run found a crash, the
  `if: failure()` upload would find nothing and the reproducer would be lost.
  Now matches `**/testdata/fuzz/**`.

### Catch-up version bumps
- `actions/checkout` v4 → v5 (all workflows)
- `codecov/codecov-action` v4 → v5
- `actions/setup-node` Node 20 → 22 (Node 20 nears maintenance EOL)
- pinned `golangci-lint` v2.11.4 → v2.12.2 — verified clean (`0 issues`) locally
  on `main`'s code before bumping, so it won't surface new failures.

## Notes / deliberately out of scope
- **Dependabot** (`github-actions` + `gomod`) would prevent this drift recurring;
  left out of this PR by request — easy to add later.
- `golangci-lint-action` kept at `@v7` (v2-compatible, known-good) rather than
  bumping the action major unverified.
- `release.yml` / `benchmark.yml` / `fuzz.yml` Go pin left at `1.23` — the
  release gate and benchmark baseline intentionally track the floor; the full
  matrix on PRs is what exercises latest Go.

All four workflow files pass YAML validation. CI on this PR will exercise the
new `checkout@v5` / `codecov@v5` / Node 22 / Go 1.26 combination directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
