### PR TITLE
fix(crdt): YArray.Push appends after the physical tail to match Yjs (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.5] — 2026-07-13
+
+CRDT convergence patch. No API changes. Found by ygo's cross-implementation
+convergence fuzzer (#70), which compares ygo's public API against live Yjs.
+
+### Fixed
+
+- **`YArray.Push` diverged from Yjs's `push` when the array's tail was a
+  tombstone ([#158](https://github.com/reearth/ygo/issues/158)).** `Push`
+  delegated to `Insert(Len())`, which anchors the new element after the last
+  **live** element (the live-index walk skips tombstones). Yjs's `push`
+  (`typeListPushGenerics`) anchors after the last **physical** item, tombstones
+  included. When the tail was a deleted element the two produced different YATA
+  anchors (`origin=nil, rightOrigin=tombstone` vs `origin=tombstone,
+  rightOrigin=null`), so a ygo peer and a Yjs peer that both pushed concurrently
+  onto such an array ordered the merged result differently. `Push` now appends
+  after the physical tail, matching Yjs. `Insert` at an explicit index is
+  unchanged — it already matched Yjs's `insert`.
+
 ## [1.31.4] — 2026-07-13
 
 CRDT convergence patch. No API changes. Found by the randomized convergence

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,27 @@
-## v1.31.4
+## v1.31.5
 
-A CRDT convergence patch. No API changes. Found by ygo's randomized convergence
-fuzzer (#70) once nested containers were exercised, and confirmed to converge in
-real Yjs where ygo diverged. Recommended for anyone using nested containers
-(XML elements, or nested shared types) with the default `gc:true`.
+A CRDT convergence patch. No API changes. Found by ygo's cross-implementation
+convergence fuzzer (#70), which replays randomized scenarios against live Yjs
+and compares the results. Recommended for anyone whose Go peers push into arrays
+that are also edited (and deleted from) by Yjs peers.
 
 ### Fixed
 
-- **A deleted-and-GC'd container's orphaned attribute could be mis-grafted onto
-  an unrelated root map, diverging peers
-  ([#156](https://github.com/reearth/ygo/issues/156)).** When an XML element is
-  deleted, auto-GC replaces its `ContentType` with a `ContentDeleted` tombstone,
-  so a concurrent attribute write on that element arrives as a keyed item whose
-  parent can no longer be resolved. A store-wide fallback then attached that
-  orphan to the **first** map-type parent it found while scanning the store —
-  which depends on integration order and Go map iteration, so two peers that saw
-  the same updates in different orders ended up with a spurious key (e.g.
-  `"id"`) on the root map on one side only. That fallback is now removed at all
-  three resolve sites (V1 within-update, V1 doc-level drain, and V2); such
-  orphans drop on every peer, matching Yjs, which integrates an item with an
-  unresolved parent as a no-op. The divergence was pre-existing and had been
-  masked by the pre-#154 hard abort; it hit 3 of the first 1000 fuzzer seeds,
-  and all 1000 now converge.
+- **`YArray.Push` diverged from Yjs's `push` when the array's tail was a
+  tombstone ([#158](https://github.com/reearth/ygo/issues/158)).** `Push`
+  delegated to `Insert(Len())`, which anchors the new element after the last
+  **live** element (the live-index walk skips tombstones). Yjs's `push` anchors
+  after the last **physical** item, tombstones included. When the tail was a
+  deleted element the two produced different YATA anchors, so a ygo peer and a
+  Yjs peer that both pushed concurrently onto such an array ordered the merged
+  result differently. `Push` now appends after the physical tail, matching Yjs.
+  `Insert` at an explicit index is unchanged — it already matched Yjs's
+  `insert`.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.4
+go get github.com/reearth/ygo@v1.31.5
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -179,6 +179,16 @@ func (a *YArray) Insert(txn *Transaction, index int, vals []any) {
 		splitItem(txn, left, offset)
 		// left is now the left half; its Right points to the right half.
 	}
+	a.insertAfterItem(txn, left, vals, index)
+}
+
+// insertAfterItem integrates a new item holding vals immediately after left
+// (left == nil means "at the head"). hintIndex is the logical position of the
+// insertion, used only for partial pos-cache invalidation. Shared by Insert
+// and Push; the two differ only in how left is chosen (Insert uses the
+// live-index neighbour, Push uses the physical tail).
+func (a *YArray) insertAfterItem(txn *Transaction, left *Item, vals []any, hintIndex int) {
+	t := &a.abstractType
 
 	var origin *ID
 	var originRight *ID
@@ -203,15 +213,34 @@ func (a *YArray) Insert(txn *Transaction, index int, vals []any) {
 		Content:     NewContentAny(vals...),
 	}
 	// Signal to integrate the logical index for partial cache invalidation.
-	if index > 0 {
-		t.insertHint = index
+	if hintIndex > 0 {
+		t.insertHint = hintIndex
 	}
 	item.integrate(txn, 0)
 }
 
-// Push appends vals to the end of the array.
+// Push appends vals to the end of the array, matching Yjs's push
+// (typeListPushGenerics): the new element anchors after the last PHYSICAL item,
+// tombstones included — NOT after the last live element. Insert(Len()) would
+// use live-index semantics (leftNeighbourAt skips tombstones), so when the tail
+// is a tombstone it anchors the new item before it (origin=nil,
+// rightOrigin=tombstone) whereas Yjs anchors after it (origin=tombstone,
+// rightOrigin=nil). Those are different YATA anchors, so a concurrent push from
+// a Yjs peer would order the two results differently — a convergence divergence
+// surfaced by the #70 cross-impl fuzz oracle.
 func (a *YArray) Push(txn *Transaction, vals []any) {
-	a.Insert(txn, a.Len(), vals)
+	t := &a.abstractType
+	// Start from the last live item (fast, pos-cached) then walk past any
+	// trailing tombstones to the physical tail. When there are no trailing
+	// tombstones this is identical to Insert(Len()) and just as cheap.
+	last, _ := t.leftNeighbourAt(t.length)
+	if last == nil {
+		last = t.start // all items deleted (leading tombstone), or nil if empty
+	}
+	for last != nil && last.Right != nil {
+		last = last.Right
+	}
+	a.insertAfterItem(txn, last, vals, t.length)
 }
 
 // Get returns the element at logical position index, or nil if out of bounds.

--- a/crdt/yarray_push_tombstone_test.go
+++ b/crdt/yarray_push_tombstone_test.go
@@ -1,0 +1,83 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestYArrayPush_TombstonedTail_MatchesYjs is a #70 cross-impl regression.
+//
+// YArray.Push must anchor the new element after the last PHYSICAL item
+// (tombstones included), matching Yjs's push (typeListPushGenerics). Before the
+// fix, Push delegated to Insert(Len()), which anchors after the last LIVE item
+// (leftNeighbourAt skips tombstones). So a push onto an array whose tail is a
+// tombstone produced different YATA anchors than Yjs
+// (origin=nil,rightOrigin=tombstone vs origin=tombstone,rightOrigin=nil), and
+// two peers pushing concurrently ordered the results differently.
+//
+// Scenario: client3 pushes F; client1 receives F, deletes it, then pushes X (so
+// X's right neighbour is the F tombstone); client2 independently pushes Y; merge
+// all three. Real Yjs 13.6.30 yields ["Y","X"] (verified out-of-band via the
+// cross-impl oracle and a hand-written Yjs script). ygo must match.
+func TestYArrayPush_TombstonedTail_MatchesYjs(t *testing.T) {
+	codecs := []struct {
+		name   string
+		encode func(*Doc) []byte
+		apply  func(*Doc, []byte) error
+	}{
+		{"V1",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV1(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV1(d, u, nil) }},
+		{"V2",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV2(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV2(d, u, nil) }},
+	}
+
+	build := func(deleteF bool, apply func(*Doc, []byte) error, encode func(*Doc) []byte) (*Doc, *Doc, *Doc) {
+		// client3 pushes F.
+		c3 := New(WithClientID(3))
+		a3 := c3.GetArray("arr")
+		c3.Transact(func(txn *Transaction) { a3.Push(txn, []any{"F"}) })
+
+		// client1 receives F, optionally deletes it, then pushes X.
+		c1 := New(WithClientID(1))
+		require.NoError(t, apply(c1, encode(c3)))
+		a1 := c1.GetArray("arr")
+		if deleteF {
+			c1.Transact(func(txn *Transaction) { a1.Delete(txn, 0, 1) })
+		}
+		c1.Transact(func(txn *Transaction) { a1.Push(txn, []any{"X"}) })
+
+		// client2 independently pushes Y (never saw F).
+		c2 := New(WithClientID(2))
+		a2 := c2.GetArray("arr")
+		c2.Transact(func(txn *Transaction) { a2.Push(txn, []any{"Y"}) })
+		return c3, c1, c2
+	}
+
+	for _, tc := range codecs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Bug scenario: F tombstoned. Yjs converges to ["Y","X"].
+			c3, c1, c2 := build(true, tc.apply, tc.encode)
+			merged := New(WithClientID(9))
+			require.NoError(t, tc.apply(merged, tc.encode(c3)))
+			require.NoError(t, tc.apply(merged, tc.encode(c1)))
+			require.NoError(t, tc.apply(merged, tc.encode(c2)))
+			got, err := merged.GetArray("arr").ToJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, `["Y","X"]`, string(got), "push after a tombstoned tail must match Yjs ordering")
+
+			// Control: F left live. Both ygo and Yjs converge to ["Y","F","X"];
+			// this path already matched Yjs and must stay unchanged.
+			c3b, c1b, c2b := build(false, tc.apply, tc.encode)
+			mergedB := New(WithClientID(9))
+			require.NoError(t, tc.apply(mergedB, tc.encode(c3b)))
+			require.NoError(t, tc.apply(mergedB, tc.encode(c1b)))
+			require.NoError(t, tc.apply(mergedB, tc.encode(c2b)))
+			gotB, err := mergedB.GetArray("arr").ToJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, `["Y","F","X"]`, string(gotB), "control (F live) must be unchanged")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a ygo↔Yjs convergence divergence ([#158](https://github.com/reearth/ygo/issues/158)) found by the #70 cross-implementation convergence fuzzer, which replays randomized scenarios against **live Yjs 13.6.30** and compares results.

`YArray.Push` delegated to `Insert(Len())`, which anchors the new element after the last **live** element (`leftNeighbourAt` skips tombstones). Yjs's `push` (`typeListPushGenerics`) anchors after the last **physical** item, tombstones included. When the array's tail was a deleted element the two produced different YATA anchors:

- ygo: `origin=nil, rightOrigin=<tombstone>` (element lands left of the tombstone)
- Yjs: `origin=<tombstone>, rightOrigin=null` (element lands right of the tombstone)

Both give the same single-document result, but a ygo peer and a Yjs peer that both `push` concurrently onto such an array order the merged result differently.

## Fix

`Push` now walks past trailing tombstones to the physical tail before anchoring, matching Yjs. The common case (no trailing tombstones) is unchanged and still uses the pos-cached fast path. `Insert` at an explicit index is untouched — it already matched Yjs's `insert`. The shared item construction is extracted into `insertAfterItem`, so `Insert` and `Push` now differ only in how the left anchor is chosen.

## Verification

- New harness-free regression `TestYArrayPush_TombstonedTail_MatchesYjs` over both the V1 and V2 wire paths — RED before (`["X","Y"]`), GREEN after (`["Y","X"]`, matching Yjs). Includes a control (tail left live) that must stay `["Y","F","X"]`.
- Full `crdt` suite under `-race` passes, including the Go↔JS round-trip conformance tests.
- In the #70 cross-impl oracle, wiring the fuzzer to call the fixed `Push` drops the failing-seed count from 118 to 49 (the remainder is a separate, unrelated text-interleaving class, tracked separately).
- `go vet` + `golangci-lint` clean.

## Compatibility

No API changes. `Push`'s single-document behaviour (append at the end) is unchanged; only the cross-peer merge ordering changes, toward the Yjs-correct result. Patch release (`v1.31.5`). CHANGELOG + RELEASE_NOTES finalized in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)