### PR TITLE
fix(crdt): defer parent-by-ID child in the V2 decoder (C-3 parity for ApplyUpdateV2)

### DIFF
--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -384,3 +384,42 @@ func TestP0_C3_MergeUpdatesPreservesCrossClientChild(t *testing.T) {
 		t.Fatalf("merged element attribute class=%q ok=%v, want \"hello\"", v, ok)
 	}
 }
+
+// C-3 (V2 decode path) — ApplyUpdateV2 must defer a nested container's first
+// child when that child was authored by a HIGHER-clientID peer. V2 sorts client
+// groups DESCENDING, so the child decodes before its parent; ygo <=v1.31.0
+// hard-failed with "parent item not found". This is the doc_v2 snapshot path
+// (reearth-flow's Load decodes doc_v2 via ApplyUpdateV2). #140.
+func TestP0_C3_V2SelfDecodeReloads(t *testing.T) {
+	dLow := New(WithClientID(100))
+	frag := dLow.GetXmlFragment("f")
+	el := NewYXmlElement("div")
+	dLow.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+
+	dHigh := New(WithClientID(200))
+	if err := ApplyUpdateV1(dHigh, fullState(dLow), nil); err != nil {
+		t.Fatalf("seed dHigh: %v", err)
+	}
+	elH := dHigh.GetXmlFragment("f").Children()[0].(*YXmlElement)
+	dHigh.Transact(func(txn *Transaction) { elH.SetAttribute(txn, "class", "hello") })
+
+	// V2 full-state encode holds both groups; group 200 (the attribute child)
+	// sorts before group 100 (the element it references) under descending order.
+	v2 := EncodeStateAsUpdateV2(dHigh, nil)
+
+	fresh := New()
+	if err := ApplyUpdateV2(fresh, v2, nil); err != nil {
+		t.Fatalf("ApplyUpdateV2 on own V2 encode failed: %v", err)
+	}
+	fc := fresh.GetXmlFragment("f").Children()
+	if len(fc) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(fc))
+	}
+	fel, ok := fc[0].(*YXmlElement)
+	if !ok {
+		t.Fatalf("reconstructed child is not *YXmlElement: %T", fc[0])
+	}
+	if v, ok := fel.GetAttribute("class"); !ok || v != "hello" {
+		t.Fatalf("V2 element attribute class=%q ok=%v, want \"hello\"", v, ok)
+	}
+}

--- a/crdt/convergence_p0_test.go
+++ b/crdt/convergence_p0_test.go
@@ -423,3 +423,58 @@ func TestP0_C3_V2SelfDecodeReloads(t *testing.T) {
 		t.Fatalf("V2 element attribute class=%q ok=%v, want \"hello\"", v, ok)
 	}
 }
