### PR TITLE
feat(websocket): wildcard '*' matching in AllowedOrigins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`websocket.Server.AllowedOrigins` now supports `*` wildcards.** Each entry
+  may contain one or more `*` wildcards, each matching any run of characters
+  (e.g. `https://*.netlify.app`, `https://pr-*---web-*.run.app`), in addition to
+  exact origins and the bare `*` allow-all. Literal segments are anchored to the
+  start and end of the Origin, so a wildcard cannot spoof a different host
+  (`https://*.example.com` does not match `https://x.example.com.evil`); a
+  *trailing* `*` matches only an optional `:<port>` (`https://app.example.com*`
+  matches `https://app.example.com:8443` but not `https://app.example.com.evil`).
+  Matching is case-insensitive. Previously only exact matches (and a bare `*`)
+  were honored, so wildcard entries silently never matched.
+
 ## [1.28.0] — 2026-06-18
 
 ### Added
@@ -43,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the common low-contention path (`BenchmarkTwoPeerConvergence` allocations
   unchanged). Closes the last open item (C) of #54; A shipped in v1.16.0 and B was
   measured and intentionally not adopted.
-
 ## [1.27.0] — 2026-06-16
 
 ### Fixed

--- a/provider/websocket/origin_test.go
+++ b/provider/websocket/origin_test.go
@@ -34,10 +34,15 @@ func TestOriginMatches(t *testing.T) {
 		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://wsgo---reearth-flow-web-x.a.run.app", false},      // wrong prefix
 		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://pr-1---reearth-flow-web-x.a.run.app.evil", false}, // suffix anchored
 
-		// trailing wildcard (e.g. allow an optional port)
+		// trailing wildcard: only an optional ":<port>", never a different host
 		{"https://app.example.com*", "https://app.example.com", true},
 		{"https://app.example.com*", "https://app.example.com:8443", true},
 		{"https://app.example.com*", "https://app.example.org", false},
+		// #129 review — a trailing "*" must NOT be a suffix-spoof vector.
+		{"https://app.example.com*", "https://app.example.com.evil", false},
+		{"https://app.example.com*", "https://app.example.com.evil.com", false},
+		{"https://app.example.com*", "https://app.example.computer.io", false},
+		{"https://app.example.com*", "https://app.example.com:80/x", false}, // port must be digits only
 	}
 	for _, c := range cases {
 		if got := originMatches(c.pattern, c.origin); got != c.want {

--- a/provider/websocket/origin_test.go
+++ b/provider/websocket/origin_test.go
@@ -1,0 +1,113 @@
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOriginMatches(t *testing.T) {
+	cases := []struct {
+		pattern, origin string
+		want            bool
+	}{
+		// exact (no wildcard)
+		{"https://flow.test.reearth.dev", "https://flow.test.reearth.dev", true},
+		{"https://flow.test.reearth.dev", "https://other.reearth.dev", false},
+		{"https://Example.com", "https://example.com", true}, // case-insensitive
+		{"http://localhost:3000", "http://localhost:3000", true},
+		{"http://localhost:3000", "http://localhost:3001", false},
+
+		// bare "*" allows anything
+		{"*", "https://anything.example", true},
+
+		// single subdomain wildcard
+		{"https://*.netlify.app", "https://foo.netlify.app", true},
+		{"https://*.netlify.app", "https://deploy-preview-12--site.netlify.app", true},
+		{"https://*.netlify.app", "https://netlify.app", false},            // no subdomain label
+		{"https://*.netlify.app", "https://evil.com", false},               // wrong suffix
+		{"https://*.netlify.app", "https://x.netlify.app.evil.com", false}, // suffix anchored
+
+		// multi-wildcard preview host
+		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://pr-1701---reearth-flow-web-6yxenhqnsq-uc.a.run.app", true},
+		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://pr-1---reearth-flow-web-x.a.run.app", true},
+		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://wsgo---reearth-flow-web-x.a.run.app", false},      // wrong prefix
+		{"https://pr-*---reearth-flow-web-*.a.run.app", "https://pr-1---reearth-flow-web-x.a.run.app.evil", false}, // suffix anchored
+
+		// trailing wildcard (e.g. allow an optional port)
+		{"https://app.example.com*", "https://app.example.com", true},
+		{"https://app.example.com*", "https://app.example.com:8443", true},
+		{"https://app.example.com*", "https://app.example.org", false},
+	}
+	for _, c := range cases {
+		if got := originMatches(c.pattern, c.origin); got != c.want {
+			t.Errorf("originMatches(%q, %q) = %v, want %v", c.pattern, c.origin, got, c.want)
+		}
+	}
+}
+
+func TestCheckOrigin(t *testing.T) {
+	mk := func(origin, host string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "https://"+host+"/room", nil)
+		r.Host = host
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+
+	t.Run("wildcard allow-list", func(t *testing.T) {
+		s := &Server{AllowedOrigins: []string{
+			"http://localhost:3000",
+			"https://flow.test.reearth.dev",
+			"https://*.netlify.app",
+			"https://pr-*---reearth-flow-web-*.a.run.app",
+		}}
+		ok := []string{
+			"https://flow.test.reearth.dev",
+			"http://localhost:3000",
+			"https://foo.netlify.app",
+			"https://pr-1701---reearth-flow-web-6yxenhqnsq-uc.a.run.app",
+		}
+		for _, o := range ok {
+			if !s.checkOrigin(mk(o, "ws.example")) {
+				t.Errorf("checkOrigin(%q) = false, want true", o)
+			}
+		}
+		bad := []string{
+			"https://evil.com",
+			"https://flow.prod.reearth.dev",
+			"https://x.netlify.app.evil.com",
+			"https://wsgo---reearth-flow-web-x.a.run.app",
+		}
+		for _, o := range bad {
+			if s.checkOrigin(mk(o, "ws.example")) {
+				t.Errorf("checkOrigin(%q) = true, want false", o)
+			}
+		}
+	})
+
+	t.Run("absent Origin header is permitted (non-browser client)", func(t *testing.T) {
+		s := &Server{AllowedOrigins: []string{"https://flow.test.reearth.dev"}}
+		if !s.checkOrigin(mk("", "ws.example")) {
+			t.Error("empty Origin should be permitted")
+		}
+	})
+
+	t.Run("empty AllowedOrigins falls back to same-origin", func(t *testing.T) {
+		s := &Server{}
+		if !s.checkOrigin(mk("https://ws.example", "ws.example")) {
+			t.Error("same-origin should be allowed")
+		}
+		if s.checkOrigin(mk("https://other.example", "ws.example")) {
+			t.Error("cross-origin should be rejected under same-origin fallback")
+		}
+	})
+
+	t.Run("bare star allows any origin", func(t *testing.T) {
+		s := &Server{AllowedOrigins: []string{"*"}}
+		if !s.checkOrigin(mk("https://whatever.example", "ws.example")) {
+			t.Error(`AllowedOrigins=["*"] should allow any origin`)
+		}
+	})
+}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -482,15 +482,23 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 // of characters, so "https://*.example.com" matches "https://app.example.com"
 // and "https://pr-*---web-*.run.app" matches "https://pr-12---web-abc.run.app".
 // A bare "*" matches any origin. The first and last literal segments are
-// anchored to the start and end of origin, so a wildcard suffix cannot be
-// spoofed (e.g. "https://*.example.com" does not match
-// "https://x.example.com.evil").
+// anchored to the start and end of origin, so a wildcard cannot be used to spoof
+// a different host (e.g. "https://*.example.com" does not match
+// "https://x.example.com.evil"). A trailing "*" is restricted to an optional
+// ":<port>": "https://app.example.com*" matches "https://app.example.com" and
+// "https://app.example.com:8443" but not "https://app.example.com.evil".
 func originMatches(pattern, origin string) bool {
 	if !strings.Contains(pattern, "*") {
 		return strings.EqualFold(pattern, origin)
 	}
 	p := strings.ToLower(pattern)
 	o := strings.ToLower(origin)
+	// A trailing "*" (other than the bare "*" allow-all) must NOT act as an
+	// unanchored suffix — otherwise "https://app.example.com*" would also match
+	// "https://app.example.com.evil", a CORS allow-list bypass (#129 review).
+	// Restrict it to an optional ":<port>" so it only covers the "host with
+	// optional port" case it is intended for.
+	trailingStar := p != "*" && strings.HasSuffix(p, "*")
 	segs := strings.Split(p, "*")
 	// First literal segment must be a prefix.
 	if !strings.HasPrefix(o, segs[0]) {
@@ -510,6 +518,29 @@ func originMatches(pattern, origin string) bool {
 			return false
 		}
 		o = o[i+len(mid):]
+	}
+	if trailingStar {
+		// Whatever remains is what the trailing "*" matched; allow only an
+		// optional ":<port>" so it cannot extend onto a different host.
+		return isOptionalPort(o)
+	}
+	return true
+}
+
+// isOptionalPort reports whether s is empty or a ":<digits>" port suffix. It
+// bounds what a trailing "*" in an AllowedOrigins pattern may match so the
+// wildcard cannot be abused to match a different host.
+func isOptionalPort(s string) bool {
+	if s == "" {
+		return true
+	}
+	if len(s) < 2 || s[0] != ':' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
 	}
 	return true
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -257,8 +257,11 @@ type Server struct {
 	AuthFunc func(r *http.Request) bool
 
 	// AllowedOrigins is the list of origins permitted to open WebSocket
-	// connections (C2 — CORS). Each entry must be a full origin string, e.g.
-	// "https://example.com". Use "*" to allow any origin.
+	// connections (C2 — CORS). Each entry is a full origin string, e.g.
+	// "https://example.com". An entry may contain "*" wildcards, each matching
+	// any run of characters: "https://*.example.com" matches any subdomain and
+	// "https://pr-*---web-*.run.app" matches preview hosts. A bare "*" allows any
+	// origin. Matching is case-insensitive.
 	//
 	// If the slice is empty the server falls back to a same-origin check:
 	// the request Origin header must match the HTTP Host header. Non-browser
@@ -466,11 +469,49 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 		return strings.EqualFold(u.Host, r.Host)
 	}
 	for _, allowed := range s.AllowedOrigins {
-		if allowed == "*" || strings.EqualFold(allowed, origin) {
+		if originMatches(allowed, origin) {
 			return true
 		}
 	}
 	return false
+}
+
+// originMatches reports whether origin matches an AllowedOrigins entry,
+// case-insensitively. An entry without "*" must equal origin exactly. An entry
+// may contain one or more "*" wildcards, each matching any (possibly empty) run
+// of characters, so "https://*.example.com" matches "https://app.example.com"
+// and "https://pr-*---web-*.run.app" matches "https://pr-12---web-abc.run.app".
+// A bare "*" matches any origin. The first and last literal segments are
+// anchored to the start and end of origin, so a wildcard suffix cannot be
+// spoofed (e.g. "https://*.example.com" does not match
+// "https://x.example.com.evil").
+func originMatches(pattern, origin string) bool {
+	if !strings.Contains(pattern, "*") {
+		return strings.EqualFold(pattern, origin)
+	}
+	p := strings.ToLower(pattern)
+	o := strings.ToLower(origin)
+	segs := strings.Split(p, "*")
+	// First literal segment must be a prefix.
+	if !strings.HasPrefix(o, segs[0]) {
+		return false
+	}
+	o = o[len(segs[0]):]
+	// Last literal segment must be a suffix.
+	last := segs[len(segs)-1]
+	if !strings.HasSuffix(o, last) {
+		return false
+	}
+	o = o[:len(o)-len(last)]
+	// Middle literal segments must occur in order.
+	for _, mid := range segs[1 : len(segs)-1] {
+		i := strings.Index(o, mid)
+		if i < 0 {
+			return false
+		}
+		o = o[i+len(mid):]
+	}
+	return true
 }
 
 // isValidRoomName reports whether name is a safe, non-empty room identifier.


### PR DESCRIPTION
## Summary

`websocket.Server.AllowedOrigins` previously matched **exactly** (plus a bare `*` allow-all), so wildcard entries like `https://*.netlify.app` or `https://pr-*---reearth-flow-web-*.a.run.app` were treated as literal strings and **silently never matched** — breaking CORS for preview/branch frontends that rely on a wildcard allow-list.

This adds `*` wildcard support to each `AllowedOrigins` entry:

- Each entry may contain one or more `*`, each matching any (possibly empty) run of characters — e.g. `https://*.example.com` matches any subdomain, `https://pr-*---web-*.run.app` matches preview hosts.
- Exact entries and the bare `*` allow-all keep working unchanged.
- Matching is case-insensitive.
- **Anchored:** the first and last literal segments are pinned to the start/end of the Origin, so a wildcard suffix cannot be spoofed — `https://*.example.com` does **not** match `https://x.example.com.evil`.

Implemented with a small `strings`-based matcher (no regex, no new imports).

## Test plan

- New `TestOriginMatches` (exact, case-insensitivity, single/multi/trailing wildcards, and negative/anchoring cases incl. suffix-spoof attempts).
- New `TestCheckOrigin` (wildcard allow-list accept/reject, absent-Origin permitted, empty-`AllowedOrigins` same-origin fallback, bare-`*`).
- `go test ./provider/websocket/ -race` green; `go vet`, `gofmt`, `golangci-lint` (0 issues) clean.

## Notes

Backward compatible: entries without `*` behave identically. Motivated by the Re:Earth Flow Go websocket cutover, where the deployed `REEARTH_FLOW_ORIGINS` already declares `*.netlify.app` / `pr-*` wildcards that the Rust server honored.