### PR TITLE
fix(crdt): UndoManager undo-of-deletion CRDT soundness + export SharedType (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restoration), so it opens markers only where the value changes, deletes only
   in-range overlapping markers, and restores the post-range state. Verified
   against `yjs@13.6.30` across fresh and loaded docs.
+- **`UndoManager` undo of a deletion now propagates to peers (CRDT-sound).**
+  Undo previously flipped `Deleted = false` in place, which produced no wire
+  record: a peer that already had the tombstone never revived the content, and a
+  back-sync re-deleted it locally — silently losing the undo. Undo now re-inserts
+  a copy of the deleted content as a new item (Yjs `redoItem`), so the
+  restoration is a normal insert that converges across peers. Works for YText,
+  YArray, and YMap. (Undoing a deletion of items inside a *deleted nested type*
+  remains a known gap.)
+
+### Added
+
+- **`crdt.SharedType`** — the previously-unexported interface satisfied by
+  `YText` / `YArray` / `YMap` / `YXml*` is now exported, so `NewUndoManager`'s
+  scope can be named from outside the package (`crdt.NewUndoManager(doc,
+  []crdt.SharedType{txt, arr})`). It was effectively unusable externally before.
+  Its methods stay unexported, so only ygo's own types can satisfy it.
 
 ### Changed
 

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -12,6 +12,15 @@ type posCacheEntry struct {
 	item  *Item
 }
 
+// SharedType is the public interface satisfied by every exported CRDT type
+// (YArray, YMap, YText, YXmlFragment, …). It exists so external callers can
+// name the element type of NewUndoManager's scope slice
+// (`[]crdt.SharedType{txt, arr}`). Its methods are unexported, so only ygo's own
+// types can satisfy it — external code can pass and hold values, but not
+// implement it. It is a type alias for the internal sharedType, so existing
+// in-package call sites are unaffected.
+type SharedType = sharedType
+
 // sharedType is implemented by every exported CRDT type (YArray, YMap, YText).
 // Doc.share stores sharedType values so it can fire per-type observers after
 // each transaction without knowing the concrete type.

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -449,10 +449,10 @@ func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction) error,
 		// content; runs BEFORE Unlock so other goroutines never see partially-
 		// GC'd state. No-op when doc.gc is false.
 		//
