### PR TITLE
feat+perf(crdt): CreateDocFromSnapshot (#58) + conflict-scan allocation fix (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   post-snapshot deletions are not applied, so a key/element deleted after the
   snapshot reappears in the reconstruction. The returned doc is non-GC, so it can
   be snapshotted or restored from again. (#58)
-- **`crdt.ErrSnapshotSourceGCed`** is returned by `CreateDocFromSnapshot` /
-  `RestoreDocument` when the source doc has GC enabled: a GC-enabled doc replaces
-  deleted items' content with length-only tombstones at transaction commit, so an
-  item deleted after the snapshot no longer carries the content it had at snapshot
-  time and reconstruction cannot be faithful. Create the source `WithGC(false)`.
+- **`crdt.ErrSnapshotSourceGCed`** is returned by `CreateDocFromSnapshot`,
+  `RestoreDocument`, and `EncodeStateFromSnapshot` when the source doc has GC
+  enabled: a GC-enabled doc replaces deleted items' content with length-only
+  tombstones at transaction commit, so an item deleted after the snapshot no
+  longer carries the content it had at snapshot time and reconstruction cannot be
+  faithful. Create the source `WithGC(false)`.
 
 ### Changed
 
-- **`RestoreDocument` now guards against a GC-enabled source.** It delegates to
-  `CreateDocFromSnapshot` and returns `ErrSnapshotSourceGCed` rather than silently
-  producing an incomplete document when the source had GC enabled (previously it
-  returned a wrong doc with a nil error). Callers already following the documented
+- **`RestoreDocument` and `EncodeStateFromSnapshot` now guard against a
+  GC-enabled source.** They return `ErrSnapshotSourceGCed` rather than silently
+  producing an incomplete document/update when the source had GC enabled
+  (previously they returned wrong data with a nil error). `RestoreDocument`
+  delegates to `CreateDocFromSnapshot`. Callers already following the documented
   `WithGC(false)` snapshot-history contract are unaffected. (#58)
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.0] — 2026-06-18
+
+### Added
+
+- **`crdt.CreateDocFromSnapshot(src, snap)`** reconstructs the state a snapshot
+  captured into a new, independent `Doc` — the Go equivalent of Yjs JS's
+  `createDocFromSnapshot`. Items inserted after the snapshot are excluded and
+  post-snapshot deletions are not applied, so a key/element deleted after the
+  snapshot reappears in the reconstruction. The returned doc is non-GC, so it can
+  be snapshotted or restored from again. (#58)
+- **`crdt.ErrSnapshotSourceGCed`** is returned by `CreateDocFromSnapshot` /
+  `RestoreDocument` when the source doc has GC enabled: a GC-enabled doc replaces
+  deleted items' content with length-only tombstones at transaction commit, so an
+  item deleted after the snapshot no longer carries the content it had at snapshot
+  time and reconstruction cannot be faithful. Create the source `WithGC(false)`.
+
+### Changed
+
+- **`RestoreDocument` now guards against a GC-enabled source.** It delegates to
+  `CreateDocFromSnapshot` and returns `ErrSnapshotSourceGCed` rather than silently
+  producing an incomplete document when the source had GC enabled (previously it
+  returned a wrong doc with a nil error). Callers already following the documented
+  `WithGC(false)` snapshot-history contract are unaffected. (#58)
+
+### Performance
+
+- **`Item.integrate` conflict scan no longer reallocates its conflict-tracking
+  map on every conflict-group reset.** It now reuses the map via `clear()`
+  (matching Yjs's `conflictingItems.clear()`) instead of allocating a fresh one,
+  which had made conflict-scan allocation quadratic in the conflict-group size.
+  Under high same-position contention (many peers inserting at the same index)
+  this cuts convergence allocations sharply — about −92% allocs, −55% bytes and
+  −29% time at 400 concurrent same-position inserts — with no measurable change to
+  the common low-contention path (`BenchmarkTwoPeerConvergence` allocations
+  unchanged). Closes the last open item (C) of #54; A shipped in v1.16.0 and B was
+  measured and intentionally not adopted.
+
 ## [1.27.0] — 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.27.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.28.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 
@@ -61,6 +61,7 @@ Post-v1.0 hardening:
 - **Awareness DoS hardening** (v1.25.0). A per-room cap on distinct presence entries (`Awareness.SetMaxClients`, `Server.MaxAwarenessClientsPerRoom`) plus server-side auto-expiry (`Server.AwarenessExpiry`) that reclaims ghost presence from peers that died silently.
 - **Server secure-by-default & decode-ceiling alignment** (v1.26.0). `cmd/ygo-server` binds loopback by default and warns loudly on a public bind (it has no built-in auth); a single wire field is now bounded by the message size rather than a fixed 16 MiB ceiling (large documents no longer fail to sync below the configured cap); malformed inbound frames are logged; and a `RelativePosition` anchored to a root type resolves to the end of the type, matching Yjs.
 - **CRDT correctness batch** (v1.27.0). Three Yjs-parity fixes, all verified against `yjs@13.6.30`: `YText.Format` ports the Yjs `formatText` algorithm so re-applying/toggling a format over a sub-range no longer strips the surrounding run (`ToDelta` also coalesces adjacent equal-attribute inserts); `UndoManager` undo of a deletion re-inserts content as a new item so it propagates to peers instead of being silently lost on the next sync; and `MergeUpdatesV1`/`DiffUpdateV1` merge at the struct level so non-integrable structs are no longer dropped. Adds struct-level `MergeUpdatesV2`/`DiffUpdateV2`/`EncodeStateVectorFromUpdate` and exports `crdt.SharedType`.
+- **Snapshot reconstruction & conflict-scan perf** (v1.28.0). Adds `crdt.CreateDocFromSnapshot` (Yjs-parity name for rebuilding a historic doc from a `Snapshot`), with a `WithGC(false)` safety guard (`ErrSnapshotSourceGCed`) so reconstruction can't silently return incomplete history; `RestoreDocument` now shares that guard. `Item.integrate` also reuses its YATA conflict-tracking map via `clear()` instead of reallocating it, cutting convergence allocations ~92% under high same-position contention with no change to the common path.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,38 @@
 ## What's new
 
-A batch of three CRDT correctness fixes, each verified against the Yjs reference
-(`yjs@13.6.30`). No breaking API changes.
-
-### Fixed
-
-- **`YText.Format` no longer strips formatting outside its range.** Re-applying
-  or toggling a format over a sub-range of an already-formatted run used to
-  delete the marker bounding content *after* the range — most visibly on
-  documents loaded via `ApplyUpdate`. `Format` now ports the Yjs `formatText`
-  algorithm; `YText.ToDelta` also coalesces adjacent equal-attribute inserts to
-  match Yjs `toDelta`.
-- **Undo of a deletion is now CRDT-sound and propagates to peers.** `UndoManager`
-  previously flipped the deleted flag in place, which produced no wire record —
-  so a peer never revived the content and a back-sync re-deleted it, silently
-  losing the undo. Undo now re-inserts a copy of the content as a new item (Yjs
-  `redoItem`), converging across peers. Works for YText, YArray, and YMap.
-- **`MergeUpdatesV1` / `DiffUpdateV1` no longer drop non-integrable structs.**
-  They re-encoded an integrated temp document, so a struct whose dependency was
-  in a prior update was silently dropped. They now merge at the struct level
-  (Yjs `mergeUpdates`/`diffUpdate` parity), preserving every struct.
+A snapshot-reconstruction API addition and a CRDT conflict-scan performance fix.
+No breaking changes for callers following the documented snapshot contract.
 
 ### Added
 
-- **`crdt.SharedType`** is exported, so `NewUndoManager`'s scope can be named
-  from outside the package (it was effectively unusable externally before).
-- **`MergeUpdatesV2`, `DiffUpdateV2`, `EncodeStateVectorFromUpdate` /
-  `EncodeStateVectorFromUpdateV2`** — the V2 columnar equivalents of the
-  merge/diff fixes, plus extracting a state vector straight from an update
-  without integrating it (closes #57).
+- **`CreateDocFromSnapshot(src, snap)`** — reconstruct a document's historic state
+  (the state a `Snapshot` captured) into a new, independent `Doc`. The Go
+  equivalent of Yjs JS's `createDocFromSnapshot`: items inserted after the
+  snapshot are excluded, and a key/element deleted *after* the snapshot reappears
+  in the reconstruction. The returned doc is non-GC, so it can be snapshotted or
+  restored from again.
+- **`ErrSnapshotSourceGCed`** — returned when reconstructing from a GC-enabled
+  source doc, which cannot be done faithfully (a GC-enabled doc discards deleted
+  items' content at commit). Create the source `WithGC(false)`.
 
-### Compatibility
+### Changed
 
-No breaking API changes. One behavioral note: `YText.ToDelta` now returns the
-same text/attributes merged into fewer ops where a run was previously split
-across backing Items — code comparing the full op list should expect the
-coalesced shape.
+- **`RestoreDocument`** now returns `ErrSnapshotSourceGCed` for a GC-enabled
+  source instead of silently returning an incomplete document. It shares the new
+  reconstruction path; callers already using `WithGC(false)` are unaffected.
+
+### Performance
+
+- **Faster, leaner convergence under high same-position contention.**
+  `Item.integrate` now reuses its YATA conflict-tracking map via `clear()` rather
+  than reallocating it on every conflict-group reset (matching Yjs). At 400 peers
+  inserting at the same index, convergence does about 92% fewer allocations, 55%
+  less memory and 29% less time; the common low-contention path is unchanged.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.27.0
+go get github.com/reearth/ygo@v1.28.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,15 +11,16 @@ No breaking changes for callers following the documented snapshot contract.
   snapshot are excluded, and a key/element deleted *after* the snapshot reappears
   in the reconstruction. The returned doc is non-GC, so it can be snapshotted or
   restored from again.
-- **`ErrSnapshotSourceGCed`** — returned when reconstructing from a GC-enabled
-  source doc, which cannot be done faithfully (a GC-enabled doc discards deleted
-  items' content at commit). Create the source `WithGC(false)`.
+- **`ErrSnapshotSourceGCed`** — returned when reconstructing/exporting from a
+  GC-enabled source doc, which cannot be done faithfully (a GC-enabled doc
+  discards deleted items' content at commit). Create the source `WithGC(false)`.
 
 ### Changed
 
-- **`RestoreDocument`** now returns `ErrSnapshotSourceGCed` for a GC-enabled
-  source instead of silently returning an incomplete document. It shares the new
-  reconstruction path; callers already using `WithGC(false)` are unaffected.
+- **`RestoreDocument` and `EncodeStateFromSnapshot`** now return
+  `ErrSnapshotSourceGCed` for a GC-enabled source instead of silently returning
+  incomplete history. `RestoreDocument` shares the new reconstruction path;
+  callers already using `WithGC(false)` are unaffected.
 
 ### Performance
 

--- a/crdt/bench_test.go
+++ b/crdt/bench_test.go
@@ -268,3 +268,36 @@ func BenchmarkTwoPeerConvergence(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkConcurrentSamePositionInsert stresses the YATA conflict-scan slow
+// path in Item.integrate (issue #54-C). N peers each insert one element at
+// position 0 of an empty doc, so every item shares Origin=nil and OriginRight=nil
+// — the maximal-contention case. Converging all N updates into one doc forces
+// integrate to walk a conflict group that grows toward N, which is exactly where
+// the `conflicting` / `beforeOrigin` maps (item.go) are allocated and reset.
+// Measure this before deciding whether pooling those maps is worthwhile.
+func BenchmarkConcurrentSamePositionInsert(b *testing.B) {
+	for _, peers := range []int{20, 100, 400} {
+		b.Run(fmt.Sprintf("peers=%d", peers), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				updates := make([][]byte, peers)
+				for p := 0; p < peers; p++ {
+					d := New(WithClientID(ClientID(p + 1)))
+					t := d.GetText("t")
+					d.Transact(func(txn *Transaction) { t.Insert(txn, 0, "x", nil) })
+					updates[p] = EncodeStateAsUpdateV1(d, nil)
+				}
+				merged := New(WithClientID(999999))
+				b.StartTimer()
+
+				for _, u := range updates {
+					if err := ApplyUpdateV1(merged, u, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -261,6 +261,59 @@ func TestP0_ConcurrentUpdatesConvergeInAllOrders(t *testing.T) {
 	}
 }
 
+// TestP0_ManyConcurrentSamePositionInserts_Converge stresses the YATA
+// conflict-scan with a large conflict group: every insert lands at position 0 of
+// the same empty base, so all share Origin=nil. It guards the #54-C allocation
+// optimization (reusing the conflict map via clear() instead of reallocating it
+// inside the scan loop) — the change must not alter the conflict-resolution
+// outcome, so every apply order must converge to byte-identical state with all
+// inserts surviving.
+func TestP0_ManyConcurrentSamePositionInserts_Converge(t *testing.T) {
+	const n = 24
+	base := New()
+	updates := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		updates[i] = textIns(t, base, ClientID(i+1), 0, string(rune('a'+i)))
+	}
+
+	apply := func(order []int) *Doc {
+		d := New()
+		for _, i := range order {
+			if err := ApplyUpdateV1(d, updates[i], nil); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+		}
+		return d
+	}
+
+	forward := make([]int, n)
+	reverse := make([]int, n)
+	rotated := make([]int, n)
+	for i := 0; i < n; i++ {
+		forward[i], reverse[i], rotated[i] = i, n-1-i, (i+n/2)%n
+	}
+
+	ref := apply(forward)
+	wantState := EncodeStateAsUpdateV1(ref, nil)
+	wantText := ref.GetText("t").ToString()
+	if len([]rune(wantText)) != n {
+		t.Fatalf("reference lost inserts: got %d chars, want %d (%q)", len([]rune(wantText)), n, wantText)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		order []int
+	}{{"reverse", reverse}, {"rotated", rotated}} {
+		d := apply(tc.order)
+		if got := d.GetText("t").ToString(); got != wantText {
+			t.Fatalf("%s order: text=%q want %q", tc.name, got, wantText)
+		}
+		if got := EncodeStateAsUpdateV1(d, nil); !bytes.Equal(got, wantState) {
+			t.Fatalf("%s order: full-state encode differs from reference (divergent CRDT state)", tc.name)
+		}
+	}
+}
+
 func mapSet(t *testing.T, base *Doc, id ClientID, key, val string) []byte {
 	t.Helper()
 	d := New(WithClientID(id))

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -134,7 +134,12 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 				// the same position. Lower ClientID wins (placed to the left).
 				if o.ID.Client < item.ID.Client {
 					left = o
-					conflicting = make(map[*Item]struct{})
+					// Reuse the map instead of reallocating (Yjs does
+					// conflictingItems.clear() here). Under high same-position
+					// contention this fires O(group size) times per integrate, so
+					// a fresh make() each time made conflict-scan allocation
+					// quadratic in the conflict-group size (#54-C).
+					clear(conflicting)
 				} else if originIDEquals(item.OriginRight, o.OriginRight) {
 					// Same left and right origin — truly symmetric; stop.
 					break
@@ -150,7 +155,7 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 				if _, inBefore := beforeOrigin[oOriginItem]; inBefore {
 					if _, inConflict := conflicting[oOriginItem]; !inConflict {
 						left = o
-						conflicting = make(map[*Item]struct{})
+						clear(conflicting) // reuse the map, not realloc (see above / Yjs parity)
 					}
 				} else {
 					break

--- a/crdt/snapshot.go
+++ b/crdt/snapshot.go
@@ -135,6 +135,9 @@ func EqualSnapshots(a, b *Snapshot) bool {
 // references, so reconstruction returns ErrSnapshotSourceGCed rather than a
 // silently-wrong doc. The returned doc is itself non-GC, so it can be
 // snapshotted or restored from again.
+//
+// Do not call from inside a Transact callback: it acquires src's lock and would
+// deadlock — resolve the snapshot outside the transaction.
 func CreateDocFromSnapshot(src *Doc, snap *Snapshot) (*Doc, error) {
 	src.mu.Lock()
 	if src.gc {
@@ -164,8 +167,18 @@ func RestoreDocument(doc *Doc, snap *Snapshot) (*Doc, error) {
 
 // EncodeStateFromSnapshot returns a V1 update representing doc's state at snap
 // time. Apply it to a fresh Doc to reconstruct the historical version.
+//
+// Like CreateDocFromSnapshot, doc must have been created WithGC(false): a
+// GC-enabled source may have discarded content the snapshot references, so this
+// returns ErrSnapshotSourceGCed rather than a silently-incomplete export. Do not
+// call it from inside a Transact callback — it takes the doc lock and would
+// deadlock.
 func EncodeStateFromSnapshot(doc *Doc, snap *Snapshot) ([]byte, error) {
 	doc.mu.Lock()
+	if doc.gc {
+		doc.mu.Unlock()
+		return nil, ErrSnapshotSourceGCed
+	}
 	update := encodeFromSnapshotLocked(doc, snap)
 	doc.mu.Unlock()
 	return update, nil

--- a/crdt/snapshot.go
+++ b/crdt/snapshot.go
@@ -1,10 +1,20 @@
 package crdt
 
 import (
+	"errors"
 	"sort"
 
 	"github.com/reearth/ygo/encoding"
 )
+
+// ErrSnapshotSourceGCed is returned by CreateDocFromSnapshot / RestoreDocument
+// when the source doc has garbage collection enabled. A GC-enabled doc replaces
+// the content of deleted items with length-only tombstones at transaction
+// commit (#78 H1), so an item deleted AFTER the snapshot no longer carries the
+// content it had at snapshot time — reconstruction would silently produce a
+// wrong (incomplete) document. Create the source with WithGC(false) to preserve
+// the history a snapshot needs.
+var ErrSnapshotSourceGCed = errors.New("crdt: cannot reconstruct from a GC-enabled source doc; create it with WithGC(false)")
 
 // Snapshot captures the state of a Yjs document at a specific moment in time.
 // It records which items existed (StateVector) and which were deleted (DeleteSet)
@@ -114,20 +124,42 @@ func EqualSnapshots(a, b *Snapshot) bool {
 	return true
 }
 
+// CreateDocFromSnapshot reconstructs the document state captured by snap into a
+// new, independent Doc — the Go equivalent of Yjs JS's createDocFromSnapshot.
+// Items inserted after the snapshot are excluded, and only deletions present in
+// the snapshot's DeleteSet are applied; a key/element deleted after the snapshot
+// reappears in the reconstruction.
+//
+// src must have been created WithGC(false) (the snapshot-history pattern):
+// a GC-enabled source may have discarded the content/tombstones the snapshot
+// references, so reconstruction returns ErrSnapshotSourceGCed rather than a
+// silently-wrong doc. The returned doc is itself non-GC, so it can be
+// snapshotted or restored from again.
+func CreateDocFromSnapshot(src *Doc, snap *Snapshot) (*Doc, error) {
+	src.mu.Lock()
+	if src.gc {
+		src.mu.Unlock()
+		return nil, ErrSnapshotSourceGCed
+	}
+	update := encodeFromSnapshotLocked(src, snap)
+	src.mu.Unlock()
+
+	newDoc := New(WithGC(false))
+	if err := ApplyUpdateV1(newDoc, update, nil); err != nil {
+		return nil, err
+	}
+	return newDoc, nil
+}
+
 // RestoreDocument creates a new Doc that reflects doc's state at the time snap
 // was taken. Items inserted after the snapshot are excluded, and only deletions
 // present in the snapshot's DeleteSet are applied.
 //
-// The original doc must still contain the full item history — either
-// doc.gc was false, or RunGC has not yet discarded items relevant to the
-// snapshot.
+// Retained for backward compatibility; it delegates to CreateDocFromSnapshot
+// (the Yjs-parity name) and shares its GC-safety guard — see
+// ErrSnapshotSourceGCed.
 func RestoreDocument(doc *Doc, snap *Snapshot) (*Doc, error) {
-	doc.mu.Lock()
-	update := encodeFromSnapshotLocked(doc, snap)
-	doc.mu.Unlock()
-
-	newDoc := New(WithGC(false))
-	return newDoc, ApplyUpdateV1(newDoc, update, nil)
+	return CreateDocFromSnapshot(doc, snap)
 }
 
 // EncodeStateFromSnapshot returns a V1 update representing doc's state at snap

--- a/crdt/snapshot_test.go
+++ b/crdt/snapshot_test.go
@@ -375,3 +375,17 @@ func TestUnit_RestoreDocument_ErrorsOnGCEnabledSource(t *testing.T) {
 	require.ErrorIs(t, err, ErrSnapshotSourceGCed)
 	assert.Nil(t, got)
 }
+
+// EncodeStateFromSnapshot shares the same GC-safety guard: a GC-enabled source
+// can't export faithful history, so it returns ErrSnapshotSourceGCed rather than
+// a silently-incomplete update.
+func TestUnit_EncodeStateFromSnapshot_ErrorsOnGCEnabledSource(t *testing.T) {
+	src := New(WithClientID(1)) // gc defaults to true
+	txt := src.GetText("t")
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	snap := CaptureSnapshot(src)
+
+	got, err := EncodeStateFromSnapshot(src, snap)
+	require.ErrorIs(t, err, ErrSnapshotSourceGCed)
+	assert.Nil(t, got)
+}

--- a/crdt/snapshot_test.go
+++ b/crdt/snapshot_test.go
@@ -285,3 +285,93 @@ func TestInteg_Snapshot_MultipleClients_Convergence(t *testing.T) {
 	snap2 := CaptureSnapshot(doc2)
 	assert.True(t, EqualSnapshots(snap1, snap2))
 }
+
+// ── CreateDocFromSnapshot (#58) ─────────────────────────────────────────────
+
+// Yjs-parity reconstruction: rebuild a historic doc from a snapshot taken
+// before later mutations.
+func TestInteg_CreateDocFromSnapshot_AtPastState(t *testing.T) {
+	src := New(WithClientID(1), WithGC(false))
+	txt := src.GetText("t")
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello", nil) })
+	snap := CaptureSnapshot(src)
+
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 5, " world", nil) })
+	require.Equal(t, "hello world", txt.ToString())
+
+	got, err := CreateDocFromSnapshot(src, snap)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got.GetText("t").ToString())
+}
+
+// A key deleted AFTER the snapshot must reappear in the reconstruction — this
+// is the case that silently breaks when the source was GC'd (content of the
+// post-snapshot-deleted item is gone), which the guard below prevents.
+func TestInteg_CreateDocFromSnapshot_YMapDeletedKeyReappears(t *testing.T) {
+	src := New(WithClientID(1), WithGC(false))
+	m := src.GetMap("m")
+	src.Transact(func(txn *Transaction) {
+		m.Set(txn, "a", "alpha")
+		m.Set(txn, "b", "beta")
+	})
+	snap := CaptureSnapshot(src)
+	src.Transact(func(txn *Transaction) { m.Delete(txn, "a") })
+
+	got, err := CreateDocFromSnapshot(src, snap)
+	require.NoError(t, err)
+	va, ok := got.GetMap("m").Get("a")
+	require.True(t, ok, "key deleted after the snapshot must reappear in the reconstruction")
+	assert.Equal(t, "alpha", va)
+}
+
+// A GC-enabled source may have discarded the content/tombstones the snapshot
+// references, so reconstruction can't be faithful — CreateDocFromSnapshot must
+// refuse rather than return a silently-wrong doc.
+func TestUnit_CreateDocFromSnapshot_ErrorsOnGCEnabledSource(t *testing.T) {
+	src := New(WithClientID(1)) // gc defaults to true
+	txt := src.GetText("t")
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello", nil) })
+	snap := CaptureSnapshot(src)
+
+	got, err := CreateDocFromSnapshot(src, snap)
+	require.ErrorIs(t, err, ErrSnapshotSourceGCed)
+	assert.Nil(t, got)
+}
+
+// The reconstructed doc is independent of the source and is itself non-GC, so
+// it can be snapshotted/restored further.
+func TestInteg_CreateDocFromSnapshot_ReconstructedIsIndependentAndRestorable(t *testing.T) {
+	src := New(WithClientID(1), WithGC(false))
+	txt := src.GetText("t")
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "base", nil) })
+	snap := CaptureSnapshot(src)
+
+	got, err := CreateDocFromSnapshot(src, snap)
+	require.NoError(t, err)
+
+	// Mutating the reconstruction must not touch the source. (Resolve the text
+	// ref outside Transact — GetText inside the closure would deadlock on the
+	// doc lock.)
+	gotTxt := got.GetText("t")
+	got.Transact(func(txn *Transaction) { gotTxt.Insert(txn, 4, "X", nil) })
+	assert.Equal(t, "base", txt.ToString(), "source unaffected by edits to the reconstruction")
+	assert.Equal(t, "baseX", gotTxt.ToString())
+
+	// Reconstruction is non-GC: it can be snapshotted again without losing history.
+	assert.False(t, got.gc)
+	snap2 := CaptureSnapshot(got)
+	assert.NotNil(t, snap2)
+}
+
+// RestoreDocument now delegates to CreateDocFromSnapshot, so it gains the same
+// GC-safety guard instead of silently returning a wrong doc.
+func TestUnit_RestoreDocument_ErrorsOnGCEnabledSource(t *testing.T) {
+	src := New(WithClientID(1)) // gc defaults to true
+	txt := src.GetText("t")
+	src.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	snap := CaptureSnapshot(src)
+
+	got, err := RestoreDocument(src, snap)
+	require.ErrorIs(t, err, ErrSnapshotSourceGCed)
+	assert.Nil(t, got)
+}

--- a/examples/snapshot-history/README.md
+++ b/examples/snapshot-history/README.md
@@ -69,22 +69,24 @@ _, err := db.Exec("INSERT INTO snapshots (doc_id, revision, data) VALUES (?, ?, 
 
 // Later: decode and restore
 snap, err := crdt.DecodeSnapshot(data)
-restored, err := crdt.RestoreDocument(doc, snap)
+restored, err := crdt.CreateDocFromSnapshot(doc, snap)
 ```
 
-## RestoreDocument vs EncodeStateFromSnapshot
+## CreateDocFromSnapshot vs EncodeStateFromSnapshot
 
 Both functions work with a snapshot, but serve different purposes:
 
-### `RestoreDocument(doc, snap) (*Doc, error)`
+### `CreateDocFromSnapshot(doc, snap) (*Doc, error)`
 
-Creates a new, independent `Doc` that reflects the document state at snapshot time. Deletions from the snapshot's delete set are applied, so the result is an exact replica of the document as it appeared at that moment.
+Creates a new, independent `Doc` that reflects the document state at snapshot time — the Go equivalent of Yjs JS's `createDocFromSnapshot`. Deletions from the snapshot's delete set are applied, so the result is an exact replica of the document as it appeared at that moment. (`RestoreDocument` is a backward-compatible alias.)
+
+The source doc must have been created `WithGC(false)`; a GC-enabled source returns `ErrSnapshotSourceGCed`, because GC frees deleted items' content at commit and reconstruction could not be faithful.
 
 Use this when you want to **read** or **display** a past version locally.
 
 ```go
 snap, _ := crdt.DecodeSnapshot(storedBytes)
-historical, _ := crdt.RestoreDocument(doc, snap)
+historical, _ := crdt.CreateDocFromSnapshot(doc, snap) // doc created WithGC(false)
 fmt.Println(historical.GetText("article").ToString())
 ```
 

--- a/examples/snapshot-history/main.go
+++ b/examples/snapshot-history/main.go
@@ -12,7 +12,8 @@
 //	crdt.CaptureSnapshot(doc)           — take a point-in-time snapshot
 //	crdt.EncodeSnapshot(snap)           — serialise to bytes (store in DB, file, etc.)
 //	crdt.DecodeSnapshot(data)           — deserialise
-//	crdt.RestoreDocument(doc, snap)     — reconstruct the document at snapshot time
+//	crdt.CreateDocFromSnapshot(doc, snap) — reconstruct the document at snapshot time (Yjs-parity name)
+//	crdt.RestoreDocument(doc, snap)     — alias of CreateDocFromSnapshot, kept for compatibility
 //	crdt.EncodeStateFromSnapshot(doc, snap) — get an update representing the historical state
 package main
 
@@ -243,15 +244,15 @@ func main() {
 	crdt.RunGC(gcDoc)
 	fmt.Println("  GC has run: deleted item content has been freed.")
 
-	// Attempt to restore to snapshot A (before the delete).
+	// Attempt to restore to snapshot A (before the delete). Because gcDoc has GC
+	// enabled, deleted items' content is freed at commit, so reconstruction can't
+	// be faithful — CreateDocFromSnapshot / RestoreDocument now refuse upfront with
+	// ErrSnapshotSourceGCed rather than returning a silently-incomplete document.
 	restoredGC, err := crdt.RestoreDocument(gcDoc, snapBeforeDelete)
 	if err != nil {
-		fmt.Printf("  Restoration after GC failed: %v\n", err)
+		fmt.Printf("  Restoration from a GC-enabled doc refused: %v\n", err)
 	} else {
-		restoredText := restoredGC.GetText("notes").ToString()
-		// After GC the content bytes of deleted items are gone, so the restored
-		// document only contains items that are still live (not freed).
-		fmt.Printf("  Restored text (after GC): %q\n", restoredText)
+		fmt.Printf("  Restored text (after GC): %q\n", restoredGC.GetText("notes").ToString())
 	}
 	fmt.Println()
 	fmt.Println("  Warning: if GC has run, items deleted AFTER a snapshot can no longer be")


### PR DESCRIPTION
Two CRDT items, validated against the existing code before implementing — both turned out narrower than their issue bodies implied, so this PR fills the *genuine* remaining gaps.

## #58 — `CreateDocFromSnapshot` + GC-safety guard

The replay machinery already existed (`RestoreDocument` / `EncodeStateFromSnapshot`). What was missing:

- **`crdt.CreateDocFromSnapshot(src, snap) (*Doc, error)`** — the Yjs-parity name (`createDocFromSnapshot`) for reconstructing a historic doc from a `Snapshot`, reusing the existing encode-from-snapshot path.
- **`crdt.ErrSnapshotSourceGCed`** + the guard that was the real gap: a GC-enabled source frees deleted items' content at commit, so an item deleted *after* the snapshot can't be faithfully reconstructed. The old `RestoreDocument` returned a silently-incomplete doc; it now delegates to `CreateDocFromSnapshot` and shares the guard.

Tests: round-trip at a past state, post-snapshot-deleted key/element reappears, GC guard fires (`ErrSnapshotSourceGCed`), reconstruction is independent & itself non-GC.

## #54 — conflict-scan allocation (item C)

A and B were already resolved (A shipped in v1.16.0; B measured and intentionally not adopted — see the issue). Only item **C** remained, and it was flagged measure-first / possibly won't-fix.

Root cause found by profiling: `Item.integrate` reset its conflict-tracking map with a fresh `make()` each time the left bound advanced — quadratic allocation in the conflict-group size. Fix: reuse the map via `clear()`, matching Yjs's `conflictingItems.clear()` (not the `sync.Pool` variant previously reverted).

`benchstat` (n=6), new `BenchmarkConcurrentSamePositionInsert`:

| workload | allocs/op | B/op | sec/op |
|---|---|---|---|
| 400 peers, same position | −91.6% | −55.4% | −28.9% |
| 100 peers, same position | −75.2% | −53.3% | −28.0% |
| **TwoPeerConvergence (common path)** | **unchanged** (405→405) | ~ | ~ |

A large-conflict-group convergence regression test guards that the `clear()` reuse doesn't change conflict-resolution outcome (byte-identical state across apply orders).

## Verification
- `go test -race ./...` — green (full suite)
- `go vet ./...` — clean
- `golangci-lint run ./crdt/...` — 0 issues
- `go run ./examples/snapshot-history` — runs; GC phase now cleanly reports the refused restore

Closes #58
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
