### PR TITLE
fix(crdt): drop orphaned keyed items instead of mis-grafting onto a map (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.4] — 2026-07-13
+
+CRDT convergence patch. No API changes. Found by the randomized convergence
+fuzzer (#70) once nested containers were exercised, and confirmed to converge
+in real Yjs where ygo diverged.
+
+### Fixed
+
+- **A deleted-and-GC'd container's orphaned attribute could be mis-grafted onto
+  an unrelated root map, diverging peers
+  ([#156](https://github.com/reearth/ygo/issues/156)).** When an XML element (or
+  other nested container) is deleted, auto-GC (default `gc:true`) replaces its
+  `ContentType` with a `ContentDeleted` tombstone, so a concurrent attribute
+  write on that element arrives as a keyed item whose parent can no longer be
+  resolved. A store-wide fallback (`findParentForMapEntry`) then attached that
+  orphan to the **first** map-type parent it happened to find while scanning the
+  store — a choice that depends on integration order and Go map iteration, so
+  two peers that saw the same updates in different orders ended up with a
+  spurious key (e.g. `"id"`) on the root map on one side only. The fallback is
+  removed at all three resolve sites (V1 within-update, V1 doc-level drain, and
+  V2); such orphans now drop on every peer, matching Yjs, which integrates an
+  item with an unresolved parent as a no-op. The divergence was pre-existing and
+  had been masked by the pre-#154 hard abort; it hit 3 of the first 1000 fuzzer
+  seeds, and all 1000 now converge.
+
 ## [1.31.3] — 2026-07-13
 
 CRDT convergence patch. No API changes. Found by the new randomized convergence

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,28 +1,32 @@
-## v1.31.3
+## v1.31.4
 
 A CRDT convergence patch. No API changes. Found by ygo's randomized convergence
-fuzzer (#70) once nested containers were exercised, and confirmed against real
-Yjs. Recommended for anyone using nested containers (XML elements, or nested
-shared types) with the default `gc:true`.
+fuzzer (#70) once nested containers were exercised, and confirmed to converge in
+real Yjs where ygo diverged. Recommended for anyone using nested containers
+(XML elements, or nested shared types) with the default `gc:true`.
 
 ### Fixed
 
-- **Deleting a GC'd nested container aborted a concurrent child-merge
-  ([#154](https://github.com/reearth/ygo/issues/154)).** When a nested container
-  (e.g. an XML element) is deleted, auto-GC replaces its `ContentType` with a
-  `ContentDeleted` tombstone. A concurrent remote update still referencing that
-  container by parent-ID then failed a `ContentType` type-assertion and returned
-  a hard "parent item is not a ContentType" error, **aborting the entire
-  update/merge** rather than dropping the single orphaned child. The V1/V2
-  decode and within-update resolve paths now treat a non-ContentType
-  parent-by-ID as an orphan (`parent = nil`) and continue — matching Yjs, which
-  on the identical scenario throws nothing, drops the orphan, and converges.
-  This also reverses the overly-strict resolve-pass error added in v1.31.2.
+- **A deleted-and-GC'd container's orphaned attribute could be mis-grafted onto
+  an unrelated root map, diverging peers
+  ([#156](https://github.com/reearth/ygo/issues/156)).** When an XML element is
+  deleted, auto-GC replaces its `ContentType` with a `ContentDeleted` tombstone,
+  so a concurrent attribute write on that element arrives as a keyed item whose
+  parent can no longer be resolved. A store-wide fallback then attached that
+  orphan to the **first** map-type parent it found while scanning the store —
+  which depends on integration order and Go map iteration, so two peers that saw
+  the same updates in different orders ended up with a spurious key (e.g.
+  `"id"`) on the root map on one side only. That fallback is now removed at all
+  three resolve sites (V1 within-update, V1 doc-level drain, and V2); such
+  orphans drop on every peer, matching Yjs, which integrates an item with an
+  unresolved parent as a no-op. The divergence was pre-existing and had been
+  masked by the pre-#154 hard abort; it hit 3 of the first 1000 fuzzer seeds,
+  and all 1000 now converge.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.3
+go get github.com/reearth/ygo@v1.31.4
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/gc_container_attr_misgraft_test.go
+++ b/crdt/gc_container_attr_misgraft_test.go
@@ -1,0 +1,88 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGC_DeletedContainerAttr_NoMapGraft is a convergence regression for #156.
+//
+// When an XML element is deleted, auto-GC replaces its ContentType with a
+// ContentDeleted placeholder, so a concurrent attribute write on that element
+// arrives with its parent lost from the wire (a keyed item whose origin chain
+// no longer resolves to a live container). Such an orphan must be dropped on
+// EVERY peer, matching Yjs, rather than mis-grafted onto an arbitrary root map
+// via a store-wide "find any map parent" fallback. Before the fix the orphaned
+// `id` attribute landed on the root map `m` as a spurious key on whichever peer
+// happened to have a live map entry integrated at resolve time, so two peers
+// that saw the same updates in different orders diverged.
+//
+// Found by the #70 convergence fuzzer (seeds 123, 267, 286) and reproduced here
+// harness-free over both the V1 and V2 wire paths.
+func TestGC_DeletedContainerAttr_NoMapGraft(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		encode func(*Doc) []byte
+		apply  func(*Doc, []byte) error
+	}{
+		{"V1",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV1(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV1(d, u, nil) }},
+		{"V2",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV2(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV2(d, u, nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Peer A: root map m with one key, plus a <div> in xml fragment x.
+			a := New(WithClientID(1))
+			am, ax := a.GetMap("m"), a.GetXmlFragment("x")
+			a.Transact(func(txn *Transaction) {
+				am.Set(txn, "k0", 1)
+				ax.InsertElement(txn, 0, NewYXmlElement("div"))
+			})
+
+			// Peer B receives the div, then sets its `id` attribute twice. The
+			// second write is LWW so its origin is the first write and it carries
+			// no on-wire parent — it inherits the key from its origin.
+			b := New(WithClientID(2))
+			require.NoError(t, tc.apply(b, tc.encode(a)))
+			bx := b.GetXmlFragment("x")
+			b.Transact(func(txn *Transaction) {
+				el := bx.Children()[0].(*YXmlElement)
+				el.SetAttribute(txn, "id", "Y")
+				el.SetAttribute(txn, "id", "Z")
+			})
+
+			// Peer A concurrently deletes the div; a follow-up empty transaction
+			// forces auto-GC of the tombstone (ContentType -> ContentDeleted).
+			a.Transact(func(txn *Transaction) { ax.Delete(txn, 0, 1) })
+			a.Transact(func(*Transaction) {})
+
+			uA := tc.encode(a) // create div + delete + map k0
+			uB := tc.encode(b) // id="Y" then id="Z" on the div
+
+			// Two fresh peers integrate the identical updates in opposite orders.
+			p := New(WithClientID(10)) // id-writes while div still live, then deletion
+			require.NoError(t, tc.apply(p, uB))
+			require.NoError(t, tc.apply(p, uA))
+
+			q := New(WithClientID(11)) // deletion first, then id-writes (div gone)
+			require.NoError(t, tc.apply(q, uA))
+			require.NoError(t, tc.apply(q, uB))
+
+			pm, err := p.GetMap("m").ToJSON()
+			require.NoError(t, err)
+			qm, err := q.GetMap("m").ToJSON()
+			require.NoError(t, err)
+
+			// Both peers must converge, and neither may carry the orphaned `id`
+			// attribute as a root-map key.
+			require.Equal(t, string(pm), string(qm), "peers diverged on root map m")
+			require.NotContains(t, string(pm), `"id"`,
+				"orphaned xml attribute mis-grafted onto root map")
+			require.NotContains(t, string(qm), `"id"`,
+				"orphaned xml attribute mis-grafted onto root map")
+		})
+	}
+}

--- a/crdt/store.go
+++ b/crdt/store.go
@@ -161,24 +161,6 @@ func (s *StructStore) insertItem(item *Item) {
 	s.clients[item.ID.Client] = items
 }
 
-// findParentForMapEntry scans all items in the store for one that belongs
-// to a map-type parent (has a non-empty ParentSub and a non-nil Parent).
-// Used as a fallback when an item's origin is a GC placeholder with no
-// parent info (Yjs wire-format limitation). Returns the first matching
-// parent found. If the document has multiple map types, this may return
-// any of them — but for single-map-type documents (the common case for
-// this bug), it returns the correct parent.
-func findParentForMapEntry(s *StructStore) *abstractType {
-	for _, items := range s.clients {
-		for _, item := range items {
-			if item.ParentSub != nil && item.Parent != nil {
-				return item.Parent
-			}
-		}
-	}
-	return nil
-}
-
 // IterateFrom calls fn for every Item whose ID is not yet in sv,
 // visiting items in client order, then clock order.
 func (s *StructStore) IterateFrom(sv StateVector, fn func(*Item)) {

--- a/crdt/update.go
+++ b/crdt/update.go
@@ -688,14 +688,14 @@ func resolveWithinUpdatePending(txn *Transaction, pending []*Item) error {
 					}
 				}
 			}
-			// If the origin is a GC placeholder (no parent), search the
-			// entire store for an item with the same ParentSub that does
-			// have a parent. This handles the Yjs wire-format case where
-			// deleted YMap entries become GC structs and the parent type
-			// name is lost.
-			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
-				item.Parent = findParentForMapEntry(txn.doc.store)
-			}
+			// A keyed item whose parent is still unresolved here is a genuine
+			// orphan: its origin/container was deleted and GC'd, so the parent
+			// type is gone. Yjs integrates such an item as a no-op (parent=nil)
+			// and drops it on every peer. Do NOT graft it onto some arbitrary
+			// map found by scanning the store — that lands the orphan on a
+			// different (or no) parent depending on integration order and Go map
+			// iteration, causing peers to diverge (#156). Leave Parent nil and
+			// let it fall through to the orphan-Append path below.
 			if item.Parent != nil {
 				// A resolved parent is not sufficient: the item may still depend
 				// on a not-yet-integrated origin/rightOrigin clock (review finding
@@ -1352,11 +1352,11 @@ func tryIntegrate(txn *Transaction, item *Item) bool {
 				return false
 			}
 		}
-		if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
-			item.Parent = findParentForMapEntry(store)
-		}
 		if item.Parent == nil {
-			// Truly unresolvable — orphan store (existing behavior).
+			// A keyed item still unresolved here is a genuine orphan (its
+			// container/origin was deleted and GC'd). Yjs drops it on every
+			// peer; do NOT graft it onto an arbitrary map by scanning the store,
+			// which diverges by integration order (#156). Orphan-store it.
 			store.Append(item)
 			return true
 		}

--- a/crdt/update_v2.go
+++ b/crdt/update_v2.go
@@ -776,9 +776,11 @@ func applyV2Txn(txn *Transaction, update []byte) (retErr error) {
 					}
 				}
 			}
-			if item.Parent == nil && item.parentID == nil && item.ParentSub != nil {
-				item.Parent = findParentForMapEntry(txn.doc.store)
-			}
+			// A keyed item still unresolved here is a genuine orphan (its
+			// container/origin was deleted and GC'd). Yjs drops it on every
+			// peer; do NOT graft it onto an arbitrary map by scanning the store,
+			// which diverges by integration order (#156). Mirrors the V1 loop:
+			// leave Parent nil and let it orphan-Append below.
 			if item.Parent != nil {
 				// A resolved parent is not sufficient: the item may still depend
 				// on a not-yet-integrated origin/rightOrigin clock (C-2).


### PR DESCRIPTION
## Summary

Fixes a CRDT convergence bug ([#156](https://github.com/reearth/ygo/issues/156)) surfaced by the randomized convergence fuzzer (#70) once nested containers were exercised, and confirmed to converge in real Yjs where ygo diverged.

When a nested container (e.g. an XML element) is deleted, auto-GC (default `gc:true`) replaces its `ContentType` with a `ContentDeleted` tombstone. A concurrent attribute write on that element then arrives as a keyed item whose parent can no longer be resolved. A store-wide fallback (`findParentForMapEntry`) attached that orphan to the **first** map-type parent it found while scanning the store — a choice that depends on integration order and Go map iteration, so two peers that saw the same updates in different orders ended up with a spurious key (e.g. `"id"`) on the root map on one side only.

## Fix

Remove the fallback at all three resolve sites (V1 within-update, V1 doc-level drain, and V2). Such orphans now fall through to the existing orphan-`Append` path and drop on every peer, matching Yjs, which integrates an item with an unresolved parent as a no-op.

This is pre-existing behaviour that had been masked by the pre-#154 hard abort. It is a strict continuation of the same "orphan-drop, don't mis-graft" philosophy as the #154 fix.

## Verification

- New harness-free public-API regression (`TestGC_DeletedContainerAttr_NoMapGraft`) over both the V1 and V2 wire paths — RED before, GREEN after.
- Full `crdt` suite under `-race` passes, including the `TestYjsCompat_GCdYMapOrigin_*` interop tests (whose assertions do not depend on the removed fallback) and the Go↔JS round-trip conformance tests.
- Convergence fuzzer: the divergence hit 3 of the first 1000 seeds (123, 267, 286); **all 1000 now converge**.
- `go vet` + `golangci-lint` clean.

## Compatibility

No API changes. Patch release (`v1.31.4`). CHANGELOG + RELEASE_NOTES finalized in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)