-		// When an UndoManager is attached we skip auto-GC: applyStackItem
-		// reconstructs deleted items by flipping the Deleted flag, which only
-		// works if their original Content is still present. Yjs handles this
-		// with a per-item keep flag; for v1.15.0 we take the conservative
+		// When an UndoManager is attached we skip auto-GC: undoing a deletion
+		// re-inserts a COPY of the deleted item's content (applyStackItem →
+		// redoItem), which only works if that original content is still present.
+		// Yjs handles this with a per-item keep flag; we take the conservative
 		// position of disabling auto-GC entirely while any UndoManager is
 		// registered. RunGC remains available as the explicit manual entry point.
 		if d.gc && d.undoManagerCount == 0 {

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -29,6 +29,13 @@ type Item struct {
 	// position instead of its original linked-list position. Set by integrate()
 	// during ContentMove priority arbitration.
 	MovedBy *Item
+	// redone is transient UndoManager state: when this item's deletion has been
+	// undone, it holds the ID of the new item that re-inserted a copy of its
+	// content. Undo restores a deletion by re-inserting (so the change
+	// propagates to peers), not by flipping Deleted in place; redone tracks the
+	// re-insertion to avoid redoing the same item twice and to let neighbour
+	// position-tracing follow the chain. Never encoded. (Yjs Item.redone parity.)
+	redone *ID
 }
 
 // parentSubKey collapses a *string parentSub to a plain string bucket label for

--- a/crdt/undo.go
+++ b/crdt/undo.go
@@ -442,8 +442,9 @@ func (u *UndoManager) redoItem(txn *Transaction, item *Item) *Item {
 }
 
 // neighbourOrigins computes the Origin / OriginRight IDs for a new item placed
-// immediately between left and right. A zero-width left (e.g. a format marker)
-// uses its own clock; a multi-unit left uses its last clock.
+// immediately between left and right. The origin is left's LAST clock — left's
+// own ID clock for a single-unit item (most items, incl. format markers, occupy
+// one clock slot), or ID.Clock + Len - 1 for a multi-unit run.
 func neighbourOrigins(left, right *Item) (origin, originRight *ID) {
 	if left != nil {
 		clock := left.ID.Clock

--- a/crdt/undo.go
+++ b/crdt/undo.go
@@ -84,7 +84,7 @@ type UndoManager struct {
 // NewUndoManager creates an UndoManager that tracks the listed shared types.
 // scope must not be empty. Multiple types can be tracked simultaneously; any
 // local transaction that touches at least one scope type is captured.
-func NewUndoManager(doc *Doc, scope []sharedType, opts ...UndoManagerOption) *UndoManager {
+func NewUndoManager(doc *Doc, scope []SharedType, opts ...UndoManagerOption) *UndoManager {
 	u := &UndoManager{
 		doc:            doc,
 		captureTimeout: 500 * time.Millisecond,
@@ -312,7 +312,14 @@ func (u *UndoManager) applyStackItem(item *StackItem) *StackItem {
 			}
 		}
 
-		// Step 2: restore items that were deleted by the captured transaction.
+		// Step 2: restore items that were deleted by the captured transaction by
+		// RE-INSERTING a copy of their content as new items (redoItem). Flipping
+		// Deleted=false in place produced no wire record, so the restoration never
+		// propagated and a back-sync from a peer (which still had the tombstone)
+		// re-deleted it locally. Re-inserting makes undo a real, convergent insert.
+		// Collect targets first, then redo (integrate appends new items to the
+		// store, which we must not visit as restore targets).
+		var toRedo []*Item
 		for client, ranges := range item.deletions.clients {
 			for _, r := range ranges {
 				for _, storeItem := range u.doc.store.clients[client] {
@@ -322,28 +329,134 @@ func (u *UndoManager) applyStackItem(item *StackItem) *StackItem {
 					if !storeItem.Deleted || !u.itemInScope(storeItem) {
 						continue
 					}
-					// Skip items whose content was freed by GC — we can't restore them.
+					// Content freed by GC cannot be restored.
 					if _, isGC := storeItem.Content.(*ContentDeleted); isGC {
 						continue
 					}
-					storeItem.Deleted = false
-					if storeItem.Content.IsCountable() {
-						storeItem.Parent.length += storeItem.Content.Len()
-						storeItem.Parent.invalidatePosCache()
-					}
-					txn.addChanged(storeItem.Parent, parentSubKey(storeItem.ParentSub))
+					toRedo = append(toRedo, storeItem)
 				}
 			}
+		}
+		for _, it := range toRedo {
+			u.redoItem(txn, it)
 		}
 
 		resultItem = &StackItem{
 			beforeState: txn.beforeState.Clone(),
-			afterState:  txn.afterState.Clone(),
-			deletions:   cloneDeleteSet(txn.deleteSet),
+			// Capture afterState from the live store: txn.afterState is only set
+			// at commit (after this closure), so it is nil here. The inverse
+			// stack item must record items this inversion INSERTED — e.g. the
+			// re-inserted content from undoing a deletion (redoItem) — so the
+			// opposite operation can delete them. Reading the store now reflects
+			// those inserts; txn.beforeState (set at txn start) is the lower bound.
+			afterState: u.doc.store.StateVector(),
+			deletions:  cloneDeleteSet(txn.deleteSet),
 		}
 	}, u) // origin = u so captureTransaction skips this txn
 
 	return resultItem
+}
+
+// redoItem re-inserts a copy of a deleted item's content as a NEW item so that
+// undoing the deletion propagates to peers as a real insert (rather than an
+// in-place tombstone flip, which never syncs). The new item is positioned via
+// the original's neighbours, following redone chains across already-restored
+// neighbours; for root and live-nested parents this reduces to the original
+// (now-tombstoned) neighbours, which preserves order. Mirrors Yjs redoItem.
+// Returns the new item, or nil if it cannot be placed.
+func (u *UndoManager) redoItem(txn *Transaction, item *Item) *Item {
+	if item.redone != nil {
+		return u.doc.store.Find(*item.redone)
+	}
+	parent := item.Parent
+	if parent == nil {
+		return nil
+	}
+	// If the containing type was itself deleted (a nested type that was removed),
+	// the parent must be redone first. ygo does not yet track that chain, so skip
+	// rather than mis-place — undoing a delete of items inside a deleted nested
+	// type is a known gap (rare; the common root/live-nested cases work).
+	if parent.item != nil && parent.item.Deleted {
+		return nil
+	}
+
+	var left, right *Item
+	if item.ParentSub == nil {
+		// Sequence element: position between the original left neighbour and the
+		// item itself, following redone pointers across neighbours that now belong
+		// to a different (re-inserted) parent.
+		left = item.Left
+		for left != nil {
+			lt := left
+			for lt != nil && lt.Parent != parent {
+				if lt.redone == nil {
+					lt = nil
+				} else {
+					lt = u.doc.store.Find(*lt.redone)
+				}
+			}
+			if lt != nil && lt.Parent == parent {
+				left = lt
+				break
+			}
+			left = left.Left
+		}
+		right = item
+		for right != nil {
+			rt := right
+			for rt != nil && rt.Parent != parent {
+				if rt.redone == nil {
+					rt = nil
+				} else {
+					rt = u.doc.store.Find(*rt.redone)
+				}
+			}
+			if rt != nil && rt.Parent == parent {
+				right = rt
+				break
+			}
+			right = right.Right
+		}
+	} else {
+		// Map entry: chain after the key's current entry (integrate's per-key LWW
+		// then picks the highest-clock winner). right stays nil.
+		if existing, ok := parent.itemMap[*item.ParentSub]; ok {
+			left = existing
+		}
+	}
+
+	origin, originRight := neighbourOrigins(left, right)
+	ni := &Item{
+		ID:          ID{Client: txn.doc.clientID, Clock: txn.doc.store.NextClock(txn.doc.clientID)},
+		Origin:      origin,
+		OriginRight: originRight,
+		Left:        left,
+		Parent:      parent,
+		ParentSub:   item.ParentSub,
+		Content:     item.Content.Copy(),
+	}
+	nid := ni.ID
+	item.redone = &nid
+	ni.integrate(txn, 0)
+	return ni
+}
+
+// neighbourOrigins computes the Origin / OriginRight IDs for a new item placed
+// immediately between left and right. A zero-width left (e.g. a format marker)
+// uses its own clock; a multi-unit left uses its last clock.
+func neighbourOrigins(left, right *Item) (origin, originRight *ID) {
+	if left != nil {
+		clock := left.ID.Clock
+		if n := left.Content.Len(); n > 0 {
+			clock += uint64(n) - 1
+		}
+		origin = &ID{Client: left.ID.Client, Clock: clock}
+	}
+	if right != nil {
+		id := right.ID
+		originRight = &id
+	}
+	return
 }
 
 // txnAffectsScope reports whether txn touched at least one tracked type.

--- a/crdt/undo_external_test.go
+++ b/crdt/undo_external_test.go
@@ -1,0 +1,28 @@
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+// F-8a (#124): NewUndoManager must be constructible from outside the crdt
+// package. Before SharedType was exported, the scope parameter took an
+// unexported interface, so []crdt.SharedType{...} could not be named by an
+// external caller and this file would not compile at all.
+func TestUnit_NewUndoManager_UsableFromExternalPackage(t *testing.T) {
+	d := crdt.New(crdt.WithClientID(1))
+	txt := d.GetText("t")
+	arr := d.GetArray("a")
+	m := d.GetMap("m")
+
+	um := crdt.NewUndoManager(d, []crdt.SharedType{txt, arr, m})
+	require.NotNil(t, um)
+
+	d.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+	d.Transact(func(txn *crdt.Transaction) { txt.Delete(txn, 0, 1) })
+	require.True(t, um.Undo())
+	require.Equal(t, "x", txt.ToString(), "undo restores via the external UndoManager")
+}

--- a/crdt/undo_soundness_test.go
+++ b/crdt/undo_soundness_test.go
@@ -1,0 +1,109 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// syncTo applies the updates `to` is missing from `from` (one direction).
+func syncTo(t *testing.T, from, to *Doc) {
+	t.Helper()
+	require.NoError(t, ApplyUpdateV1(to, EncodeStateAsUpdateV1(from, to.StateVector()), nil))
+}
+
+// F-8b (#124): undoing a deletion must propagate to peers. The pre-fix undo
+// flipped Deleted=false in place, which produced no wire record — so a peer
+// stayed deleted and a back-sync re-deleted locally, obliterating the undo.
+// The fix re-inserts the content as a new item, which syncs like any insert.
+func TestInteg_UndoManager_TextDeleteUndo_PropagatesToPeer(t *testing.T) {
+	docA := newTestDoc(1)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *Transaction) { txtA.Insert(txn, 0, "hello", nil) })
+
+	docB := newTestDoc(2)
+	txtB := docB.GetText("t")
+	syncTo(t, docA, docB)
+	require.Equal(t, "hello", txtB.ToString())
+
+	um := NewUndoManager(docA, []SharedType{txtA})
+	docA.Transact(func(txn *Transaction) { txtA.Delete(txn, 0, 5) })
+	require.Empty(t, txtA.ToString())
+	syncTo(t, docA, docB)
+	require.Empty(t, txtB.ToString())
+
+	require.True(t, um.Undo())
+	require.Equal(t, "hello", txtA.ToString(), "undo restores locally")
+
+	syncTo(t, docA, docB)
+	require.Equal(t, "hello", txtB.ToString(), "undo must propagate to the peer")
+
+	// Full bidirectional convergence — the undo must survive a back-sync.
+	syncTo(t, docB, docA)
+	require.Equal(t, "hello", txtA.ToString())
+	require.Equal(t, txtA.ToString(), txtB.ToString())
+}
+
+// Redo of an undone deletion re-applies the deletion (inverse of the undo's
+// re-insert), and that too converges across peers.
+func TestInteg_UndoManager_TextRedoAfterUndo(t *testing.T) {
+	docA := newTestDoc(1)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *Transaction) { txtA.Insert(txn, 0, "hello", nil) })
+
+	um := NewUndoManager(docA, []SharedType{txtA})
+	docA.Transact(func(txn *Transaction) { txtA.Delete(txn, 0, 5) })
+
+	require.True(t, um.Undo())
+	require.Equal(t, "hello", txtA.ToString())
+	require.True(t, um.Redo())
+	require.Empty(t, txtA.ToString(), "redo re-applies the deletion")
+}
+
+// Array deletes undo and propagate too (the sequence path with non-text content).
+func TestInteg_UndoManager_ArrayDeleteUndo_PropagatesToPeer(t *testing.T) {
+	docA := newTestDoc(1)
+	arrA := docA.GetArray("a")
+	docA.Transact(func(txn *Transaction) { arrA.Push(txn, []any{"x", "y", "z"}) })
+
+	docB := newTestDoc(2)
+	arrB := docB.GetArray("a")
+	syncTo(t, docA, docB)
+	require.Equal(t, 3, arrB.Len())
+
+	um := NewUndoManager(docA, []SharedType{arrA})
+	docA.Transact(func(txn *Transaction) { arrA.Delete(txn, 1, 1) }) // remove "y"
+	syncTo(t, docA, docB)
+	require.Equal(t, 2, arrB.Len())
+
+	require.True(t, um.Undo())
+	require.Equal(t, 3, arrA.Len())
+	syncTo(t, docA, docB)
+	require.Equal(t, 3, arrB.Len(), "undo must restore the element on the peer")
+	require.Equal(t, "y", arrB.Get(1))
+}
+
+// Map deletes undo and propagate too (the ParentSub path of redoItem).
+func TestInteg_UndoManager_MapDeleteUndo_PropagatesToPeer(t *testing.T) {
+	docA := newTestDoc(1)
+	mA := docA.GetMap("m")
+	docA.Transact(func(txn *Transaction) { mA.Set(txn, "k", "v") })
+
+	docB := newTestDoc(2)
+	mB := docB.GetMap("m")
+	syncTo(t, docA, docB)
+	got, _ := mB.Get("k")
+	require.Equal(t, "v", got)
+
+	um := NewUndoManager(docA, []SharedType{mA})
+	docA.Transact(func(txn *Transaction) { mA.Delete(txn, "k") })
+	syncTo(t, docA, docB)
+	_, ok := mB.Get("k")
+	require.False(t, ok, "delete synced")
+
+	require.True(t, um.Undo())
+	syncTo(t, docA, docB)
+	gotB, okB := mB.Get("k")
+	require.True(t, okB, "undo must restore the key on the peer")
+	require.Equal(t, "v", gotB)
+}


