### PR TITLE
feat(provider/websocket): read-only connections via Server.Authorize (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.30.0] — 2026-07-03
+
+### Added
+
+- **`websocket.Server.Authorize`** — a richer alternative to `AuthFunc`:
+  `func(*http.Request) (ConnectionConfig, bool)`. The bool accepts/rejects the
+  connection (false → 401, as before); the returned `ConnectionConfig` describes
+  the accepted connection. The first field is `ReadOnly`. When `Authorize` is set
+  it takes precedence over `AuthFunc`; `AuthFunc` is unchanged and still grants
+  read-write. This enables Hocuspocus-style read-only connections — public-read
+  docs, viewer roles, monitoring connections (#59).
+- **`websocket.ConnectionConfig`** — per-connection configuration returned by
+  `Authorize`. Currently carries `ReadOnly bool`; extensible for future
+  per-connection settings.
+
+### Changed
+
+- **Read-only WebSocket peers drop inbound writes.** A peer accepted with
+  `ConnectionConfig{ReadOnly: true}` still receives document and awareness
+  broadcasts and can request state (its `SyncStep1` is answered with `SyncStep2`)
+  and query awareness, but its inbound writes are dropped server-side: sync
+  `SyncStep2`/`Update` messages, Hocuspocus `SyncReply` (tag 4), and awareness
+  updates are not applied or broadcast. Stateless signals (tags 5/6) are not
+  gated by read-only. This is additive — connections authorized via `AuthFunc`
+  (or with no auth hook) remain read-write. (#59)
+
 ## [1.29.1] — 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.29.1**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.30.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 
@@ -63,6 +63,7 @@ Post-v1.0 hardening:
 - **CRDT correctness batch** (v1.27.0). Three Yjs-parity fixes, all verified against `yjs@13.6.30`: `YText.Format` ports the Yjs `formatText` algorithm so re-applying/toggling a format over a sub-range no longer strips the surrounding run (`ToDelta` also coalesces adjacent equal-attribute inserts); `UndoManager` undo of a deletion re-inserts content as a new item so it propagates to peers instead of being silently lost on the next sync; and `MergeUpdatesV1`/`DiffUpdateV1` merge at the struct level so non-integrable structs are no longer dropped. Adds struct-level `MergeUpdatesV2`/`DiffUpdateV2`/`EncodeStateVectorFromUpdate` and exports `crdt.SharedType`.
 - **Snapshot reconstruction & conflict-scan perf** (v1.28.0). Adds `crdt.CreateDocFromSnapshot` (Yjs-parity name for rebuilding a historic doc from a `Snapshot`), with a `WithGC(false)` safety guard (`ErrSnapshotSourceGCed`) so reconstruction can't silently return incomplete history; `RestoreDocument` now shares that guard. `Item.integrate` also reuses its YATA conflict-tracking map via `clear()` instead of reallocating it, cutting convergence allocations ~92% under high same-position contention with no change to the common path.
 - **Provider security hardening** (v1.29.0). The HTTP provider gains `AuthFunc` (401), room-name validation (400, the same rule the WebSocket provider uses), and a configurable `MaxUpdateBytes` (413) — parity with the WebSocket provider. The WebSocket provider gains optional per-peer message rate limiting (`MessageRateLimit`/`MessageRateBurst`): a peer that floods past the limit is disconnected rather than diverged. `AllowedOrigins` also gains `*` wildcard matching (e.g. `https://*.netlify.app`), anchored so a wildcard can't spoof a host. The new config fields are additive (zero values preserve current behaviour); the one behaviour change is that the HTTP provider now rejects invalid room names with 400.
+- **Read-only WebSocket connections** (v1.30.0). New `Server.Authorize func(*http.Request) (ConnectionConfig, bool)` both accepts/rejects a connection and reports per-connection config — currently `ReadOnly`. A read-only peer receives document and awareness broadcasts but its inbound writes (sync step-2/update and awareness) are dropped server-side, while still being able to request state (SyncStep1) and query awareness. The existing bool `AuthFunc` is unchanged; `Authorize` takes precedence when both are set. Matches Hocuspocus's `readOnly` connection flag (#59).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 
@@ -348,6 +349,17 @@ Each defaults to a sensible value or unlimited where noted.
 ```go
 server.AuthFunc = func(r *http.Request) bool {
     return validateBearer(r.Header.Get("Authorization"))
+}
+```
+
+For **read-only connections** (v1.30.0, #59), use `Server.Authorize` instead — it both accepts/rejects and reports per-connection config. A read-only peer receives document and awareness broadcasts but its inbound writes (sync step-2/update and awareness) are dropped server-side; it can still request state (SyncStep1) and query awareness. When set, `Authorize` takes precedence over `AuthFunc`:
+
+```go
+server.Authorize = func(r *http.Request) (ygws.ConnectionConfig, bool) {
+    if !validateBearer(r.Header.Get("Authorization")) {
+        return ygws.ConnectionConfig{}, false // reject → 401
+    }
+    return ygws.ConnectionConfig{ReadOnly: !isEditor(r)}, true
 }
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,32 @@
 ## What's new
 
-A clustering bug fix. When multiple WebSocket server instances share a document
-through a `cluster.Relay`, the second instance to activate a room that already had
-history on the shared stream could deadlock — and because it deadlocked while
-holding the server's rooms lock, the whole instance stopped serving every room.
-This release fixes that; no API changes.
+Read-only WebSocket connections. The WebSocket provider gains a richer auth entry
+point, `Server.Authorize`, that can mark a connection read-only — it receives
+document and awareness broadcasts but its inbound writes are dropped server-side.
+This matches Hocuspocus's `readOnly` connection flag and covers public-read docs,
+viewer roles, and monitoring connections. Additive: the existing `AuthFunc` is
+unchanged and connections stay read-write unless you opt in.
 
-### Fixed
+### Added
 
-- **WebSocket clustering deadlock (#133)** — `getOrCreateRoom` fired the relay's
-  `RoomActivated` callback while holding the rooms lock. A relay that replays
-  caught-up history from inside `RoomActivated` (via `Sink.Inject`) re-entered
-  `getOrCreateRoom` and blocked on the same non-reentrant lock, wedging the whole
-  instance. `RoomActivated` now fires after the lock is released and the room is
-  published, so the re-entrant `Inject` finds the room and returns. This matches
-  how `RoomDeactivated` was already invoked off-lock. Single-node and
-  first-instance deployments were never affected.
+- **`websocket.Server.Authorize func(*http.Request) (ConnectionConfig, bool)`** —
+  accepts/rejects a connection (false → 401) *and* reports its config. Takes
+  precedence over `AuthFunc` when both are set. (#59)
+- **`websocket.ConnectionConfig{ ReadOnly bool }`** — per-connection config
+  returned by `Authorize`; extensible for future settings. (#59)
+
+### Behaviour
+
+- A **read-only** peer still receives broadcasts, gets a `SyncStep2` in reply to
+  its `SyncStep1`, and can query awareness — but its inbound document writes
+  (`SyncStep2`/`Update`, Hocuspocus `SyncReply`) and awareness updates are dropped
+  server-side. Stateless signals are not gated. Connections authorized via
+  `AuthFunc` (or with no auth hook) remain read-write.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.29.1
+go get github.com/reearth/ygo@v1.30.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/provider/websocket/example_test.go
+++ b/provider/websocket/example_test.go
@@ -20,3 +20,24 @@ func ExampleServer() {
 	fmt.Println("server ready")
 	// Output: server ready
 }
+
+// ExampleServer_authorize demonstrates read-only connections (#59). Authorize
+// both accepts/rejects the connection and reports whether it is read-only. A
+// read-only peer receives document and awareness broadcasts but its inbound
+// writes are dropped server-side. When set, Authorize takes precedence over
+// AuthFunc.
+func ExampleServer_authorize() {
+	srv := ygws.NewServer()
+	srv.Authorize = func(r *http.Request) (ygws.ConnectionConfig, bool) {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			return ygws.ConnectionConfig{}, false // reject: 401
+		}
+		// A viewer token grants observe-only access; an editor token can write.
+		return ygws.ConnectionConfig{ReadOnly: token == "viewer"}, true
+	}
+
+	_ = srv
+	fmt.Println("configured")
+	// Output: configured
+}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -27,6 +27,7 @@ type peer struct {
 	writeCh    chan []byte   // buffered queue drained by runWriter goroutine
 	writerDone chan struct{} // closed when runWriter exits
 	limiter    *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
+	readOnly   bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
 
 	// disconnectOnce ensures the full teardown sequence in handleDisconnect
 	// runs exactly once, regardless of how many callers race (e.g. broadcast's
@@ -53,6 +54,14 @@ func (p *peer) handleMessage(data []byte) {
 	case msgSync:
 		// Sync payload follows directly (no VarBytes wrapper).
 		payload := dec.RemainingBytes()
+		if p.readOnly {
+			// Read-only peers may still request state (SyncStep1 → we reply with
+			// SyncStep2), but must not push changes: drop SyncStep2/Update without
+			// applying or broadcasting (#59). A malformed frame is dropped too.
+			if subType, _, e := ygsync.ReadSyncMessage(payload); e != nil || subType != ygsync.MsgSyncStep1 {
+				return
+			}
+		}
 		reply, err := ygsync.ApplySyncMessage(p.room.doc, payload, p)
 		if err != nil {
 			p.server.log().Debug("discarded unappliable sync message",
@@ -68,6 +77,9 @@ func (p *peer) handleMessage(data []byte) {
 		}
 
 	case msgAwareness:
+		if p.readOnly {
+			return // #59: read-only peers' inbound awareness is dropped.
+		}
 		// Awareness payload is VarBytes-wrapped (y-websocket protocol).
 		awBytes, err := dec.ReadVarBytes()
 		if err != nil {
@@ -98,6 +110,9 @@ func (p *peer) handleMessage(data []byte) {
 		// back, which would cause an infinite ping-pong on noisy links.
 		// Apply locally and broadcast updates, but never reply with our
 		// own step-1.
+		if p.readOnly {
+			return // #59: SyncReply carries a SyncStep2 write; drop it for read-only peers.
+		}
 		payload := dec.RemainingBytes()
 		if _, err := ygsync.ApplySyncMessage(p.room.doc, payload, p); err != nil {
 			p.server.log().Debug("discarded unappliable sync(reply) message",

--- a/provider/websocket/readonly_test.go
+++ b/provider/websocket/readonly_test.go
@@ -1,0 +1,192 @@
+package websocket_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/awareness"
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+	ygws "github.com/reearth/ygo/provider/websocket"
+	ygsync "github.com/reearth/ygo/sync"
+)
+
+// makeUpdate builds a V1 update that inserts text into YText "t".
+func makeUpdate(t *testing.T, text string) []byte {
+	t.Helper()
+	d := crdt.New()
+	txt := d.GetText("t")
+	d.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, text, nil) })
+	return crdt.EncodeStateAsUpdateV1(d, nil)
+}
+
+// makeAwareness builds a one-client awareness update for the given client ID.
+func makeAwareness(id uint64) []byte {
+	a := awareness.New(id)
+	a.SetLocalState(map[string]any{"cursor": 1})
+	return a.EncodeUpdate([]uint64{id})
+}
+
+// dialReadOnly dials the test server, marking the connection read-only via a
+// header the test's Authorize func keys off of.
+func dialReadOnly(t *testing.T, ts *httptest.Server, room string, readOnly bool) *gws.Conn {
+	t.Helper()
+	h := http.Header{}
+	if readOnly {
+		h.Set("X-Read-Only", "1")
+	}
+	conn, _, err := gws.DefaultDialer.Dial(wsURL(ts, room), h)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// readOnlyByHeader authorizes every connection but marks it read-only when the
+// X-Read-Only header is set.
+func readOnlyByHeader(r *http.Request) (ygws.ConnectionConfig, bool) {
+	return ygws.ConnectionConfig{ReadOnly: r.Header.Get("X-Read-Only") == "1"}, true
+}
+
+// #59 — a read-only peer's inbound document update must NOT mutate server state.
+func TestReadOnly_InboundUpdateDropped(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.Authorize = func(*http.Request) (ygws.ConnectionConfig, bool) {
+		return ygws.ConnectionConfig{ReadOnly: true}, true
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	conn := dial(t, ts, "room")
+	drainHandshake(t, conn, crdt.New())
+
+	sendUpdate(t, conn, makeUpdate(t, "hello"))
+	time.Sleep(100 * time.Millisecond)
+
+	doc := srv.GetDoc("room")
+	require.NotNil(t, doc)
+	assert.Empty(t, doc.GetText("t").ToString(),
+		"read-only peer's update must not mutate server state")
+}
+
+// #59 — a read-only peer still receives broadcasts from read-write peers.
+func TestReadOnly_ReceivesBroadcasts(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.Authorize = readOnlyByHeader
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	editor := dialReadOnly(t, ts, "room", false)
+	drainHandshake(t, editor, crdt.New())
+	reader := dialReadOnly(t, ts, "room", true)
+	docReader := crdt.New()
+	drainHandshake(t, reader, docReader)
+
+	sendUpdate(t, editor, makeUpdate(t, "hello"))
+
+	// The read-only peer should receive the broadcast (skip any awareness frames).
+	deadline := time.Now().Add(3 * time.Second)
+	for docReader.GetText("t").ToString() != "hello" {
+		if time.Now().After(deadline) {
+			t.Fatalf("read-only peer never received the broadcast; text = %q",
+				docReader.GetText("t").ToString())
+		}
+		if outerType, payload := readOne(t, reader, 2*time.Second); outerType == 0 {
+			_, _ = ygsync.ApplySyncMessage(docReader, payload, nil)
+		}
+	}
+}
+
+// #59 — a read-only peer still receives a SyncStep2 in reply to its SyncStep1
+// (read-only drops writes, not reads).
+func TestReadOnly_SyncStep1StillAnswered(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.Authorize = func(*http.Request) (ygws.ConnectionConfig, bool) {
+		return ygws.ConnectionConfig{ReadOnly: true}, true
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	conn := dial(t, ts, "room")
+	drainHandshake(t, conn, crdt.New())
+
+	sendSync(t, conn, ygsync.EncodeSyncStep1(crdt.New()))
+
+	outerType, payload := readOne(t, conn, 2*time.Second)
+	require.Equal(t, uint64(0), outerType, "expected a sync reply")
+	syncType, err := encoding.NewDecoder(payload).ReadVarUint()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(ygsync.MsgSyncStep2), syncType,
+		"read-only peer's SyncStep1 must be answered with SyncStep2")
+}
+
+// #59 — a read-only peer's inbound awareness must NOT be recorded server-side.
+func TestReadOnly_InboundAwarenessDropped(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.Authorize = func(*http.Request) (ygws.ConnectionConfig, bool) {
+		return ygws.ConnectionConfig{ReadOnly: true}, true
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	conn := dial(t, ts, "room")
+	drainHandshake(t, conn, crdt.New())
+
+	const roClient = uint64(7777)
+	sendAwareness(t, conn, makeAwareness(roClient))
+	time.Sleep(100 * time.Millisecond)
+
+	aw, ok := srv.GetAwareness("room")
+	require.True(t, ok)
+	_, present := aw.GetStates()[roClient]
+	assert.False(t, present, "read-only peer's awareness must not be recorded server-side")
+}
+
+// #59 — the existing bool AuthFunc keeps working: false rejects, true accepts
+// as read-write.
+func TestReadOnly_LegacyAuthFuncStillWorks(t *testing.T) {
+	t.Run("reject", func(t *testing.T) {
+		srv := ygws.NewServer()
+		srv.AuthFunc = func(*http.Request) bool { return false }
+		ts := httptest.NewServer(srv)
+		defer ts.Close()
+		_, _, err := gws.DefaultDialer.Dial(wsURL(ts, "room"), nil)
+		assert.Error(t, err, "AuthFunc=false must reject the upgrade")
+	})
+	t.Run("accept_read_write", func(t *testing.T) {
+		srv := ygws.NewServer()
+		srv.AuthFunc = func(*http.Request) bool { return true }
+		ts := httptest.NewServer(srv)
+		defer ts.Close()
+		conn := dial(t, ts, "room")
+		drainHandshake(t, conn, crdt.New())
+		sendUpdate(t, conn, makeUpdate(t, "hello"))
+		time.Sleep(100 * time.Millisecond)
+		assert.Equal(t, "hello", srv.GetDoc("room").GetText("t").ToString(),
+			"legacy AuthFunc-accepted peer must be read-write")
+	})
+}
+
+// #59 — when both AuthFunc and Authorize are set, the richer Authorize wins.
+func TestReadOnly_AuthorizeTakesPrecedenceOverAuthFunc(t *testing.T) {
+	srv := ygws.NewServer()
+	srv.AuthFunc = func(*http.Request) bool { return true } // would allow read-write
+	srv.Authorize = func(*http.Request) (ygws.ConnectionConfig, bool) {
+		return ygws.ConnectionConfig{ReadOnly: true}, true // richer one wins → read-only
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	conn := dial(t, ts, "room")
+	drainHandshake(t, conn, crdt.New())
+	sendUpdate(t, conn, makeUpdate(t, "hello"))
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Empty(t, srv.GetDoc("room").GetText("t").ToString(),
+		"Authorize must take precedence over AuthFunc")
+}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -221,6 +221,16 @@ type room struct {
 	relayUnsub []func()
 }
 
+// ConnectionConfig describes an accepted WebSocket connection. It is returned by
+// Server.Authorize (issue #59). Additional per-connection settings can be added
+// here in a backward-compatible way.
+type ConnectionConfig struct {
+	// ReadOnly, when true, makes the peer read-only: it receives document and
+	// awareness broadcasts but its inbound writes are dropped server-side. See
+	// Server.Authorize for the exact semantics.
+	ReadOnly bool
+}
+
 // Server is a net/http-compatible WebSocket handler.
 // Each distinct room name maps to an independent Yjs document.
 type Server struct {
@@ -256,7 +266,20 @@ type Server struct {
 	// connection. Return false to reject the connection; the server responds
 	// with 401 Unauthorized. Use this hook for token validation, session checks,
 	// or IP allow-lists. If nil, all connections are accepted.
+	//
+	// AuthFunc grants read-write access. To grant read-only access, use Authorize
+	// instead — when Authorize is set it takes precedence and AuthFunc is ignored.
 	AuthFunc func(r *http.Request) bool
+
+	// Authorize, if non-nil, is the richer alternative to AuthFunc: it both
+	// accepts/rejects the connection (second return value; false → 401) and
+	// returns a ConnectionConfig describing the accepted connection — notably
+	// whether it is read-only (issue #59). When Authorize is set it takes
+	// precedence over AuthFunc. A read-only peer receives document and awareness
+	// broadcasts but its inbound writes (SyncStep2/Update and awareness updates)
+	// are dropped; it can still request state (SyncStep1 is answered) and query
+	// awareness. Stateless signals are not gated by read-only.
+	Authorize func(r *http.Request) (ConnectionConfig, bool)
 
 	// AllowedOrigins is the list of origins permitted to open WebSocket
 	// connections (C2 — CORS). Each entry is a full origin string, e.g.
@@ -788,9 +811,23 @@ func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room,
 // Room name is taken from the {room} path variable (Go 1.22 ServeMux) or
 // falls back to the last path segment.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if s.AuthFunc != nil && !s.AuthFunc(r) {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+	// Authorize (issue #59) takes precedence over AuthFunc when both are set: it
+	// both accepts/rejects and reports per-connection config (read-only). AuthFunc
+	// grants read-write. Rejecting either way is a 401 before the upgrade.
+	var readOnly bool
+	switch {
+	case s.Authorize != nil:
+		cfg, ok := s.Authorize(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		readOnly = cfg.ReadOnly
+	case s.AuthFunc != nil:
+		if !s.AuthFunc(r) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 
 	name := r.PathValue("room")
@@ -856,6 +893,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeCh:    make(chan []byte, s.peerWriteQueueSize()),
 		writerDone: make(chan struct{}),
 		limiter:    s.newPeerLimiter(),
+		readOnly:   readOnly,
 	}
 
 	// Verify the room is still in the server map before adding the peer.


### PR DESCRIPTION
## Summary

Implements #59: Hocuspocus-style **read-only** WebSocket connections.

Adds `Server.Authorize func(*http.Request) (ConnectionConfig, bool)` — a richer alternative to `AuthFunc` that both accepts/rejects a connection (false → 401) and reports per-connection config:

```go
type ConnectionConfig struct {
    ReadOnly bool // room-scoped config can extend here later
}

srv.Authorize = func(r *http.Request) (ws.ConnectionConfig, bool) {
    if !validate(r) {
        return ws.ConnectionConfig{}, false // reject → 401
    }
    return ws.ConnectionConfig{ReadOnly: !isEditor(r)}, true
}
```

`AuthFunc` is **unchanged** and still grants read-write; `Authorize` takes precedence when both are set.

## Read-only semantics

A read-only peer **still receives** document + awareness broadcasts, gets a `SyncStep2` in reply to its `SyncStep1`, and can query awareness. Only its **inbound writes** are dropped server-side (not applied, not broadcast):

- sync `SyncStep2` / `Update`
- Hocuspocus `SyncReply` (tag 4)
- awareness updates

Stateless signals (tags 5/6) are **not** gated — they're app-level, not document/awareness state. The key nuance: `msgSync` is peeked with `sync.ReadSyncMessage` so `SyncStep1` (a read) is still answered while writes are dropped — a viewer can receive the doc without being able to change it.

## #56 deferred

The paired request was #56 (Attribution API). Per discussion it's **not** in this PR: it's a multi-day `crdt` wire-format port in a different package, and its own issue gates it on a real y/hub-interop or authorship-tracking need that isn't present. Left as a tracked gap.

## Tests (all `-race` clean)

- read-only inbound update → server state unchanged
- read-only peer still receives a read-write peer's broadcast
- read-only peer's `SyncStep1` still answered with `SyncStep2`
- read-only inbound awareness not recorded server-side
- legacy `AuthFunc` still works (reject + accept-read-write)
- `Authorize` takes precedence over `AuthFunc`
- runnable godoc example (`ExampleServer_authorize`)

## Verification

`go build ./...`, `go test -race ./provider/websocket/`, `go vet`, `golangci-lint` (0 issues), `gofmt` — all clean.

New public API → **minor release (v1.30.0)**; CHANGELOG/RELEASE_NOTES/README updated.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)