### PR TITLE
fix(crdt): V2 OriginRight parking (#151) + merge/diff origin preservation (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.2] — 2026-07-13
+
+CRDT convergence patch. No API changes. Both fixes were found by ygo's new
+randomized convergence fuzzer (#70) and confirmed by independent harness-free
+isolation.
+
+### Fixed
+
+- **`ApplyUpdateV2` mis-positioned an item whose `OriginRight` was a
+  not-yet-integrated clock ([#151](https://github.com/reearth/ygo/issues/151)).**
+  V2 decodes client groups in descending client order, so a higher-clientID
+  item could reach integration before its lower-clientID right neighbour
+  existed and land at the wrong position, diverging from `ApplyUpdateV1` for an
+  identical logical update. `applyV2Txn` now defers such an item (first-pass
+  `OriginRight`-clock guard plus a retry-loop `itemFutureDep` check), matching
+  the V1 apply path — the C-2 `rightOrigin`-parking fix (#65/#68) that had never
+  been ported to V2.
+- **`MergeUpdates`/`DiffUpdate` stripped a real item's origin when its parent
+  was outside the input set, on both V1 and V2
+  ([#152](https://github.com/reearth/ygo/issues/152)).** The re-encoders cleared
+  `Origin`/`OriginRight` whenever the referenced neighbour's `Parent` was nil —
+  but a `Parent` is also nil when its anchor lives in the receiver's base rather
+  than in the merged update. Stripping detached the item, so the receiver
+  integrated it at the type head (reorder/loss). The encoders now strip only
+  when the neighbour is a genuine GC orphan (no `Parent` and no
+  `Origin`/`OriginRight`/`parentID`); genuine GC-origin handling (#125) is
+  preserved.
+
 ## [1.31.1] — 2026-07-11
 
 Correctness and performance patch. No API changes. Several of these fixes were

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,48 +1,34 @@
-## v1.31.1
+## v1.31.2
 
-A CRDT correctness and performance patch bundling two fix PRs (#145, #150). No
-API changes. Several of these were surfaced by ygo's new randomized convergence
-fuzzer (#70) on its first runs and confirmed by independent byte-exact
-isolation. Upgrading is recommended for anyone using `YMap` or the V2 codec
-across concurrent peers.
+A CRDT convergence patch. No API changes. Both fixes were found by ygo's new
+randomized convergence fuzzer (#70) and confirmed by independent harness-free
+isolation. Upgrading is recommended for anyone syncing via the V2 wire format or
+using `MergeUpdates`/`DiffUpdate`.
 
 ### Fixed
 
-- **YMap key silently lost on `ApplyUpdateV1` ([#149](https://github.com/reearth/ygo/issues/149)).**
-  When a map-keyed item's origin was authored by a higher-clientID peer, the
-  item decoded before its origin's client group and took the V1 deferred-parent
-  retry path, which resolved the parent but did not inherit `ParentSub`. The
-  item integrated keyless and vanished from the map — a single document's own
-  full-state encode could fail to round-trip (`EncodeStateAsUpdateV1` →
-  `ApplyUpdateV1` dropping a live key), and two peers applying the same updates
-  in different orders could diverge. Present since the Yjs wire-format work; in
-  v1.31.0.
+- **`ApplyUpdateV2` mis-positioned an item whose `OriginRight` was a
+  not-yet-integrated clock ([#151](https://github.com/reearth/ygo/issues/151)).**
+  V2 decodes client groups in descending client order, so a higher-clientID item
+  could integrate before its lower-clientID right neighbour existed and land at
+  the wrong position — `ApplyUpdateV2` diverging from `ApplyUpdateV1` for an
+  identical logical update. `applyV2Txn` now defers such an item, matching the V1
+  apply path (the C-2 `rightOrigin`-parking fix, #65/#68, that had never been
+  ported to V2).
 
-- **`ApplyUpdateV2` hard-failed on a deferred parent-by-ID child
-  ([#146](https://github.com/reearth/ygo/issues/146)).** When a nested
-  container's first child was authored by a higher-clientID peer, V2's
-  descending client-group order decoded the child before its parent, and
-  `ApplyUpdateV2` returned `parent item not found`. The V2 decoder now defers
-  and resolves it, matching the V1 fix (#140).
-
-- **V2 struct-level merge/diff dropped a deferred parent-by-ID child.**
-  `MergeUpdatesV2`/`DiffUpdateV2` re-encoded such a child as a GC placeholder,
-  losing its content and parent link. Fixed, with the V1/V2 resolve passes now
-  returning a consistent error on a genuinely corrupt parent-by-ID.
-
-- **`examples/peer-sync` deadlocked ([#138](https://github.com/reearth/ygo/issues/138)).**
-  It called `GetText`/`GetArray`/`GetMap` inside a `Transact` callback (a
-  re-entrant lock hang); handles are now resolved before the transaction.
-
-### Performance
-
-- **V2 string-column decode is now O(n), not O(n²)** — `ApplyUpdateV2` on
-  string-heavy documents drops roughly 6×, on par with `ApplyUpdateV1`.
+- **`MergeUpdates`/`DiffUpdate` stripped a real item's origin when its parent was
+  outside the input set — both V1 and V2
+  ([#152](https://github.com/reearth/ygo/issues/152)).** The re-encoders cleared
+  `Origin`/`OriginRight` whenever the referenced neighbour's `Parent` was nil,
+  but that is also true when the neighbour's anchor lives in the receiver's base
+  rather than in the update being merged. Stripping detached the item, so the
+  receiver integrated it at the type head (reorder/loss). The encoders now strip
+  only for genuine GC orphans; the #125 GC-origin handling is preserved.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.1
+go get github.com/reearth/ygo@v1.31.2
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/merge_origin_preserve_test.go
+++ b/crdt/merge_origin_preserve_test.go
@@ -1,0 +1,88 @@
+package crdt
+
+import "testing"
+
+// TestMerge_PreservesOriginWhenParentOutsideSet guards a merge/diff re-encode
+// bug: encodeItem/encodeItemV2 stripped a real content item's Origin when the
+// origin item's Parent was nil — but a Parent can be nil simply because the
+// item's anchor chain bottoms out on an item OUTSIDE the merge input set (it
+// lives in the receiver's base), not because it is a GC placeholder. Stripping
+// the origin then detaches the item, so the receiver integrates it at the type
+// head → reordering / loss.
+//
+// Scenario: base = "A" (client 1). "B" after A (client 2, origin=A). "C" after
+// B (client 4, origin=B). The delta {B, C} is merged/diffed and applied onto a
+// receiver holding "A". In the merge set {B, C}, B's origin A is absent so
+// B.Parent is nil; C's origin B is present-but-parentless, which used to strip
+// C's origin. Applying the re-encoded delta must still yield "ABC".
+func TestMerge_PreservesOriginWhenParentOutsideSet(t *testing.T) {
+	d1 := New(WithClientID(1))
+	t1 := d1.GetText("t")
+	d1.Transact(func(txn *Transaction) { t1.Insert(txn, 0, "A", nil) })
+	base := fullState(d1)
+
+	d2 := New(WithClientID(2))
+	if err := ApplyUpdateV1(d2, base, nil); err != nil {
+		t.Fatalf("d2 seed: %v", err)
+	}
+	t2 := d2.GetText("t")
+	d2.Transact(func(txn *Transaction) { t2.Insert(txn, 1, "B", nil) }) // "AB", B.origin=A
+
+	d4 := New(WithClientID(4))
+	if err := ApplyUpdateV1(d4, fullState(d2), nil); err != nil {
+		t.Fatalf("d4 seed: %v", err)
+	}
+	t4 := d4.GetText("t")
+	d4.Transact(func(txn *Transaction) { t4.Insert(txn, 2, "C", nil) }) // "ABC", C.origin=B (client 4)
+
+	// Delta carrying just {B, C} (everything an A-only receiver is missing).
+	lOnly := New()
+	if err := ApplyUpdateV1(lOnly, base, nil); err != nil {
+		t.Fatalf("lOnly seed: %v", err)
+	}
+	sv, err := DecodeStateVectorV1(EncodeStateVectorV1(lOnly))
+	if err != nil {
+		t.Fatalf("sv: %v", err)
+	}
+	deltaV1 := EncodeStateAsUpdateV1(d4, sv)
+	deltaV2 := EncodeStateAsUpdateV2(d4, sv)
+
+	const want = "ABC"
+
+	// applyOnBase seeds a receiver with "A", applies u via applyFn, returns text.
+	applyOnBase := func(applyFn func(*Doc, []byte, any) error, u []byte) string {
+		r := New()
+		if err := ApplyUpdateV1(r, base, nil); err != nil {
+			t.Fatalf("receiver seed: %v", err)
+		}
+		if err := applyFn(r, u, nil); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		return r.GetText("t").ToString()
+	}
+
+	// Sanity: applying the raw deltas directly already converges.
+	if got := applyOnBase(ApplyUpdateV1, deltaV1); got != want {
+		t.Fatalf("raw V1 delta: got %q, want %q", got, want)
+	}
+	if got := applyOnBase(ApplyUpdateV2, deltaV2); got != want {
+		t.Fatalf("raw V2 delta: got %q, want %q", got, want)
+	}
+
+	// The bug: MergeUpdates re-encodes and strips C's origin.
+	mergedV1, err := MergeUpdatesV1(deltaV1)
+	if err != nil {
+		t.Fatalf("MergeUpdatesV1: %v", err)
+	}
+	if got := applyOnBase(ApplyUpdateV1, mergedV1); got != want {
+		t.Fatalf("MergeUpdatesV1 re-encode: got %q, want %q (origin stripped)", got, want)
+	}
+
+	mergedV2, err := MergeUpdatesV2(deltaV2)
+	if err != nil {
+		t.Fatalf("MergeUpdatesV2: %v", err)
+	}
+	if got := applyOnBase(ApplyUpdateV2, mergedV2); got != want {
+		t.Fatalf("MergeUpdatesV2 re-encode: got %q, want %q (origin stripped)", got, want)
+	}
+}

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -181,6 +181,18 @@ func encodeV1Locked(doc *Doc, sv StateVector) []byte {
 	})
 }
 
+// isGCOrphan reports whether item carries no positional anchors at all — the
+// shape of a garbage-collected/deleted placeholder decoded from the wire GC
+// format, whose parent a receiver cannot infer. An item with a non-nil Origin,
+// OriginRight, or parentID is NOT an orphan even if its Parent is momentarily
+// unresolved (e.g. its anchor lives outside a merge input set): its origin must
+// be preserved on the wire so the receiver can resolve the parent once it has
+// the dependency. Stripping such an origin detaches the item (#149-class merge
+// corruption).
+func (item *Item) isGCOrphan() bool {
+	return item.Parent == nil && item.Origin == nil && item.OriginRight == nil && item.parentID == nil
+}
+
 func encodeItem(enc *encoding.Encoder, item *Item, offset int, store *StructStore) {
 	// Orphaned items (no parent) came from GC wire format where the parent
 	// type name is lost. Encode them as GC structs so receivers get valid
@@ -250,12 +262,12 @@ func encodeItem(enc *encoding.Encoder, item *Item, offset int, store *StructStor
 	// parent info is encoded instead, allowing the receiver to resolve the
 	// parent directly from the named root type or container item ID.
 	if origin != nil {
-		if oi := store.Find(*origin); oi != nil && oi.Parent == nil {
+		if oi := store.Find(*origin); oi != nil && oi.isGCOrphan() {
 			origin = nil
 		}
 	}
 	if originRight != nil {
-		if ori := store.Find(*originRight); ori != nil && ori.Parent == nil {
+		if ori := store.Find(*originRight); ori != nil && ori.isGCOrphan() {
 			originRight = nil
 		}
 	}

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -717,6 +717,19 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 				continue
 			}
 
+			// Defer if the right origin references a not-yet-integrated clock:
+			// V2 decodes client groups descending, so a higher-clientID item can
+			// reach here before its lower-clientID right neighbour exists. Without
+			// this the item integrates at the wrong position (permanent
+			// divergence, review finding C-2). Mirrors the V1 guard in update.go;
+			// only at offset==0 (a split's origins are necessarily satisfied).
+			if offset == 0 && item.OriginRight != nil &&
+				item.OriginRight.Clock >= txn.doc.store.NextClock(item.OriginRight.Client) {
+				pending = append(pending, item)
+				clock = itemEnd
+				continue
+			}
+
 			if offset == 0 && item.Origin != nil {
 				item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
 			}
@@ -771,6 +784,15 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 				item.Parent = findParentForMapEntry(txn.doc.store)
 			}
 			if item.Parent != nil {
+				// A resolved parent is not sufficient: the item may still depend
+				// on a not-yet-integrated origin/rightOrigin clock (C-2).
+				// Integrating now would place it at the wrong position. Defer to
+				// `remaining` so the no-progress branch below parks it via
+				// itemFutureDep. Mirrors the V1 retry loop in update.go.
+				if _, _, isFuture := itemFutureDep(item, txn.doc.store); isFuture {
+					remaining = append(remaining, item)
+					continue
+				}
 				if item.Origin != nil {
 					item.Left = txn.doc.store.getItemCleanEnd(txn, item.Origin.Client, item.Origin.Clock)
 				}

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -413,12 +413,12 @@ func encodeItemV2(enc *v2Encoder, item *Item, offset int, store *StructStore) {
 	// infer this item's parent from it. Clear the origin so explicit parent
 	// info is encoded instead.
 	if origin != nil {
-		if oi := store.Find(*origin); oi != nil && oi.Parent == nil {
+		if oi := store.Find(*origin); oi != nil && oi.isGCOrphan() {
 			origin = nil
 		}
 	}
 	if originRight != nil {
-		if ori := store.Find(*originRight); ori != nil && ori.Parent == nil {
+		if ori := store.Find(*originRight); ori != nil && ori.isGCOrphan() {
 			originRight = nil
 		}
 	}

--- a/crdt/update_v2_originright_test.go
+++ b/crdt/update_v2_originright_test.go
@@ -1,0 +1,75 @@
+package crdt
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestV2_OriginRightDeferral_ArrayConverges guards a V2 apply-path bug: an item
+// whose OriginRight references a not-yet-integrated clock must be deferred, like
+// the V1 path does (update.go C-2 guard), or it integrates at the wrong
+// position. V2 decodes client groups descending, so a higher-clientID item can
+// decode before its lower-clientID right neighbour.
+//
+// Setup: canonical [L, M, R] where L=client1, R=client2 (after L), M=client3
+// (between L and R, so M.Origin=L, M.OriginRight=R). A target holding only L
+// receives {R, M}. In V2 the group order is client 3 (M) before client 2 (R),
+// so M decodes before its OriginRight R exists. ApplyUpdateV2 must match
+// ApplyUpdateV1's correct [L, M, R]; before the fix it produced [L, R, M].
+func TestV2_OriginRightDeferral_ArrayConverges(t *testing.T) {
+	d1 := New(WithClientID(1))
+	a1 := d1.GetArray("a")
+	d1.Transact(func(txn *Transaction) { a1.Insert(txn, 0, []any{"L"}) })
+
+	d2 := New(WithClientID(2))
+	if err := ApplyUpdateV1(d2, fullState(d1), nil); err != nil {
+		t.Fatalf("d2 seed: %v", err)
+	}
+	a2 := d2.GetArray("a")
+	d2.Transact(func(txn *Transaction) { a2.Insert(txn, 1, []any{"R"}) }) // [L, R]
+
+	d3 := New(WithClientID(3))
+	if err := ApplyUpdateV1(d3, fullState(d1), nil); err != nil {
+		t.Fatalf("d3 seed L: %v", err)
+	}
+	if err := ApplyUpdateV1(d3, fullState(d2), nil); err != nil {
+		t.Fatalf("d3 seed R: %v", err)
+	}
+	a3 := d3.GetArray("a")
+	d3.Transact(func(txn *Transaction) { a3.Insert(txn, 1, []any{"M"}) }) // [L, M, R]
+
+	want := []any{"L", "M", "R"}
+	if got := d3.GetArray("a").ToSlice(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonical setup produced %v, want %v", got, want)
+	}
+
+	// State vector of a doc that holds only L → the {R, M} delta.
+	lOnly := New()
+	if err := ApplyUpdateV1(lOnly, fullState(d1), nil); err != nil {
+		t.Fatalf("lOnly seed: %v", err)
+	}
+	sv, err := DecodeStateVectorV1(EncodeStateVectorV1(lOnly))
+	if err != nil {
+		t.Fatalf("sv: %v", err)
+	}
+	uV1 := EncodeStateAsUpdateV1(d3, sv)
+	uV2 := EncodeStateAsUpdateV2(d3, sv)
+
+	apply := func(applyFn func(*Doc, []byte, any) error, u []byte) []any {
+		d := New(WithClientID(9))
+		if err := ApplyUpdateV1(d, fullState(d1), nil); err != nil {
+			t.Fatalf("target seed L: %v", err)
+		}
+		if err := applyFn(d, u, nil); err != nil {
+			t.Fatalf("apply delta: %v", err)
+		}
+		return d.GetArray("a").ToSlice()
+	}
+
+	if got := apply(ApplyUpdateV1, uV1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("V1 apply: got %v, want %v", got, want)
+	}
+	if got := apply(ApplyUpdateV2, uV2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("V2 apply diverged from V1: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Two CRDT convergence fixes found by the new randomized convergence fuzzer (#70) and each confirmed by an independent harness-free reproduction. Bug-fix only, **no API change → v1.31.2**.

## Fixes

### 1. `ApplyUpdateV2` OriginRight parking (#151)
`applyV2Txn` integrated an item as soon as its parent resolved, even when its `OriginRight` referenced a not-yet-integrated clock. V2 decodes client groups descending, so a higher-clientID item integrated before its lower-clientID right neighbour existed → wrong position → `ApplyUpdateV2` diverges from `ApplyUpdateV1`. This is the C-2 `rightOrigin`-parking fix (#65/#68) that landed in V1 but was never ported to V2. Ports both halves of V1's handling (first-pass deferral guard + retry-loop `itemFutureDep` check).

Repro (`TestV2_OriginRightDeferral_ArrayConverges`): target holding `L` receives `{R, M}` (M between L and R) → V1 `[L,M,R]`, V2 was `[L,R,M]`.

### 2. Merge/diff origin stripping on both V1 and V2 (#152)
`encodeItem`/`encodeItemV2` cleared `Origin`/`OriginRight` whenever the referenced neighbour's `Parent` was nil — intended for genuine GC placeholders (#125), but also true when the neighbour's anchor lives in the receiver's base rather than the merged update. Stripping detached a real content item → receiver integrated at the head (reorder/loss) through `MergeUpdatesV1/V2` and `DiffUpdateV1/V2`. New `Item.isGCOrphan()` restricts stripping to true orphans (no `Parent` and no `Origin`/`OriginRight`/`parentID`); #125 handling preserved.

Repro (`TestMerge_PreservesOriginWhenParentOutsideSet`): `MergeUpdatesV1({B,C})` onto base `"A"` produced `"AB"` (C dropped) instead of `"ABC"`.

## Validation
- Both fixes RED-tested first.
- Full `crdt` suite green under `-race` (no regression to the #125 GC-origin path, merge, or JS-conformance tests); module builds + vets clean.
- With both fixes, the #70 convergence fuzzer goes from 264/1000 seeds failing to **0/1000**.

Pre-existing on main; both distinct from the v1.31.1 map-key-loss fix (#149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)