### PR TITLE
fix(crdt): preserve deferred parent-by-ID child in struct-level MergeUpdatesV1/DiffUpdateV1 (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.30.1] — 2026-07-08
+
+### Fixed
+
+- **`MergeUpdatesV1`/`DiffUpdateV1` silently dropped a nested-type child whose
+  parent is referenced by item-ID when the container is in a later client group**
+  (the deferred parent-by-ID / C-3 case). The struct-level merge decodes structs
+  without integrating them, so a deferred child kept `Parent == nil` with only
+  `parentID` set; `encodeItem` then (1) matched the GC-orphan guard and re-encoded
+  the child as a content-less GC placeholder, and (2) wrote an empty-named root
+  type for the parent — either way detaching the child. A 37-byte full-state
+  update round-tripped through `MergeUpdatesV1` came back 20 bytes with the child
+  reduced to a GC placeholder, so `MergeUpdatesV1(u)` was not equivalent to
+  apply-then-encode. Regression from the struct-level merge rewrite (#125),
+  present v1.27.0–v1.30.0. Fixed by excluding deferred `parentID` items from the
+  GC-orphan guard and re-emitting the explicit parent-by-ID when `Parent` is
+  still unresolved. Consumers that reconstruct a document by folding a base
+  snapshot plus tail updates through `MergeUpdatesV1` (e.g. loading from
+  persistence) no longer lose nested-type children authored by a lower-clientID
+  peer. (#140)
+
 ## [1.30.0] — 2026-07-03
 
 This release bundles two additive features: read-only WebSocket connections

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.30.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.30.1**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,80 +1,27 @@
 ## What's new
 
-Two additive features.
+A data-loss bug fix for `MergeUpdatesV1`/`DiffUpdateV1`. No API changes.
 
-**Read-only WebSocket connections (#59).** The WebSocket provider gains a richer
-auth entry point, `Server.Authorize`, that can mark a connection read-only — it
-receives document and awareness broadcasts but its inbound writes are dropped
-server-side. This matches Hocuspocus's `readOnly` connection flag and covers
-public-read docs, viewer roles, and monitoring connections. Additive: the
-existing `AuthFunc` is unchanged and connections stay read-write unless you opt in.
+### Fixed
 
-**Attribution API (#56).** A Go port of yjs-v14's `IdSet`/`IdMap`/`ContentMap`
-primitives for stamping CRDT content with per-item authorship metadata — who
-inserted or deleted which item, plus any attributes you attach (`userid`, `ts`, a
-request ID, …) — without integrating the update into a doc. This is the pattern
-y-redis (also known as y/hub, the Yjs cluster backend) uses to store per-character
-authorship in Postgres. `IDSet`/`IDMap` encode/decode byte-for-byte compatibly
-with published yjs v14 (pinned `npm:yjs@14.0.0-16`); `ContentMap`/`ContentIDs`
-follow yjs-main's `writeContentMap`/`writeContentIds` composition (two
-`IdMap`s/`IdSet`s, inserts then deletes) — each half byte-verified against that
-pin, with the top-level wrapper pinned once yjs v14.0.0 final ships (follow-up).
-
-### Added
-
-- **`websocket.Server.Authorize func(*http.Request) (ConnectionConfig, bool)`** —
-  accepts/rejects a connection (false → 401) *and* reports its config; takes
-  precedence over `AuthFunc` when both are set. **`websocket.ConnectionConfig{
-  ReadOnly bool }`** carries the per-connection config, extensible for future
-  settings. (#59)
-- **`crdt.IDSet` / `crdt.IDMap`** — per-client sorted item-ID runs, with `IDMap`
-  additionally carrying attribution data per range (overlaps split, attributes
-  joined on read). `EncodeIDSet`/`DecodeIDSet` and `EncodeIDMap`/`DecodeIDMap`
-  are byte-compatible with published yjs v14 (`npm:yjs@14.0.0-16`). (#56)
-- **`crdt.ContentAttribute`** — one `{Name, Value}` attribution fact via
-  `NewContentAttribute`/`MustContentAttribute`, validated against the lib0 `any`
-  domain up front. (#56)
-- **`crdt.ContentIDs` / `crdt.ContentMap`** — the insert/delete pair of `IDSet`s
-  or `IDMap`s for an update or doc, with matching `EncodeContentIDs`/`DecodeContentIDs`
-  and `EncodeContentMap`/`DecodeContentMap` codecs. (#56)
-- **Builders** — `ContentIDsFromUpdateV1`/`V2` (stamp an incoming update without
-  integrating it), `InsertSetFromDoc`/`DeleteSetFromDoc`,
-  `CreateContentMapFromContentIDs`. (#56)
-- **Set algebra** — `MergeIDSets`/`MergeIDMaps`, `ExcludeIDSet`/`ExcludeIDMap`,
-  `IntersectIDSets`/`IntersectIDMaps`, `FilterIDMap`, and the `ContentMap`-level
-  `MergeContentMaps`/`ExcludeContentMap`/`IntersectContentMaps`/`FilterContentMap`
-  wrappers. (#56)
-- A runnable godoc example, `crdt.Example_attribution`. (#56)
-
-### Behaviour
-
-- A **read-only** peer still receives broadcasts, gets a `SyncStep2` in reply to
-  its `SyncStep1`, and can query awareness — but its inbound document writes
-  (`SyncStep2`/`Update`, Hocuspocus `SyncReply`) and awareness updates are dropped
-  server-side. Stateless signals are not gated. Connections authorized via
-  `AuthFunc` (or with no auth hook) remain read-write. (#59)
-
-### Security
-
-- All four attribution decoders bound every length-prefixed count against the
-  decoder's remaining input before allocating, and `DecodeIDMap` additionally
-  caps the per-range attribute pre-allocation (N-C2 analogue), so malformed input
-  fails fast rather than triggering an oversized allocation. (#56)
-
-### Scope / caveats
-
-- Attribution ships primitives only — no storage integration (callers persist
-  `EncodeContentMap(cm)` themselves) and no provider wiring.
-- `diffDocsToDelta` is not implemented (depends on yjs v14's still-changing
-  delta/renderer subsystem); tracked as a follow-up.
-- GC erases attributed history (`IDSet`/`IDMap` reference items by
-  `(client, clock)`): retain raw updates, or create the doc `WithGC(false)`, to
-  render attributed history later.
+- **`MergeUpdatesV1`/`DiffUpdateV1` no longer drop a nested-type child whose
+  parent is referenced by item-ID across client groups (#140).** The struct-level
+  merge path decodes structs without integrating them, so a deferred child
+  (`Parent` not yet resolved, only `parentID` known) was re-encoded either as a
+  content-less GC placeholder or attached to an empty-named root type — silently
+  detaching it. This made `MergeUpdatesV1(u)` diverge from apply-then-encode: a
+  37-byte full-state update came back 20 bytes with the child reduced to a GC
+  placeholder. It was a regression from the struct-level merge rewrite (#125),
+  affecting v1.27.0–v1.30.0. Consumers that reconstruct a document by folding a
+  base snapshot plus tail updates through `MergeUpdatesV1` (e.g. loading from
+  persistence) lost nested-type children authored by a lower-clientID peer, with
+  no error. The merge/diff encoder now re-emits the deferred parent-by-ID so the
+  child is preserved.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.30.0
+go get github.com/reearth/ygo@v1.30.1
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -350,3 +350,37 @@ func permute(a []int, k int, fn func([]int)) {
 		a[k], a[i] = a[i], a[k]
 	}
 }
+
+// C-3 (merge path) — MergeUpdatesV1 must preserve a cross-client parent-by-ID
+// child, not just ApplyUpdateV1. The struct-level merge decodes without
+// integrating, so the encoder must re-emit the deferred parentID; otherwise the
+// child detaches from its container on re-encode (silent data loss). #140.
+func TestP0_C3_MergeUpdatesPreservesCrossClientChild(t *testing.T) {
+	d200 := New(WithClientID(200))
+	frag := d200.GetXmlFragment("f")
+	el := NewYXmlElement("div")
+	d200.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+
+	d100 := New(WithClientID(100))
+	if err := ApplyUpdateV1(d100, fullState(d200), nil); err != nil {
+		t.Fatalf("seed d100: %v", err)
+	}
+	el100 := d100.GetXmlFragment("f").Children()[0].(*YXmlElement)
+	d100.Transact(func(txn *Transaction) { el100.SetAttribute(txn, "class", "hello") })
+
+	merged, err := MergeUpdatesV1(fullState(d100))
+	if err != nil {
+		t.Fatalf("MergeUpdatesV1: %v", err)
+	}
+	fresh := New()
+	if err := ApplyUpdateV1(fresh, merged, nil); err != nil {
+		t.Fatalf("apply merged: %v", err)
+	}
+	fc := fresh.GetXmlFragment("f").Children()
+	if len(fc) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(fc))
+	}
+	if v, ok := fc[0].(*YXmlElement).GetAttribute("class"); !ok || v != "hello" {
+		t.Fatalf("merged element attribute class=%q ok=%v, want \"hello\"", v, ok)
+	}
+}

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -22,7 +22,11 @@ type Item struct {
 	// item's parent is referenced by item-ID (a nested type) but that container
 	// has not yet been integrated. It lets integration defer the item until the
 	// parent arrives (Yjs pendingStructs parity, review finding C-3) instead of
-	// hard-failing the decode. Resolved to Parent during integration; never encoded.
+	// hard-failing the decode. Resolved to Parent during integration. The
+	// integrate/apply path never encodes it (Parent is set by then), but the
+	// struct-level MergeUpdatesV1/DiffUpdateV1 encode path (which does not
+	// integrate) re-emits it as the explicit parent-by-ID so the child is not
+	// detached on re-encode. (#140)
 	parentID *ID
 	// MovedBy points to the winning ContentMove item that has claimed this item
 	// as its target. When non-nil, this item is rendered at the ContentMove's

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -192,7 +192,13 @@ func encodeItem(enc *encoding.Encoder, item *Item, offset int, store *StructStor
 	// (origin + content, no parent info), NOT as a GC placeholder, or its content
 	// would be lost. Parent info is only written in the no-origin branch below,
 	// so an origin-bearing item never dereferences item.Parent. (#125)
-	if item.Parent == nil && item.Origin == nil && item.OriginRight == nil {
+	//
+	// Also exclude items carrying a deferred parent-by-ID: they have a nil Parent
+	// (not yet integrated) but a known container ID in parentID, and must be
+	// encoded as a normal item so the no-origin branch below can re-emit the
+	// explicit parent-by-ID. Treating them as GC orphans here dropped their
+	// content and parent link (silent data loss on merge). (#140)
+	if item.Parent == nil && item.Origin == nil && item.OriginRight == nil && item.parentID == nil {
 		length := item.Content.Len()
 		if offset > 0 {
 			length -= offset
@@ -288,6 +294,17 @@ func encodeItem(enc *encoding.Encoder, item *Item, offset int, store *StructStor
 			enc.WriteUint8(0)
 			enc.WriteVarUint(uint64(item.Parent.item.ID.Client))
 			enc.WriteVarUint(item.Parent.item.ID.Clock)
+		} else if item.parentID != nil {
+			// Deferred parent-by-ID: this item was decoded but not yet
+			// integrated (its container is in a later client group), so Parent
+			// is still nil while parentID holds the container's ID. Re-emit the
+			// explicit parent-by-ID so the receiver can defer and resolve it too.
+			// Without this the struct-level MergeUpdatesV1/DiffUpdateV1 encode
+			// path falls through to the root-named-type branch below and writes
+			// an empty name, detaching the child (silent data loss). (#140)
+			enc.WriteUint8(0)
+			enc.WriteVarUint(uint64(item.parentID.Client))
+			enc.WriteVarUint(item.parentID.Clock)
 		} else {
 			// Root named type.
 			enc.WriteUint8(1)


### PR DESCRIPTION
Fixes #140.

## Problem
`MergeUpdatesV1` (and `DiffUpdateV1`) silently drop a struct whose parent is referenced by item-ID when the container is in a later client group, i.e. the deferred parent-by-ID case from the C-3 fix. `ApplyUpdateV1` of the identical bytes preserves the child, so `MergeUpdatesV1(u)` is not equivalent to apply-then-encode. Regression from the struct-level merge rewrite (#125), present v1.27.0 through v1.30.0.

## Root cause
The struct-level merge decodes structs (`decodeStructsV1`) but never integrates them, so a deferred child keeps `Parent == nil` with only `parentID` set. Then `encodeItem`:
1. matched the **GC-orphan guard** at the top (`Parent == nil && no origins`) and re-encoded the child as a GC struct, dropping its content, parent link and `ParentSub`; and
2. even without that, the parent-info block only consulted `item.Parent`, so with `Parent == nil` it wrote an empty-named root type.

Both detach the child. Concretely, a 37-byte full-state update round-tripped through `MergeUpdatesV1` came back 20 bytes with the child reduced to `00 01` (a GC placeholder).

## Fix
- Exclude items carrying a deferred `parentID` from the GC-orphan guard.
- In the no-origin parent block, re-emit the explicit parent-by-ID from `parentID` when `Parent` is still unresolved.
- Update the `Item.parentID` doc comment (it is now encoded by the merge/diff path).

Adds `TestP0_C3_MergeUpdatesPreservesCrossClientChild` (merge counterpart of the existing `TestP0_C3_SelfEncodeReloads`). Fails before, passes after.

## Validation
`go build ./...`, `go vet ./crdt/`, and `go test -race ./...` all green.

## Impact
Consumers that fold persisted updates through `MergeUpdatesV1` (loading a document by merging a base snapshot plus tail updates) lose nested-type children authored by a lower-clientID peer, with no error. This is what surfaced in reearth-flow (rooms failing to open / missing data after growth).