### PR TITLE
docs: release v1.31.0 (subdocument lifecycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.31.0] — 2026-07-09
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.30.1**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.31.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## v1.31.0
 
 Subdocument lifecycle (issue #63): a `Doc` can now embed another `Doc` as a
 subdocument — its own clock space and GUID, nested inside a parent doc's
@@ -38,9 +38,7 @@ is a separate, tracked follow-up (see [#142](https://github.com/reearth/ygo/issu
 ## Install
 
 ```
-go get github.com/reearth/ygo@vX.Y.Z
+go get github.com/reearth/ygo@v1.31.0
 ```
-
-*(Version to be assigned at release time.)*
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.


### PR DESCRIPTION
Finalizes the release docs for **v1.31.0** (subdocument lifecycle, #63), which merged in #143 with the CHANGELOG/RELEASE_NOTES still at `## [Unreleased]`.

- CHANGELOG: `## [Unreleased]` → `## [1.31.0] — 2026-07-09`
- RELEASE_NOTES: heading → `## v1.31.0`; install line pinned to `@v1.31.0` (was `@vX.Y.Z` placeholder)
- README: current-release line → **v1.31.0**

New public subdocument API → minor bump. No code changes; docs only. Once merged, the `v1.31.0` tag is cut from the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)