### PR TITLE
fix(crdt): orphan-drop GC'd-container parent-by-ID instead of aborting the merge (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.3] — 2026-07-13
+
+CRDT convergence patch. No API changes. Found by the new randomized convergence
+fuzzer (#70) once nested containers were exercised, and confirmed against real
+Yjs.
+
+### Fixed
+
+- **Deleting a GC'd nested container aborted a concurrent child-merge
+  ([#154](https://github.com/reearth/ygo/issues/154)).** When a nested container
+  (e.g. an XML element) is deleted, auto-GC (default `gc:true`) replaces its
+  `ContentType` with a `ContentDeleted` tombstone. A concurrent remote update
+  that still referenced that container by parent-ID then failed a
+  `ContentType` type-assertion and returned a hard "parent item is not a
+  ContentType" error, aborting the **entire** update/merge instead of dropping
+  the one orphaned child. All four sites (V1/V2 decode and within-update
+  resolve) now treat a non-ContentType parent-by-ID as an orphan
+  (`parent = nil`) and continue, matching Yjs. This also reverses the
+  overly-strict resolve-pass error introduced in v1.31.2.
+
 ## [1.31.2] — 2026-07-13
 
 CRDT convergence patch. No API changes. Both fixes were found by ygo's new

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,34 +1,28 @@
-## v1.31.2
+## v1.31.3
 
-A CRDT convergence patch. No API changes. Both fixes were found by ygo's new
-randomized convergence fuzzer (#70) and confirmed by independent harness-free
-isolation. Upgrading is recommended for anyone syncing via the V2 wire format or
-using `MergeUpdates`/`DiffUpdate`.
+A CRDT convergence patch. No API changes. Found by ygo's randomized convergence
+fuzzer (#70) once nested containers were exercised, and confirmed against real
+Yjs. Recommended for anyone using nested containers (XML elements, or nested
+shared types) with the default `gc:true`.
 
 ### Fixed
 
-- **`ApplyUpdateV2` mis-positioned an item whose `OriginRight` was a
-  not-yet-integrated clock ([#151](https://github.com/reearth/ygo/issues/151)).**
-  V2 decodes client groups in descending client order, so a higher-clientID item
-  could integrate before its lower-clientID right neighbour existed and land at
-  the wrong position — `ApplyUpdateV2` diverging from `ApplyUpdateV1` for an
-  identical logical update. `applyV2Txn` now defers such an item, matching the V1
-  apply path (the C-2 `rightOrigin`-parking fix, #65/#68, that had never been
-  ported to V2).
-
-- **`MergeUpdates`/`DiffUpdate` stripped a real item's origin when its parent was
-  outside the input set — both V1 and V2
-  ([#152](https://github.com/reearth/ygo/issues/152)).** The re-encoders cleared
-  `Origin`/`OriginRight` whenever the referenced neighbour's `Parent` was nil,
-  but that is also true when the neighbour's anchor lives in the receiver's base
-  rather than in the update being merged. Stripping detached the item, so the
-  receiver integrated it at the type head (reorder/loss). The encoders now strip
-  only for genuine GC orphans; the #125 GC-origin handling is preserved.
+- **Deleting a GC'd nested container aborted a concurrent child-merge
+  ([#154](https://github.com/reearth/ygo/issues/154)).** When a nested container
+  (e.g. an XML element) is deleted, auto-GC replaces its `ContentType` with a
+  `ContentDeleted` tombstone. A concurrent remote update still referencing that
+  container by parent-ID then failed a `ContentType` type-assertion and returned
+  a hard "parent item is not a ContentType" error, **aborting the entire
+  update/merge** rather than dropping the single orphaned child. The V1/V2
+  decode and within-update resolve paths now treat a non-ContentType
+  parent-by-ID as an orphan (`parent = nil`) and continue — matching Yjs, which
+  on the identical scenario throws nothing, drops the orphan, and converges.
+  This also reverses the overly-strict resolve-pass error added in v1.31.2.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.2
+go get github.com/reearth/ygo@v1.31.3
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/gc_container_parent_test.go
+++ b/crdt/gc_container_parent_test.go
@@ -1,0 +1,63 @@
+package crdt
+
+import "testing"
+
+// TestGC_DeletedContainerParent_OrphanDrops guards against a merge-aborting bug:
+// deleting a nested container (default gc:true) auto-GCs its ContentType into a
+// ContentDeleted tombstone. A concurrent remote update that references that
+// container by parent-ID must be treated as an orphan (parent=nil, item dropped
+// from the visible tree) — matching Yjs — NOT rejected with a hard
+// "parent item is not a ContentType" error that aborts the whole update/merge.
+//
+// Runs the scenario through both the V1 and V2 apply paths (decode + deferred
+// resolve).
+func TestGC_DeletedContainerParent_OrphanDrops(t *testing.T) {
+	cases := []struct {
+		name   string
+		encode func(*Doc) []byte
+		apply  func(*Doc, []byte, any) error
+	}{
+		{"V1", func(d *Doc) []byte { return EncodeStateAsUpdateV1(d, nil) }, ApplyUpdateV1},
+		{"V2", func(d *Doc) []byte { return EncodeStateAsUpdateV2(d, nil) }, ApplyUpdateV2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := New(WithClientID(1))
+			b := New(WithClientID(2))
+
+			aFrag := a.GetXmlFragment("x")
+			a.Transact(func(txn *Transaction) { aFrag.InsertElement(txn, 0, NewYXmlElement("div")) })
+			if err := tc.apply(b, tc.encode(a), nil); err != nil {
+				t.Fatalf("b seed: %v", err)
+			}
+
+			// A deletes the element; auto-GC tombstones the container's ContentType.
+			a.Transact(func(txn *Transaction) { aFrag.Delete(txn, 0, 1) })
+
+			// B, concurrently, inserts a child into the (still-alive to B) element.
+			bElem := b.GetXmlFragment("x").Children()[0].(*YXmlElement)
+			b.Transact(func(txn *Transaction) { bElem.InsertText(txn, 0, NewYXmlText()) })
+
+			// Merge B's child-insert into A, which already GC'd the container.
+			// Must orphan-drop, not abort.
+			if err := tc.apply(a, tc.encode(b), nil); err != nil {
+				t.Fatalf("merge B->A aborted instead of orphan-dropping: %v", err)
+			}
+			// Converge the other direction.
+			if err := tc.apply(b, tc.encode(a), nil); err != nil {
+				t.Fatalf("merge A->B: %v", err)
+			}
+
+			// Both peers converge; the element was deleted, so the fragment is
+			// empty on both (the orphaned child is not visible under a deleted
+			// container).
+			ax, bx := a.GetXmlFragment("x").ToXML(), b.GetXmlFragment("x").ToXML()
+			if ax != bx {
+				t.Fatalf("diverged after cross-sync: A=%q B=%q", ax, bx)
+			}
+			if n := a.GetXmlFragment("x").Len(); n != 0 {
+				t.Fatalf("expected empty fragment (element deleted), got len=%d xml=%q", n, ax)
+			}
+		})
+	}
+}

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -679,16 +679,13 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 			// which would otherwise graft this keyed item onto an arbitrary map.
 			if item.Parent == nil && item.parentID != nil {
 				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
-					ct, ok := pi.Content.(*ContentType)
-					if !ok {
-						// Parent-by-ID resolves to a non-container item: corrupt
-						// update. decodeItem errors on this at decode time when the
-						// parent is already integrated; error here too so the outcome
-						// doesn't depend on decode order (kept consistent with the V2
-						// resolve path).
-						return fmt.Errorf("parent item {%d,%d} is not a ContentType", item.parentID.Client, item.parentID.Clock)
+					// A non-ContentType here means the container was tombstoned/
+					// GC'd (its ContentType replaced by a ContentDeleted
+					// placeholder). Leave Parent nil so the item orphan-drops
+					// (Yjs parent=nil) rather than aborting the whole update.
+					if ct, ok := pi.Content.(*ContentType); ok {
+						item.Parent = ct.Type
 					}
-					item.Parent = ct.Type
 				}
 			}
 			// If the origin is a GC placeholder (no parent), search the
@@ -937,7 +934,13 @@ func decodeItem(dec *encoding.Decoder, doc *Doc, client ClientID, clock uint64) 
 			} else if ct, ok := parentItem.Content.(*ContentType); ok {
 				parent = ct.Type
 			} else {
-				return nil, fmt.Errorf("parent item {%d,%d} is not a ContentType", pc, pk)
+				// Parent resolves to a tombstoned/GC'd container (its ContentType
+				// was replaced by a ContentDeleted placeholder). Treat it as a
+				// deferred/orphan reference rather than hard-failing: the item
+				// ends up with no parent and drops from the visible tree, matching
+				// Yjs's parent=nil handling. Aborting the whole update here would
+				// discard unrelated structs in the same batch.
+				parentByID = &ID{Client: ClientID(pc), Clock: pk}
 			}
 		}
 	}

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -768,16 +768,12 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 			// fallback, which would otherwise graft this keyed item onto an arbitrary map.
 			if item.Parent == nil && item.parentID != nil {
 				if pi := txn.doc.store.Find(*item.parentID); pi != nil {
-					ct, ok := pi.Content.(*ContentType)
-					if !ok {
-						// Parent-by-ID resolves to a non-container item: the update
-						// is corrupt. decodeItemV2 errors on this when the parent is
-						// already integrated at decode time; error here too so the
-						// outcome doesn't depend on decode order (a deferred parent
-						// would otherwise be silently orphaned).
-						return fmt.Errorf("parent item {%d,%d} is not a ContentType", item.parentID.Client, item.parentID.Clock)
+					// Non-ContentType => tombstoned/GC'd container. Leave Parent
+					// nil so the item orphan-drops (Yjs parent=nil) rather than
+					// aborting the update. See update.go resolveWithinUpdatePending.
+					if ct, ok := pi.Content.(*ContentType); ok {
+						item.Parent = ct.Type
 					}
-					item.Parent = ct.Type
 				}
 			}
 			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
@@ -974,7 +970,9 @@ func decodeItemV2(dec *v2Decoder, doc *Doc, client ClientID, clock uint64, info 
 			} else if ct, ok := parentItem.Content.(*ContentType); ok {
 				parent = ct.Type
 			} else {
-				return nil, 0, fmt.Errorf("parent item {%d,%d} is not a ContentType", pid.Client, pid.Clock)
+				// Tombstoned/GC'd container: defer as an orphan reference instead
+				// of hard-failing (Yjs parent=nil). See update.go decodeItem.
+				parentByID = &pid
 			}
 		}
 


### PR DESCRIPTION
Fixes #154. v1.31.3 (bug-fix only, no API change).

Deleting a nested container (default `gc:true`) auto-GCs its `ContentType` into a `ContentDeleted` tombstone. A concurrent remote update referencing that container by parent-ID then hit a `ContentType` type-assert failure and threw `"parent item is not a ContentType"`, **aborting the whole update/merge** — where Yjs orphan-drops (`parent = nil`) and continues.

## Fix
All four sites — `decodeItem`, `decodeItemV2`, and the V1/V2 within-update resolve passes — treat a non-ContentType parent-by-ID as a deferred/orphan reference (leave `Parent` nil → the item flows to the existing "store without integration" fallback) instead of erroring. This also reverses the overly-strict resolve-pass error added in v1.31.2 (#145 Copilot fix); "consistency with the decode error" was the wrong direction — both should orphan-drop.

## Validation
- RED→GREEN: `TestGC_DeletedContainerParent_OrphanDrops` (V1 + V2).
- **Yjs-conformance confirmed:** the identical scenario in `yjs@13.6.x` throws nothing, drops the orphan, and converges to an empty fragment on both peers — matching this fix exactly.
- Full `crdt` suite green under `-race`; no test asserted the old error.

Found by the #70 convergence fuzzer once nested containers (XML) were fuzzed, and confirmed by a harness-free public-API reproduction. Pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)