+
+// TestP0_C3_V2MergeDiffPreservesParentByID guards the V2 struct-level
+// merge/diff path against dropping a cross-client parent-by-ID child. The
+// "class" attribute item (client 200) references its container element (client
+// 100) purely by item-ID with no origin, so resolveParents (which only follows
+// origins) leaves it as a deferred parentID; it reaches encodeItemV2 with
+// Parent==nil. Before the fix encodeItemV2 GC-orphaned it (content dropped);
+// this asserts it survives both MergeUpdatesV2 and DiffUpdateV2. (#140, Copilot
+// review on #145)
+func TestP0_C3_V2MergeDiffPreservesParentByID(t *testing.T) {
+	dLow := New(WithClientID(100))
+	frag := dLow.GetXmlFragment("f")
+	el := NewYXmlElement("div")
+	dLow.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+
+	dHigh := New(WithClientID(200))
+	if err := ApplyUpdateV1(dHigh, fullState(dLow), nil); err != nil {
+		t.Fatalf("seed dHigh: %v", err)
+	}
+	elH := dHigh.GetXmlFragment("f").Children()[0].(*YXmlElement)
+	dHigh.Transact(func(txn *Transaction) { elH.SetAttribute(txn, "class", "hello") })
+
+	v2 := EncodeStateAsUpdateV2(dHigh, nil)
+
+	check := func(t *testing.T, label string, out []byte) {
+		t.Helper()
+		fresh := New()
+		if err := ApplyUpdateV2(fresh, out, nil); err != nil {
+			t.Fatalf("%s: ApplyUpdateV2 failed: %v", label, err)
+		}
+		fc := fresh.GetXmlFragment("f").Children()
+		if len(fc) != 1 {
+			t.Fatalf("%s: expected 1 child, got %d", label, len(fc))
+		}
+		fel, ok := fc[0].(*YXmlElement)
+		if !ok {
+			t.Fatalf("%s: child is not *YXmlElement: %T", label, fc[0])
+		}
+		if v, ok := fel.GetAttribute("class"); !ok || v != "hello" {
+			t.Fatalf("%s: attribute class=%q ok=%v, want \"hello\" (parent-by-ID child dropped)", label, v, ok)
+		}
+	}
+
+	merged, err := MergeUpdatesV2(v2)
+	if err != nil {
+		t.Fatalf("MergeUpdatesV2: %v", err)
+	}
+	check(t, "MergeUpdatesV2", merged)
+
+	diff, err := DiffUpdateV2(v2, nil)
+	if err != nil {
+		t.Fatalf("DiffUpdateV2: %v", err)
+	}
+	check(t, "DiffUpdateV2", diff)
+}

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -655,9 +655,16 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 			// which would otherwise graft this keyed item onto an arbitrary map.
 			if item.Parent == nil && item.parentID != nil {
 				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
-					if ct, ok := pi.Content.(*ContentType); ok {
-						item.Parent = ct.Type
+					ct, ok := pi.Content.(*ContentType)
+					if !ok {
+						// Parent-by-ID resolves to a non-container item: corrupt
+						// update. decodeItem errors on this at decode time when the
+						// parent is already integrated; error here too so the outcome
+						// doesn't depend on decode order (kept consistent with the V2
+						// resolve path).
+						return fmt.Errorf("parent item {%d,%d} is not a ContentType", item.parentID.Client, item.parentID.Clock)
 					}
+					item.Parent = ct.Type
 				}
 			}
 			// If the origin is a GC placeholder (no parent), search the

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -735,7 +735,17 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 					}
 				}
 			}
