### PR TITLE
fix(provider/websocket): off-lock relay RoomActivated to prevent re-entrant deadlock (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.29.1] — 2026-06-29
+
+### Fixed
+
+- **WebSocket clustering deadlock**: `getOrCreateRoom` invoked the relay's
+  `RoomActivated` callback while holding the server's rooms lock (`s.rmu`). A relay
+  that replays stream history from within `RoomActivated` by calling `Sink.Inject`
+  re-entered `getOrCreateRoom` and blocked on the same non-reentrant mutex,
+  deadlocking the goroutine while it still held the lock and wedging the entire
+  instance — every subsequent room create or serve blocked. This was reachable in
+  normal multi-node operation: the second instance to activate a room whose cluster
+  stream already had history ran a catch-up replay at activation time and
+  deadlocked. `RoomActivated` now fires after the rooms lock is released and the
+  room is published, so a re-entrant `Inject` finds the room and returns instead of
+  deadlocking. This mirrors `RoomDeactivated`, which already fired off-lock. (#133)
+
 ## [1.29.0] — 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.29.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.29.1**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,36 +1,26 @@
 ## What's new
 
-Provider security hardening. The HTTP provider gains the auth hook, room-name
-validation, and configurable body-size cap the WebSocket provider already had; the
-WebSocket provider gains optional per-peer message rate limiting and `*` wildcard
-matching in `AllowedOrigins`. Every new config field is additive (zero values
-preserve current behaviour); the one behaviour change is that the HTTP provider now
-rejects invalid room names with 400.
+A clustering bug fix. When multiple WebSocket server instances share a document
+through a `cluster.Relay`, the second instance to activate a room that already had
+history on the shared stream could deadlock — and because it deadlocked while
+holding the server's rooms lock, the whole instance stopped serving every room.
+This release fixes that; no API changes.
 
-### Added
+### Fixed
 
-- **`http.Server.AuthFunc`** — reject unauthenticated requests with 401 before any
-  document is read or mutated (parity with the WebSocket provider). (#50)
-- **`http.Server.MaxUpdateBytes`** — configurable POST-body cap; oversize bodies get
-  413. Zero keeps the 64 MiB default. (#50)
-- **`websocket.Server.MessageRateLimit` / `MessageRateBurst`** — optional per-peer
-  inbound rate limit. A peer that floods past it is disconnected — not silently
-  dropped, which would diverge it. Zero is unlimited. (#51)
-
-### Changed
-
-- **The HTTP provider now validates room names** (empty / oversized / `.` / `..` /
-  control chars → 400), using the same rule as the WebSocket provider. Names that
-  were previously accepted are now rejected. (#50)
-- **`websocket.Server.AllowedOrigins` now supports `*` wildcards** — e.g.
-  `https://*.netlify.app` or `https://pr-*---web-*.run.app`, in addition to exact
-  origins and the bare `*`. Matching is anchored so a wildcard can't spoof a host,
-  and a trailing `*` covers only an optional `:<port>`. (#129)
+- **WebSocket clustering deadlock (#133)** — `getOrCreateRoom` fired the relay's
+  `RoomActivated` callback while holding the rooms lock. A relay that replays
+  caught-up history from inside `RoomActivated` (via `Sink.Inject`) re-entered
+  `getOrCreateRoom` and blocked on the same non-reentrant lock, wedging the whole
+  instance. `RoomActivated` now fires after the lock is released and the room is
+  published, so the re-entrant `Inject` finds the room and returns. This matches
+  how `RoomDeactivated` was already invoked off-lock. Single-node and
+  first-instance deployments were never affected.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.29.0
+go get github.com/reearth/ygo@v1.29.1
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/provider/websocket/cluster.go
+++ b/provider/websocket/cluster.go
@@ -110,8 +110,8 @@ func (s *Server) relayWorker(ctx context.Context, out <-chan relayOutbound) {
 
 // registerRelayObservers wires doc.OnUpdate and awareness.OnChange for a room so
 // local (non-sentinel-origin) changes are published to the relay. Must be called
-// with s.rmu.Lock held (from getOrCreateRoom). The unsubscribe functions are
-// stored on the room and invoked by teardownRelayRoom.
+// with s.rmu.Lock held (from getOrCreateRoomLocked). The unsubscribe functions
+// are stored on the room and invoked by teardownRelayRoom.
 func (s *Server) registerRelayObservers(r *room, name string) {
 	sentinel := s.relaySentinel
 

--- a/provider/websocket/cluster_reentrancy_internal_test.go
+++ b/provider/websocket/cluster_reentrancy_internal_test.go
@@ -1,4 +1,5 @@
-// Package websocket - internal regression test for issue #133.
+// Package websocket - internal regression tests for issue #133: a relay whose
+// RoomActivated callback re-enters the Server via Sink.Inject must not deadlock.
 package websocket
 
 import (
@@ -17,8 +18,10 @@ import (
 // exactly the cross-instance path: a second node activating an already-active
 // room replays existing stream entries during activation.
 type reentrantActivationRelay struct {
-	sink   cluster.Sink
-	update []byte
+	sink      cluster.Sink
+	kind      cluster.Kind
+	data      []byte
+	injectErr error // written in RoomActivated, read after the activation returns
 }
 
 func (r *reentrantActivationRelay) Publish(context.Context, cluster.Outbound) error { return nil }
@@ -31,53 +34,131 @@ func (r *reentrantActivationRelay) Start(_ context.Context, sink cluster.Sink) e
 func (r *reentrantActivationRelay) RoomActivated(room string) {
 	// Catch-up replay delivered synchronously from inside the activation
 	// callback — the natural way for a relay to push stream history.
-	_ = r.sink.Inject(context.Background(), cluster.Inbound{
-		Room: room, Kind: cluster.KindSync, Data: r.update,
+	r.injectErr = r.sink.Inject(context.Background(), cluster.Inbound{
+		Room: room, Kind: r.kind, Data: r.data,
 	})
 }
 
 func (r *reentrantActivationRelay) RoomDeactivated(string) {}
 func (r *reentrantActivationRelay) Close() error           { return nil }
 
-// TestGetOrCreateRoom_ReentrantInjectFromRoomActivated_NoDeadlock asserts that a
-// relay which calls Sink.Inject from within RoomActivated does not deadlock the
-// Server, and that the replayed update reaches the room (#133).
-func TestGetOrCreateRoom_ReentrantInjectFromRoomActivated_NoDeadlock(t *testing.T) {
+// runWithDeadlockGuard runs fn in a goroutine and fails the test if it does not
+// return within 2s — a deadlocked getOrCreateRoom parks forever on s.rmu, so a
+// timeout is the only way to observe the bug without hanging the whole binary.
+func runWithDeadlockGuard(t *testing.T, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("getOrCreateRoom deadlocked: RoomActivated re-entered Sink.Inject " +
+			"while the Server held s.rmu (#133)")
+	}
+}
+
+// TestGetOrCreateRoom_ReentrantSyncInjectFromRoomActivated asserts that a relay
+// which replays a document update from within RoomActivated does not deadlock,
+// and that the replayed update reaches the room.
+func TestGetOrCreateRoom_ReentrantSyncInjectFromRoomActivated(t *testing.T) {
 	// A valid V1 update for the activation replay to inject. The shared-type ref
 	// is resolved OUTSIDE the Transact closure (GetText inside Transact deadlocks).
 	src := crdt.New()
 	txt := src.GetText("t")
 	src.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
-	update := crdt.EncodeStateAsUpdateV1(src, nil)
 
 	s := NewServer()
-	relay := &reentrantActivationRelay{update: update}
+	relay := &reentrantActivationRelay{kind: cluster.KindSync, data: crdt.EncodeStateAsUpdateV1(src, nil)}
 	if err := s.AttachRelay(relay); err != nil {
 		t.Fatalf("AttachRelay: %v", err)
 	}
 
-	done := make(chan struct{})
-	go func() {
-		// getOrCreateRoom fires RoomActivated, which re-enters via Sink.Inject.
-		_, _ = s.getOrCreateRoom(context.Background(), "doc1")
-		close(done)
-	}()
+	runWithDeadlockGuard(t, func() { _, _ = s.getOrCreateRoom(context.Background(), "doc1") })
 
-	select {
-	case <-done:
-		// reached: no deadlock.
-	case <-time.After(2 * time.Second):
-		t.Fatal("getOrCreateRoom deadlocked: RoomActivated re-entered Sink.Inject " +
-			"while the Server held s.rmu (#133)")
+	if relay.injectErr != nil {
+		t.Fatalf("re-entrant Inject returned error: %v", relay.injectErr)
 	}
-
-	// The off-lock activation replay must have materialised the room and applied
-	// the injected update.
 	d := s.GetDoc("doc1")
 	if d == nil {
 		t.Fatal("room doc1 was not created")
 	}
 	if got := d.GetText("t").ToString(); got != "hi" {
 		t.Fatalf("injected update not applied: GetText = %q, want %q", got, "hi")
+	}
+}
+
+// TestGetOrCreateRoom_ReentrantAwarenessInjectFromRoomActivated covers the other
+// Inject branch (KindAwareness), which also re-enters getOrCreateRoom.
+func TestGetOrCreateRoom_ReentrantAwarenessInjectFromRoomActivated(t *testing.T) {
+	s := NewServer()
+	relay := &reentrantActivationRelay{kind: cluster.KindAwareness, data: awarenessUpdateFor(7)}
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	runWithDeadlockGuard(t, func() { _, _ = s.getOrCreateRoom(context.Background(), "doc1") })
+
+	if relay.injectErr != nil {
+		t.Fatalf("re-entrant Inject returned error: %v", relay.injectErr)
+	}
+	if aw, ok := s.GetAwareness("doc1"); !ok || aw == nil {
+		t.Fatal("awareness for doc1 was not created")
+	}
+}
+
+// roomActivatedProbeRelay records each RoomActivated call and whether the room
+// was already published into s.rooms (GetDoc != nil) at callback time.
+type roomActivatedProbeRelay struct {
+	sink                cluster.Sink
+	activations         []string
+	publishedAtCallback []bool
+}
+
+func (r *roomActivatedProbeRelay) Publish(context.Context, cluster.Outbound) error { return nil }
+func (r *roomActivatedProbeRelay) Start(_ context.Context, sink cluster.Sink) error {
+	r.sink = sink
+	return nil
+}
+func (r *roomActivatedProbeRelay) RoomActivated(room string) {
+	r.activations = append(r.activations, room)
+	r.publishedAtCallback = append(r.publishedAtCallback, r.sink.GetDoc(room) != nil)
+}
+func (r *roomActivatedProbeRelay) RoomDeactivated(string) {}
+func (r *roomActivatedProbeRelay) Close() error           { return nil }
+
+// TestGetOrCreateRoom_RoomActivatedFiresOnceOffLockAfterPublish asserts the fix's
+// invariant: RoomActivated fires exactly once per created room, after the room is
+// published into s.rooms and after s.rmu is released (so a re-entrant Inject can
+// find the room). A second getOrCreateRoom for the same name must not re-fire it.
+func TestGetOrCreateRoom_RoomActivatedFiresOnceOffLockAfterPublish(t *testing.T) {
+	s := NewServer()
+	relay := &roomActivatedProbeRelay{}
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	r1, err := s.getOrCreateRoom(context.Background(), "doc1")
+	if err != nil {
+		t.Fatalf("first getOrCreateRoom: %v", err)
+	}
+	r2, err := s.getOrCreateRoom(context.Background(), "doc1")
+	if err != nil {
+		t.Fatalf("second getOrCreateRoom: %v", err)
+	}
+	if r1 != r2 {
+		t.Fatal("getOrCreateRoom returned a different room on the second call")
+	}
+
+	if len(relay.activations) != 1 {
+		t.Fatalf("RoomActivated fired %d times, want exactly 1", len(relay.activations))
+	}
+	if relay.activations[0] != "doc1" {
+		t.Fatalf("RoomActivated room = %q, want %q", relay.activations[0], "doc1")
+	}
+	if !relay.publishedAtCallback[0] {
+		t.Fatal("RoomActivated fired before the room was published into s.rooms (#133)")
 	}
 }

--- a/provider/websocket/cluster_reentrancy_internal_test.go
+++ b/provider/websocket/cluster_reentrancy_internal_test.go
@@ -1,0 +1,83 @@
+// Package websocket - internal regression test for issue #133.
+package websocket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
+)
+
+// reentrantActivationRelay reproduces issue #133: a cluster.Relay whose
+// RoomActivated synchronously delivers caught-up history by calling Sink.Inject.
+// Inject re-enters getOrCreateRoom; if RoomActivated runs while the Server still
+// holds s.rmu, the non-reentrant mutex self-deadlocks the whole instance. This is
+// exactly the cross-instance path: a second node activating an already-active
+// room replays existing stream entries during activation.
+type reentrantActivationRelay struct {
+	sink   cluster.Sink
+	update []byte
+}
+
+func (r *reentrantActivationRelay) Publish(context.Context, cluster.Outbound) error { return nil }
+
+func (r *reentrantActivationRelay) Start(_ context.Context, sink cluster.Sink) error {
+	r.sink = sink
+	return nil
+}
+
+func (r *reentrantActivationRelay) RoomActivated(room string) {
+	// Catch-up replay delivered synchronously from inside the activation
+	// callback — the natural way for a relay to push stream history.
+	_ = r.sink.Inject(context.Background(), cluster.Inbound{
+		Room: room, Kind: cluster.KindSync, Data: r.update,
+	})
+}
+
+func (r *reentrantActivationRelay) RoomDeactivated(string) {}
+func (r *reentrantActivationRelay) Close() error           { return nil }
+
+// TestGetOrCreateRoom_ReentrantInjectFromRoomActivated_NoDeadlock asserts that a
+// relay which calls Sink.Inject from within RoomActivated does not deadlock the
+// Server, and that the replayed update reaches the room (#133).
+func TestGetOrCreateRoom_ReentrantInjectFromRoomActivated_NoDeadlock(t *testing.T) {
+	// A valid V1 update for the activation replay to inject. The shared-type ref
+	// is resolved OUTSIDE the Transact closure (GetText inside Transact deadlocks).
+	src := crdt.New()
+	txt := src.GetText("t")
+	src.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	update := crdt.EncodeStateAsUpdateV1(src, nil)
+
+	s := NewServer()
+	relay := &reentrantActivationRelay{update: update}
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		// getOrCreateRoom fires RoomActivated, which re-enters via Sink.Inject.
+		_, _ = s.getOrCreateRoom(context.Background(), "doc1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// reached: no deadlock.
+	case <-time.After(2 * time.Second):
+		t.Fatal("getOrCreateRoom deadlocked: RoomActivated re-entered Sink.Inject " +
+			"while the Server held s.rmu (#133)")
+	}
+
+	// The off-lock activation replay must have materialised the room and applied
+	// the injected update.
+	d := s.GetDoc("doc1")
+	if d == nil {
+		t.Fatal("room doc1 was not created")
+	}
+	if got := d.GetText("t").ToString(); got != "hi" {
+		t.Fatalf("injected update not applied: GetText = %q, want %q", got, "hi")
+	}
+}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -674,14 +674,38 @@ func (s *Server) GetDoc(name string) *crdt.Doc {
 	return nil
 }
 
+// getOrCreateRoom returns the room for name, creating it on first use. When a
+// new room is created and a relay is attached, the relay's RoomActivated
+// callback fires AFTER s.rmu is released (#133): RoomActivated may synchronously
+// replay stream history via Sink.Inject, which re-enters getOrCreateRoom — under
+// s.rmu the non-reentrant mutex would self-deadlock and wedge the whole instance.
+// This mirrors teardownRelayRoom, which already fires RoomDeactivated off-lock.
 func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error) {
+	r, created, err := s.getOrCreateRoomLocked(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if created && s.relay != nil {
+		// Off-lock: the room is already published into s.rooms, so a re-entrant
+		// Sink.Inject finds it and returns instead of blocking on s.rmu.
+		s.relay.RoomActivated(name)
+	}
+	return r, nil
+}
+
+// getOrCreateRoomLocked is the locked portion of getOrCreateRoom. It returns the
+// room, whether it was newly created (so the caller fires RoomActivated exactly
+// once off-lock), and any creation error. Relay observers are registered here,
+// before the room is published into s.rooms, so no local change is missed — only
+// the RoomActivated notification is deferred until after s.rmu is released.
+func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room, bool, error) {
 	s.rmu.Lock()
 	defer s.rmu.Unlock()
 	if r, ok := s.rooms[name]; ok {
-		return r, nil
+		return r, false, nil
 	}
 	if s.MaxRooms > 0 && len(s.rooms) >= s.MaxRooms {
-		return nil, ErrTooManyRooms
+		return nil, false, ErrTooManyRooms
 	}
 	docOpts := []crdt.DocOption{}
 	if s.MaxPendingItems > 0 {
@@ -709,11 +733,11 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 	if s.persistence != nil {
 		data, err := s.persistence.LoadDoc(name)
 		if err != nil {
-			return nil, fmt.Errorf("loading room %q: %w", name, err)
+			return nil, false, fmt.Errorf("loading room %q: %w", name, err)
 		}
 		if len(data) > 0 {
 			if err := crdt.ApplyUpdateV1(r.doc, data, nil); err != nil {
-				return nil, fmt.Errorf("bootstrapping room %q: %w", name, err)
+				return nil, false, fmt.Errorf("bootstrapping room %q: %w", name, err)
 			}
 		}
 	}
@@ -730,7 +754,7 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 			hookErr = hook(ctx, name, r.doc)
 		})
 		if hookErr != nil {
-			return nil, fmt.Errorf("OnLoadDocument for room %q: %w", name, hookErr)
+			return nil, false, fmt.Errorf("OnLoadDocument for room %q: %w", name, hookErr)
 		}
 	}
 	if s.persistence != nil {
@@ -749,15 +773,15 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 		})
 	}
 	// Wire relay observers (doc.OnUpdate + awareness.OnChange) so local changes
-	// are published to other nodes. Registered under s.rmu.Lock (held by the
-	// caller) before the room is published into s.rooms, so no change is missed.
-	// No-op when no relay is attached.
+	// are published to other nodes. Registered under s.rmu.Lock before the room
+	// is published into s.rooms, so no change is missed. No-op when no relay is
+	// attached. RoomActivated is NOT fired here — the caller fires it off-lock
+	// once getOrCreateRoomLocked returns created=true (#133).
 	if s.relay != nil {
 		s.registerRelayObservers(r, name)
-		s.relay.RoomActivated(name)
 	}
 	s.rooms[name] = r
-	return r, nil
+	return r, true, nil
 }
 
 // ServeHTTP upgrades the request to WebSocket and runs the peer sync loop.


### PR DESCRIPTION
## Summary

Fixes #133: a clustering deadlock that could wedge an entire WebSocket server instance.

`getOrCreateRoom` invoked the relay's `RoomActivated` callback **while holding the server's rooms write lock** (`s.rmu`). A `cluster.Relay` that replays caught-up stream history from within `RoomActivated` — by calling `Sink.Inject`, the natural delivery path — re-enters `getOrCreateRoom`, which blocks on the same **non-reentrant** `sync.RWMutex`. The goroutine deadlocks while still holding the rooms lock, so every subsequent room create/serve on that instance blocks too.

This is reachable in normal multi-node operation: the **second** instance to activate a room whose cluster stream already has history runs a catch-up replay at activation time and deadlocks. Single-node and first-instance paths never trip it (a fresh room has nothing to replay), which is why it's easy to miss.

## Fix

Split `getOrCreateRoom` into:
- `getOrCreateRoomLocked` — does all the lock-held work (build room, register relay observers, publish into `s.rooms`) under `s.rmu` and returns a `created` flag.
- `getOrCreateRoom` — fires `relay.RoomActivated` **after** the lock is released, only when a new room was created.

A re-entrant `Sink.Inject` now finds the already-published room and returns immediately instead of blocking on `s.rmu`. This mirrors `teardownRelayRoom`, which already fired `RoomDeactivated` off-lock — the bug was the activation/deactivation asymmetry. Relay observers stay registered under the lock (before publish), so no local update is missed.

No public API change → patch release (**v1.29.1**).

## Tests

Three internal regression tests (`cluster_reentrancy_internal_test.go`), all run under `-race`:
- `KindSync` re-entry from `RoomActivated` → no deadlock, replayed update reaches the room. (Confirmed it deadlocks on a 2s guard *before* the fix.)
- `KindAwareness` re-entry → covers the other `Inject` branch.
- `RoomActivated` fires exactly once, off-lock, **after** the room is published into `s.rooms`.

## Verification

- `go test -race ./provider/websocket/ ./cluster/...` — pass
- `go vet` — clean
- `golangci-lint run` — 0 issues
- `gofmt` — clean

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)