### PR TITLE
fix(crdt): inherit ParentSub in V1 deferred-parent resolution (YMap key loss, #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.1] — 2026-07-11
+
+### Fixed
+
+- **YMap key silently lost on `ApplyUpdateV1` ([#149](https://github.com/reearth/ygo/issues/149)).**
+  When a map-keyed item's origin was authored by a higher-clientID peer, the
+  item decoded before its origin's client group and took the V1 deferred-parent
+  retry path, which resolved the parent but did not inherit `ParentSub`. The
+  item integrated keyless and vanished from the map — a single document's own
+  full-state encode could fail to round-trip, dropping a live key
+  non-deterministically by arrival order. The V1 within-update resolver now
+  inherits `ParentSub` like the sibling sites and the V2 decoder already do.
+  Found by the new randomized convergence fuzzer (#70).
+
 ## [1.31.0] — 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.31.1] — 2026-07-11
 
+Correctness and performance patch. No API changes. Several of these fixes were
+surfaced by ygo's new randomized convergence fuzzer (#70).
+
 ### Fixed
 
 - **YMap key silently lost on `ApplyUpdateV1` ([#149](https://github.com/reearth/ygo/issues/149)).**
@@ -17,7 +20,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full-state encode could fail to round-trip, dropping a live key
   non-deterministically by arrival order. The V1 within-update resolver now
   inherits `ParentSub` like the sibling sites and the V2 decoder already do.
-  Found by the new randomized convergence fuzzer (#70).
+- **`ApplyUpdateV2` hard-failed on a deferred parent-by-ID child
+  ([#146](https://github.com/reearth/ygo/issues/146)).** When a nested
+  container's first child was authored by a higher-clientID peer, V2's
+  descending client-group order decoded the child before its parent. The V2
+  decoder now defers and resolves it (parity with the V1 `#140` fix) instead of
+  returning `parent item not found`.
+- **V2 struct-level merge/diff dropped a deferred parent-by-ID child.**
+  `MergeUpdatesV2`/`DiffUpdateV2` re-encoded such a child as a GC placeholder,
+  losing its content and parent link. `encodeItemV2` now excludes `parentID`
+  from the GC-orphan path and re-emits the explicit parent-by-ID, and both the
+  V1 and V2 resolve passes return a consistent error on a genuinely corrupt
+  (non-container) parent-by-ID rather than silently orphaning.
+- **`examples/peer-sync` deadlocked ([#138](https://github.com/reearth/ygo/issues/138)).**
+  The example called `GetText`/`GetArray`/`GetMap` inside a `Transact` callback
+  (a re-entrant document-lock hang); the shared-type handles are now resolved
+  before the transaction, matching `examples/http-sync`.
+
+### Performance
+
+- **V2 string-column decode is now O(n), not O(n²).** `ApplyUpdateV2` on
+  string-heavy documents drops roughly 6×, on par with `ApplyUpdateV1`.
 
 ## [1.31.0] — 2026-07-09
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,44 +1,29 @@
-## v1.31.0
+## v1.31.1
 
-Subdocument lifecycle (issue #63): a `Doc` can now embed another `Doc` as a
-subdocument — its own clock space and GUID, nested inside a parent doc's
-`YMap` — mirroring Yjs's subdocuments feature. This is the local half of the
-feature (create, embed, enumerate, observe); live cross-peer subdocument sync
-is a separate, tracked follow-up (see [#142](https://github.com/reearth/ygo/issues/142)).
+A CRDT correctness patch. No API changes.
 
-### Added
+### Fixed
 
-- **Subdocument embedding** — `YMap.Set(txn, key, subdoc)` where `subdoc` is
-  a `*crdt.Doc`; `YMap.Get` returns the `*crdt.Doc` back out. A `Doc` may be
-  embedded only once — a second attempt panics with the new
-  `crdt.ErrSubdocAlreadyIntegrated`.
-- **`Doc.GetSubdocs()` / `Doc.GetSubdocGUIDs()`** — the subdocuments
-  currently resident on a doc, sorted by GUID.
-- **`Doc.OnSubdocs(func(crdt.SubdocsEvent)) func()`** — subscribes to
-  subdocument add/remove/load events; returns an unsubscribe closure.
-- **`crdt.SubdocsEvent{Added, Removed, Loaded []*Doc}`** — reports docs newly
-  embedded, docs detached, and docs that should now be synced.
-- **`Doc.Load()`** — signals a subdocument's data should be synced, flipping
-  `ShouldLoad()` to `true` and emitting a `Loaded` event on the parent.
-- **`crdt.WithAutoLoad`/`WithShouldLoad`/`WithCollectionID`** `DocOption`s,
-  plus accessors `Doc.AutoLoad()`/`Doc.ShouldLoad()`/`Doc.CollectionID()`.
-- **`crdt.Example_subdocs`** — a runnable godoc example
-  (`crdt/example_subdocs_test.go`).
-- `ContentDoc` opts (guid/gc/autoLoad/collectionId) now round-trip on both
-  V1 and V2 wire formats and survive `MergeUpdatesV1`/`MergeUpdatesV2`; byte
-  parity with real Yjs verified against a `yjs@13.6.30` fixture.
+- **YMap key silently lost on `ApplyUpdateV1` ([#149](https://github.com/reearth/ygo/issues/149)).**
+  When a map-keyed item's origin was authored by a higher-clientID peer, the
+  item decoded before its origin's client group within the same update and took
+  the V1 deferred-parent retry path, which resolved the parent but did not
+  inherit `ParentSub`. The item integrated keyless and vanished from the map —
+  a single document's own full-state encode could fail to round-trip
+  (`EncodeStateAsUpdateV1` → `ApplyUpdateV1` dropping a live key), and two peers
+  applying the same updates in different orders could diverge. The V1
+  within-update resolver now inherits `ParentSub`, matching the sibling
+  resolution sites and the V2 decoder.
 
-### Changed
-
-- **`crdt.New()` now defaults a Doc's `guid` to a random uuidv4** (was
-  `""`) — Yjs parity, and an observable change to `Doc.GUID()` for docs
-  created without `WithGUID`. Docs constructed with `crdt.WithGUID(...)` are
-  unaffected.
+This bug was found by ygo's new randomized convergence fuzzer (#70) on its first
+run and confirmed by an independent byte-exact isolation. It affects all V1
+decode paths since the Yjs wire-format work and is present in v1.31.0; upgrading
+is recommended for anyone using `YMap` across concurrent peers.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.0
+go get github.com/reearth/ygo@v1.31.1
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,24 +1,43 @@
 ## v1.31.1
 
-A CRDT correctness patch. No API changes.
+A CRDT correctness and performance patch bundling two fix PRs (#145, #150). No
+API changes. Several of these were surfaced by ygo's new randomized convergence
+fuzzer (#70) on its first runs and confirmed by independent byte-exact
+isolation. Upgrading is recommended for anyone using `YMap` or the V2 codec
+across concurrent peers.
 
 ### Fixed
 
 - **YMap key silently lost on `ApplyUpdateV1` ([#149](https://github.com/reearth/ygo/issues/149)).**
   When a map-keyed item's origin was authored by a higher-clientID peer, the
-  item decoded before its origin's client group within the same update and took
-  the V1 deferred-parent retry path, which resolved the parent but did not
-  inherit `ParentSub`. The item integrated keyless and vanished from the map —
-  a single document's own full-state encode could fail to round-trip
-  (`EncodeStateAsUpdateV1` → `ApplyUpdateV1` dropping a live key), and two peers
-  applying the same updates in different orders could diverge. The V1
-  within-update resolver now inherits `ParentSub`, matching the sibling
-  resolution sites and the V2 decoder.
+  item decoded before its origin's client group and took the V1 deferred-parent
+  retry path, which resolved the parent but did not inherit `ParentSub`. The
+  item integrated keyless and vanished from the map — a single document's own
+  full-state encode could fail to round-trip (`EncodeStateAsUpdateV1` →
+  `ApplyUpdateV1` dropping a live key), and two peers applying the same updates
+  in different orders could diverge. Present since the Yjs wire-format work; in
+  v1.31.0.
 
-This bug was found by ygo's new randomized convergence fuzzer (#70) on its first
-run and confirmed by an independent byte-exact isolation. It affects all V1
-decode paths since the Yjs wire-format work and is present in v1.31.0; upgrading
-is recommended for anyone using `YMap` across concurrent peers.
+- **`ApplyUpdateV2` hard-failed on a deferred parent-by-ID child
+  ([#146](https://github.com/reearth/ygo/issues/146)).** When a nested
+  container's first child was authored by a higher-clientID peer, V2's
+  descending client-group order decoded the child before its parent, and
+  `ApplyUpdateV2` returned `parent item not found`. The V2 decoder now defers
+  and resolves it, matching the V1 fix (#140).
+
+- **V2 struct-level merge/diff dropped a deferred parent-by-ID child.**
+  `MergeUpdatesV2`/`DiffUpdateV2` re-encoded such a child as a GC placeholder,
+  losing its content and parent link. Fixed, with the V1/V2 resolve passes now
+  returning a consistent error on a genuinely corrupt parent-by-ID.
+
+- **`examples/peer-sync` deadlocked ([#138](https://github.com/reearth/ygo/issues/138)).**
+  It called `GetText`/`GetArray`/`GetMap` inside a `Transact` callback (a
+  re-entrant lock hang); handles are now resolved before the transaction.
+
+### Performance
+
+- **V2 string-column decode is now O(n), not O(n²)** — `ApplyUpdateV2` on
+  string-heavy documents drops roughly 6×, on par with `ApplyUpdateV1`.
 
 ## Install
 

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -642,11 +642,23 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 			if item.Origin != nil {
 				if oi := txn.doc.store.Find(*item.Origin); oi != nil {
 					item.Parent = oi.Parent
+					// A keyed (map) item with an origin carries no on-wire
+					// ParentSub — it inherits the key from its origin. Without
+					// this, the item integrates keyless (as a sequence element),
+					// vanishes from itemMap, and the map key is silently lost.
+					// Matches decodeItem, the doc-level drain, and the V2 decoder.
+					// (#YMap-wire)
+					if item.ParentSub == nil {
+						item.ParentSub = oi.ParentSub
+					}
 				}
 			}
 			if item.Parent == nil && item.OriginRight != nil {
 				if ori := txn.doc.store.Find(*item.OriginRight); ori != nil {
 					item.Parent = ori.Parent
+					if item.ParentSub == nil {
+						item.ParentSub = ori.ParentSub
+					}
 				}
 			}
 			// Parent referenced by container item-ID (review finding C-3): now

--- a/crdt/ymap_parentsub_test.go
+++ b/crdt/ymap_parentsub_test.go
@@ -1,0 +1,90 @@
+package crdt
+
+import "testing"
+
+// TestYMap_ParentSubInheritedOnDeferredParent guards a V1-decoder key-loss bug:
+// when a map-keyed item's origin is authored by a higher-clientID peer, the item
+// decodes BEFORE its origin's client group within the same update (client groups
+// are written ascending), so it is deferred and resolved by
+// resolveWithinUpdatePending. That retry must inherit ParentSub from the origin
+// item — otherwise the item integrates keyless (as a plain sequence element),
+// vanishes from itemMap, and the key is silently lost. The two sibling
+// resolution sites (decodeItem, the doc-level drain) and the V2 decoder all
+// inherit ParentSub; this V1 site was the one that missed it.
+//
+// Decisive shape: a single document's own full-state encode fails to round-trip
+// through EncodeStateAsUpdateV1 -> ApplyUpdateV1.
+func TestYMap_ParentSubInheritedOnDeferredParent(t *testing.T) {
+	// Peer B (higher clientID) sets key "k". Resolve the map handle outside the
+	// transaction (GetMap takes the doc lock, which Transact already holds).
+	dB := New(WithClientID(2))
+	mB := dB.GetMap("m")
+	dB.Transact(func(txn *Transaction) { mB.Set(txn, "k", "fromB") })
+
+	// Peer A (lower clientID) integrates B, then overwrites "k". A's item has
+	// its origin/left set to B's item, so A's item references a higher-clientID
+	// predecessor.
+	dA := New(WithClientID(1))
+	if err := ApplyUpdateV1(dA, EncodeStateAsUpdateV1(dB, nil), nil); err != nil {
+		t.Fatalf("dA seed: %v", err)
+	}
+	mA := dA.GetMap("m")
+	dA.Transact(func(txn *Transaction) { mA.Set(txn, "k", "fromA") })
+
+	if v, ok := mA.Get("k"); !ok || v != "fromA" {
+		t.Fatalf("precondition: dA should resolve k=fromA, got %v ok=%v", v, ok)
+	}
+
+	// A's full state contains both client groups (1 before 2). Item {1,0}
+	// decodes before its origin {2,0}, exercising the deferred-parent retry.
+	full := EncodeStateAsUpdateV1(dA, nil)
+	fresh := New()
+	if err := ApplyUpdateV1(fresh, full, nil); err != nil {
+		t.Fatalf("applying own full-state encode failed: %v", err)
+	}
+	if v, ok := fresh.GetMap("m").Get("k"); !ok || v != "fromA" {
+		t.Fatalf("key k lost/wrong after self round-trip: got %v ok=%v, want \"fromA\"", v, ok)
+	}
+}
+
+// TestYMap_DeferredParentConvergesAcrossApplyOrder is the multi-peer symptom of
+// the same bug: two receivers that integrate the identical set of updates in
+// different orders must converge, and the map key must not vanish. Before the
+// ParentSub-inheritance fix, whichever receiver decoded the keyed item before
+// its origin's client group lost the key, so the two receivers diverged.
+func TestYMap_DeferredParentConvergesAcrossApplyOrder(t *testing.T) {
+	dB := New(WithClientID(2))
+	mB := dB.GetMap("m")
+	dB.Transact(func(txn *Transaction) { mB.Set(txn, "k", "fromB") })
+	uB := EncodeStateAsUpdateV1(dB, nil)
+
+	dA := New(WithClientID(1))
+	if err := ApplyUpdateV1(dA, uB, nil); err != nil {
+		t.Fatalf("dA seed: %v", err)
+	}
+	mA := dA.GetMap("m")
+	dA.Transact(func(txn *Transaction) { mA.Set(txn, "k", "fromA") })
+	uA := EncodeStateAsUpdateV1(dA, nil) // full state: contains both client groups
+
+	apply := func(updates ...[]byte) (any, bool) {
+		d := New()
+		for _, u := range updates {
+			if err := ApplyUpdateV1(d, u, nil); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+		}
+		return d.GetMap("m").Get("k")
+	}
+
+	vAB, okAB := apply(uB, uA)
+	vBA, okBA := apply(uA, uB)
+	if !okAB || !okBA {
+		t.Fatalf("key k vanished: order(B,A) ok=%v order(A,B) ok=%v", okAB, okBA)
+	}
+	if vAB != vBA {
+		t.Fatalf("order-dependent divergence: (B,A)=%v (A,B)=%v", vAB, vBA)
+	}
+	if vAB != "fromA" {
+		t.Fatalf("wrong winner: got %v, want \"fromA\" (client 1's write supersedes client 2's origin)", vAB)
+	}
+}


### PR DESCRIPTION
Fixes #149.

## Problem

`ApplyUpdateV1` can silently drop a `YMap` key. When a map-keyed item's origin was authored by a **higher**-clientID peer, the item decodes before its origin's client group within the same update (V1 writes client groups ascending), so it is deferred and resolved by `resolveWithinUpdatePending`. That retry set `item.Parent = oi.Parent` but never inherited `oi.ParentSub`, so the item integrated **keyless**, landed in the list as a plain sequence element, and vanished from `itemMap`.

Decisive symptom (plain public API, no Merge/Diff): a single document's own full-state encode fails to round-trip — `EncodeStateAsUpdateV1(doc)` → `ApplyUpdateV1(fresh)` drops a live key. Two peers applying the same updates in different orders also diverge. Pre-existing since the Yjs wire-format work (`0064b9c`); present in **v1.31.0**.

## Fix

The V1 within-update resolver now inherits `ParentSub` at both the `Origin` and `OriginRight` branches, mirroring the two sibling sites (`decodeItem`, the doc-level drain `itemFutureDep`) and the V2 decoder, which already do this. Six lines.

## Tests

- `TestYMap_ParentSubInheritedOnDeferredParent` — self-round-trip; RED before the fix (`k` returns `(nil,false)`), green after.
- `TestYMap_DeferredParentConvergesAcrossApplyOrder` — the multi-peer symptom (two apply orders must converge and keep the key).

Full `crdt` suite green under `-race`; `go vet` clean.

## Discovery

Found by the new randomized convergence fuzzer (#70) on its first real run (seed 4; 264/1000 seeds) and confirmed by an independent byte-exact isolation. Distinct from the previously-fixed C-1 (the item here is live, not tombstoned — it is orphaned from its key during decode).

Bug-fix only, no API change → patch release **v1.31.1** (CHANGELOG + RELEASE_NOTES finalized in-branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)