### PR DESCRIPTION
## Summary

Fixes **#124** (2nd of the 3 correctness PRs riding the single **v1.27.0** release). **Stacked on #126 (F-7)** — base branch is `fix/ytext-format-negated-attrs`, so the diff here is F-8 only; please merge #126 first.

Two related UndoManager defects:

### F-8b — undo of a deletion is now CRDT-sound
Undo flipped `storeItem.Deleted = false` **in place**, which produced no wire record. A peer that already had the tombstone never revived the content, and a back-sync re-applied the deletion locally — silently losing the undo, with both docs converging to the *deleted* state.

Undo now **re-inserts a copy of the deleted content as a new item** (a port of Yjs `redoItem`):
- New transient `Item.redone *ID` tracks the re-insertion (prevents double-redo; lets neighbour tracing follow the chain).
- The new item is positioned via the original's neighbours (following `redone`), so for root / live-nested parents it lands at the original spot and propagates as a normal insert that converges across peers.
- `applyStackItem` now captures the inverse stack item's `afterState` from the live store (`txn.afterState` is only set at commit, *after* the closure), so **Redo** correctly deletes the re-inserted content.
- Works for **YText / YArray / YMap**. Undoing a deletion of items inside a *deleted nested type* is a documented known gap (rare).

### F-8a — `crdt.SharedType` is now exported
`NewUndoManager`'s `scope` took an unexported interface, so `[]crdt.SharedType{…}` couldn't be named outside the package — UndoManager was effectively **dead API for external consumers**. The interface is now exported (alias of the internal one; methods stay unexported, so only ygo's own types satisfy it). In-package call sites are unchanged.

## Testing

- Two-doc **delete → undo → sync convergence** tests for YText, YArray, and YMap (both docs must converge to the *restored* state, and survive a back-sync).
- Redo re-applies the deletion.
- An **external-package** (`package crdt_test`) construction test — it would not compile before F-8a.
- Full `go test -race ./crdt/... ./provider/...`, `go vet`, `gofmt`, `golangci-lint` clean; existing undo suite still green.

## Release

Appends to the shared `[1.27.0]` CHANGELOG section; the final PR (F-6) finalizes the combined `RELEASE_NOTES`. No per-PR tag — one `v1.27.0` is cut after all three correctness PRs merge.

Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