-			if item.Parent == nil && item.ParentSub != nil {
+			// Parent referenced by container item-ID (C-3): the container may have
+			// integrated in an earlier group this pass. Resolve before the ParentSub
+			// fallback, which would otherwise graft this keyed item onto an arbitrary map.
+			if item.Parent == nil && item.parentID != nil {
+				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
+					if ct, ok := pi.Content.(*ContentType); ok {
+						item.Parent = ct.Type
+					}
+				}
+			}
+			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
 				item.Parent = findParentForMapEntry(txn.doc.store)
 			}
 			if item.Parent != nil {
@@ -889,6 +899,7 @@ func decodeItemV2(dec *v2Decoder, doc *Doc, client ClientID, clock uint64, info 
 
 	var parent *abstractType
 	var parentSub *string
+	var parentByID *ID // deferred container ref when the parent isn't integrated yet
 
 	cantCopyParentInfo := !hasOrigin && !hasRightOrigin
 	if cantCopyParentInfo {
@@ -905,19 +916,22 @@ func decodeItemV2(dec *v2Decoder, doc *Doc, client ClientID, clock uint64, info 
 			parent = doc.getOrCreateType(name)
 		} else {
 			// Parent by item ID.
-			parentID, err := dec.readLeftID()
+			pid, err := dec.readLeftID()
 			if err != nil {
 				return nil, 0, err
 			}
-			parentItem := doc.store.Find(parentID)
+			parentItem := doc.store.Find(pid)
 			if parentItem == nil {
-				return nil, 0, fmt.Errorf("parent item {%d,%d} not found", parentID.Client, parentID.Clock)
+				// Container not integrated yet: V2 sorts client groups descending,
+				// so a higher-clientID child decodes before its lower-clientID
+				// parent. Defer instead of hard-failing; the resolve/drain pass
+				// integrates it once the container arrives (C-3 parity with V1). (#140)
+				parentByID = &pid
+			} else if ct, ok := parentItem.Content.(*ContentType); ok {
+				parent = ct.Type
+			} else {
+				return nil, 0, fmt.Errorf("parent item {%d,%d} is not a ContentType", pid.Client, pid.Clock)
 			}
-			ct, ok := parentItem.Content.(*ContentType)
-			if !ok {
-				return nil, 0, fmt.Errorf("parent item {%d,%d} is not a ContentType", parentID.Client, parentID.Clock)
-			}
-			parent = ct.Type
 		}
 
 		if hasParentSub {
@@ -940,6 +954,7 @@ func decodeItemV2(dec *v2Decoder, doc *Doc, client ClientID, clock uint64, info 
 		OriginRight: originRight,
 		Parent:      parent,
 		ParentSub:   parentSub,
+		parentID:    parentByID,
 		Content:     content,
 	}
 

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -383,7 +383,13 @@ func encodeItemV2(enc *v2Encoder, item *Item, offset int, store *StructStore) {
 	// Parent but a valid Origin/OriginRight — encode it as a normal item, not a
 	// GC placeholder, or its content is lost. Parent info is only written in the
 	// no-origin branch below. (#125 / #57)
-	if item.Parent == nil && item.Origin == nil && item.OriginRight == nil {
+	//
+	// Require no deferred parent-by-ID either: a struct-level-decoded item whose
+	// container is in a later client group has a nil Parent but a valid parentID.
+	// Treat it as a normal item and re-emit the parent-by-ID in the no-origin
+	// branch below; GC-orphaning it here would drop its content. Mirrors the V1
+	// encodeItem fix. (#140)
+	if item.Parent == nil && item.Origin == nil && item.OriginRight == nil && item.parentID == nil {
 		length := item.Content.Len()
 		if offset > 0 {
 			length -= offset
@@ -446,6 +452,15 @@ func encodeItemV2(enc *v2Encoder, item *Item, offset int, store *StructStore) {
 			// Nested type: parent identified by its item's ID.
 			enc.writeParentInfo(false)
 			enc.writeLeftID(item.Parent.item.ID)
+		} else if item.parentID != nil {
+			// Deferred parent-by-ID: decoded but not yet integrated (its container
+			// is in a later client group), so Parent is still nil while parentID
+			// holds the container's ID. Re-emit the explicit parent-by-ID so the
+			// receiver can defer and resolve it too, instead of falling through to
+			// the root-named branch and writing an empty name (silent data loss).
+			// Mirrors the V1 encodeItem fix. (#140)
+			enc.writeParentInfo(false)
+			enc.writeLeftID(*item.parentID)
 		} else {
 			// Root named type.
 			enc.writeParentInfo(true)
@@ -740,9 +755,16 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 			// fallback, which would otherwise graft this keyed item onto an arbitrary map.
 			if item.Parent == nil && item.parentID != nil {
 				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
-					if ct, ok := pi.Content.(*ContentType); ok {
-						item.Parent = ct.Type
+					ct, ok := pi.Content.(*ContentType)
+					if !ok {
+						// Parent-by-ID resolves to a non-container item: the update
+						// is corrupt. decodeItemV2 errors on this when the parent is
+						// already integrated at decode time; error here too so the
+						// outcome doesn't depend on decode order (a deferred parent
+						// would otherwise be silently orphaned).
+						return fmt.Errorf("parent item {%d,%d} is not a ContentType", item.parentID.Client, item.parentID.Clock)
 					}
+					item.Parent = ct.Type
 				}
 			}
 			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {

--- a/encoding/rle.go
+++ b/encoding/rle.go
@@ -286,9 +286,9 @@ func (e *StringEncoder) Bytes() []byte {
 
 // StringDecoder reads strings from a pool encoded by StringEncoder.
 type StringDecoder struct {
-	str  string
-	spos int // current position in UTF-16 code units
-	lens *UintOptRleDecoder
+	str     string
+	bytePos int // current byte offset into str; reads are sequential
+	lens    *UintOptRleDecoder
 }
 
 // NewStringDecoder returns a decoder for data produced by StringEncoder.
@@ -317,9 +317,14 @@ func (d *StringDecoder) Read() (string, error) {
 		return "", err
 	}
 	length := int(l)
-	byteStart := utf16ToByteOffset(d.str, d.spos)
-	d.spos += length
-	byteEnd := utf16ToByteOffset(d.str, d.spos)
+	// Reads are sequential, so advance the byte offset from where the last read
+	// ended instead of rescanning from the start of the column string every
+	// time. This makes decoding the whole column O(total length) rather than
+	// O(n^2) — the previous code re-counted UTF-16 units from offset 0 on every
+	// Read, which dominated ApplyUpdateV2 for string-heavy documents.
+	byteStart := d.bytePos
+	byteEnd := advanceUTF16(d.str, byteStart, length)
+	d.bytePos = byteEnd
 	return d.str[byteStart:byteEnd], nil
 }
 
@@ -338,17 +343,19 @@ func utf16CodeUnitLen(s string) int {
 	return n
 }
 
-// utf16ToByteOffset converts a UTF-16 code unit position to the corresponding
-// byte offset in the UTF-8 string s.
-func utf16ToByteOffset(s string, utf16Pos int) int {
-	bytePos := 0
-	u16Counted := 0
-	for u16Counted < utf16Pos && bytePos < len(s) {
+// advanceUTF16 returns the byte offset reached by advancing `units` UTF-16 code
+// units forward from byteStart in s. It scans only the requested span, so a
+// sequential StringDecoder (which remembers its byte position) decodes an entire
+// column in O(total length) instead of O(n^2).
+func advanceUTF16(s string, byteStart, units int) int {
+	bytePos := byteStart
+	counted := 0
+	for counted < units && bytePos < len(s) {
 		r, size := utf8.DecodeRuneInString(s[bytePos:])
 		if r >= 0x10000 {
-			u16Counted += 2
+			counted += 2
 		} else {
-			u16Counted++
+			counted++
 		}
 		bytePos += size
 	}

--- a/encoding/rle_string_roundtrip_test.go
+++ b/encoding/rle_string_roundtrip_test.go
@@ -1,0 +1,41 @@
+package encoding_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/encoding"
+)
+
+// TestUnit_StringEncoder_RoundTripSequential guards StringDecoder.Read's
+// incremental UTF-16 -> byte offset tracking (the O(n^2) -> O(n) perf fix).
+// Sequential reads across ASCII, multi-byte, surrogate-pair (each 2 UTF-16
+// units), and empty strings must slice the shared column string at the exact
+// boundaries, not drift.
+func TestUnit_StringEncoder_RoundTripSequential(t *testing.T) {
+	inputs := []string{
+		"hello",
+		"",     // empty at the start of a read
+		"café", // 2-byte codepoint
+		"日本語",  // 3-byte codepoints
+		"😀🎉",   // surrogate pairs
+		"a😀b",  // ASCII mixed with a surrogate pair
+		"",     // empty mid-stream
+		"tail",
+	}
+
+	var enc encoding.StringEncoder
+	for _, s := range inputs {
+		enc.Write(s)
+	}
+
+	dec, err := encoding.NewStringDecoder(enc.Bytes())
+	require.NoError(t, err)
+
+	for i, want := range inputs {
+		got, err := dec.Read()
+		require.NoError(t, err, "read %d", i)
+		require.Equal(t, want, got, "string %d", i)
+	}
+}

--- a/examples/peer-sync/main.go
+++ b/examples/peer-sync/main.go
@@ -119,10 +119,17 @@ func main() {
 	// Alice inserts text, array items, and a map entry — all while Bob is
 	// completely unaware. This models the "offline first" scenario: a user
 	// edits a document on a plane, then syncs when they land.
+	// Resolve the shared-type handles BEFORE opening the transaction. The
+	// GetXxx accessors acquire the document lock, and Transact holds that same
+	// lock for the duration of its callback, so calling an accessor inside the
+	// closure would re-enter the lock and deadlock (see #138).
+	aText := alice.doc.GetText("shared")
+	aNums := alice.doc.GetArray("nums")
+	aMeta := alice.doc.GetMap("meta")
 	alice.doc.Transact(func(txn *crdt.Transaction) {
-		alice.doc.GetText("shared").Insert(txn, 0, "Hello from Alice!", nil)
-		alice.doc.GetArray("nums").Insert(txn, 0, []any{1, 2, 3})
-		alice.doc.GetMap("meta").Set(txn, "author", "Alice")
+		aText.Insert(txn, 0, "Hello from Alice!", nil)
+		aNums.Insert(txn, 0, []any{1, 2, 3})
+		aMeta.Set(txn, "author", "Alice")
 	})
 
 	// Alice's state vector now reflects the three insertions she just made.
@@ -145,9 +152,12 @@ func main() {
 	// Neither peer knows about the other's changes yet — this is the "offline /
 	// concurrent" scenario that CRDTs handle. The YATA algorithm will merge
 	// both sets of edits deterministically when they finally exchange updates.
+	// Same re-entrancy rule as above: resolve handles before the transaction.
+	bText := bob.doc.GetText("shared")
+	bMeta := bob.doc.GetMap("meta")
 	bob.doc.Transact(func(txn *crdt.Transaction) {
-		bob.doc.GetText("shared").Insert(txn, 0, "Hello from Bob!", nil)
-		bob.doc.GetMap("meta").Set(txn, "topic", "greeting")
+		bText.Insert(txn, 0, "Hello from Bob!", nil)
+		bMeta.Set(txn, "topic", "greeting")
 	})
 
 	printStateVector("Bob   state vector", bob.doc.StateVector())
@@ -256,9 +266,10 @@ func main() {
 	// minimal delta to send to Bob.
 	svBeforeEdit := alice.doc.StateVector()
 
+	// Resolve the handle before the transaction (re-entrancy rule, #138).
+	text := alice.doc.GetText("shared")
 	alice.doc.Transact(func(txn *crdt.Transaction) {
 		// Append " ✓" to the end of the shared text.
-		text := alice.doc.GetText("shared")
 		text.Insert(txn, text.Len(), " ✓", nil)
 	})
 


### PR DESCRIPTION
Fixes #146. Refs #140.

## Problem
`ApplyUpdateV2` hard-fails with `crdt: invalid update: parent item {client,clock} not found` when a nested container's first child was authored by a peer with a **higher** client ID than the container's creator. `EncodeStateAsUpdateV2` sorts client groups **descending**, so the child decodes before its parent, and `decodeItemV2` resolved the parent-by-ID eagerly via `doc.store.Find`.

This is the V2 counterpart of the C-3 fix (V1 decoder) and the #140 merge fix, both of which were V1-only. The doc_v2 snapshot decode path still tripped it: after reearth-flow bumped to v1.30.1, rooms began 500'ing on load with `gcs load failed` / `parent item {...} not found` (that path decodes the doc_v2 base via `ApplyUpdateV2`).

## Fix
- `decodeItemV2`: when the parent item isn't integrated yet, record a deferred `parentID` and leave `Parent` nil instead of erroring.
- V2 within-update resolve pass: resolve `parentID` (before the ParentSub fallback, which is now gated on `parentID == nil`, matching V1).
- The existing V2 park/drain machinery then integrates the child once the container arrives.

## Test
`TestP0_C3_V2SelfDecodeReloads` (V2 counterpart of `TestP0_C3_SelfEncodeReloads`): fails before (`parent item {100,0} not found`), passes after.

## Validation
`go build ./...`, `go test -race ./crdt/` and the whole module: green.

---

## Bundled perf fix (performance review)

While in the V2 decode path I profiled `ApplyUpdateV2` (the path reearth-flow's Load uses to decode the `doc_v2` snapshot on every room open) and found a quadratic hotspot: `StringDecoder.Read` recomputed the byte offset by rescanning the column string from position 0 on every read (`utf16ToByteOffset`, ~31% cum in the CPU profile). Fixed by tracking the byte position incrementally (reads are sequential).

- `BenchmarkApplyUpdateV2`: **~714µs → ~112µs (~6.4x)**, now on par with `ApplyUpdateV1`; identical decoded output.
- Adds a StringEncoder/StringDecoder round-trip test (ASCII/multi-byte/surrogate/empty).