### PR TITLE
fix(crdt): text tombstone anchoring + firstLive/pos cache invalidation (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.6] — 2026-07-13
+
+CRDT convergence + correctness patch. No API changes. Found by ygo's
+cross-implementation convergence fuzzer (#70), which compares ygo's public API
+against live Yjs. Three related, tombstone-triggered fixes
+([#160](https://github.com/reearth/ygo/issues/160)).
+
+### Fixed
+
+- **`YText.Insert` anchored a run before an adjacent tombstone, diverging from
+  Yjs (the text-path mirror of #158).** `Insert`/`InsertEmbed` anchored a new
+  run relative to the last **live** item, leaving `originRight` pointing at an
+  adjacent tombstone, so the run landed *before* it. Yjs's text path advances
+  its cursor past deleted items before anchoring, landing *after* them; two
+  peers inserting next to the same tombstone therefore ordered their runs
+  differently. `Insert`/`InsertEmbed` now advance the anchor past adjacent
+  deleted items. (Only text was affected — Yjs's array path doesn't skip
+  tombstones, so arrays/maps/XML already converged.)
+- **Stale `firstLiveCache` after inserting past leading tombstones.** Inserting
+  a live run after leading tombstones made it the first live item without it
+  becoming the list head, so the only insert-time `firstLiveCache` invalidation
+  (the new-head branch) never fired. A later `Delete` then walked from a stale
+  cached head and tombstoned the wrong indices (it could silently no-op).
+  `integrate` now also invalidates when a live item lands after a deleted left
+  neighbour. (Exposed by the fix above.)
+- **Stale `posCache` after a remote delete-only apply (pre-existing).** Remote
+  applies run with `Local==true`, so `item.delete`'s position-cache
+  invalidation was skipped and the remote delete-set path never cleared it. A
+  remote update that only tombstoned an item left cached `(index → item)`
+  entries for still-live items after it with an index that was too high, so the
+  next local positioned insert resolved the wrong neighbour. The remote
+  delete-set path now invalidates the position cache after deleting a countable
+  item.
+
 ## [1.31.5] — 2026-07-13
 
 CRDT convergence patch. No API changes. Found by ygo's cross-implementation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,27 +1,34 @@
-## v1.31.5
+## v1.31.6
 
-A CRDT convergence patch. No API changes. Found by ygo's cross-implementation
-convergence fuzzer (#70), which replays randomized scenarios against live Yjs
-and compares the results. Recommended for anyone whose Go peers push into arrays
-that are also edited (and deleted from) by Yjs peers.
+A CRDT convergence + correctness patch. No API changes. Found by ygo's
+cross-implementation convergence fuzzer (#70), which replays randomized
+scenarios against live Yjs and compares the results. Three related,
+tombstone-triggered fixes ([#160](https://github.com/reearth/ygo/issues/160)).
+Recommended for anyone editing text (or arrays) that also gets deletions.
 
 ### Fixed
 
-- **`YArray.Push` diverged from Yjs's `push` when the array's tail was a
-  tombstone ([#158](https://github.com/reearth/ygo/issues/158)).** `Push`
-  delegated to `Insert(Len())`, which anchors the new element after the last
-  **live** element (the live-index walk skips tombstones). Yjs's `push` anchors
-  after the last **physical** item, tombstones included. When the tail was a
-  deleted element the two produced different YATA anchors, so a ygo peer and a
-  Yjs peer that both pushed concurrently onto such an array ordered the merged
-  result differently. `Push` now appends after the physical tail, matching Yjs.
-  `Insert` at an explicit index is unchanged — it already matched Yjs's
-  `insert`.
+- **`YText.Insert` anchored a run before an adjacent tombstone, diverging from
+  Yjs (text-path mirror of #158).** It anchored relative to the last **live**
+  item (leaving `originRight` pointing at a tombstone) and landed *before* the
+  tombstone; Yjs advances past deleted items and lands *after*. Two peers
+  inserting next to the same tombstone then ordered their runs differently.
+  `Insert`/`InsertEmbed` now advance the anchor past adjacent deleted items.
+  Only text was affected; arrays/maps/XML already converged.
+- **Stale `firstLiveCache` after inserting past leading tombstones.** A live run
+  inserted after leading tombstones became the first live item without becoming
+  the list head, so the cache was never invalidated and a later `Delete` walked
+  a stale head and removed the wrong indices (it could silently no-op). Now
+  invalidated when a live item lands after a deleted left neighbour.
+- **Stale `posCache` after a remote delete-only apply (pre-existing).** A remote
+  update that only tombstoned an item left the position cache stale, so the next
+  local positioned insert resolved the wrong neighbour. The remote delete-set
+  path now invalidates the position cache after deleting a countable item.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.5
+go get github.com/reearth/ygo@v1.31.6
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.

--- a/crdt/cache_invalidation_test.go
+++ b/crdt/cache_invalidation_test.go
@@ -1,0 +1,88 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFirstLiveCache_StaleAfterInsertAfterTombstone is #70 residual class 1.
+//
+// Inserting after leading tombstones (the anchor the YText tombstone-skip fix
+// produces) makes a new live run that is NOT the list head, so item.integrate's
+// new-head branch — the only place firstLiveCache is invalidated on insert —
+// never fires. deleteRange then walks from a stale firstLiveFromStart and
+// deletes the wrong indices. Here the final Delete(2,2) silently no-ops
+// (leaving "edfbγ") instead of removing "fb" (→ "edγ").
+func TestFirstLiveCache_StaleAfterInsertAfterTombstone(t *testing.T) {
+	c2 := New(WithClientID(2))
+	t2 := c2.GetText("t")
+	c2.Transact(func(txn *Transaction) { t2.Insert(txn, 0, "dd", nil) }) // "dd"
+	c2.Transact(func(txn *Transaction) { t2.Delete(txn, 0, 2) })         // "" — two leading tombstones
+
+	// Remote "γ本δ" from another client.
+	c4 := New(WithClientID(4))
+	t4 := c4.GetText("t")
+	c4.Transact(func(txn *Transaction) { t4.Insert(txn, 0, "γ本δ", nil) })
+	require.NoError(t, ApplyUpdateV1(c2, EncodeStateAsUpdateV1(c4, nil), nil))
+	require.Equal(t, "γ本δ", mustText(t, c2, "t"))
+
+	c2.Transact(func(txn *Transaction) { t2.Delete(txn, 1, 2) })           // "γ"
+	c2.Transact(func(txn *Transaction) { t2.Insert(txn, 0, "edfb", nil) }) // "edfbγ"
+	c2.Transact(func(txn *Transaction) { t2.Delete(txn, 2, 2) })           // remove "fb" -> "edγ"
+
+	require.Equal(t, "edγ", mustText(t, c2, "t"),
+		"Delete after insert-past-tombstone must use the live head, not a stale firstLiveCache")
+}
+
+// TestPosCache_StaleAfterRemoteDeleteOnlyApply is #70 residual class 2 — a
+// pre-existing bug independent of the YText fix.
+//
+// transactInternal hardcodes txn.Local=true even for ApplyUpdate, so
+// item.delete's posCache-clearing branch (`if !txn.Local`) is dead during
+// remote applies, and applyToPartial never invalidates posCache. A remote
+// update that only tombstones an item leaves posCache stale, so the next local
+// positioned insert resolves the wrong neighbour.
+func TestPosCache_StaleAfterRemoteDeleteOnlyApply(t *testing.T) {
+	docA := New(WithClientID(1))
+	arrA := docA.GetArray("a")
+	docA.Transact(func(txn *Transaction) {
+		for _, v := range []any{"A", "B", "C", "D", "E"} {
+			arrA.Push(txn, []any{v})
+		}
+	})
+
+	docB := New(WithClientID(2))
+	require.NoError(t, ApplyUpdateV1(docB, EncodeStateAsUpdateV1(docA, nil), nil))
+	arrB := docB.GetArray("a")
+
+	// Populate docB's posCache with a positioned insert near the end, so live
+	// items AFTER the soon-deleted "B" (namely C@3, D@4) get cached. -> [A B C D X E]
+	docB.Transact(func(txn *Transaction) { arrB.Insert(txn, 4, []any{"X"}) })
+
+	// docA deletes "B"; ship ONLY that delete to docB. The cached C/D entries
+	// stay LIVE but their cumulative index is now off by one.
+	var delUpdate []byte
+	docA.OnUpdate(func(u []byte, _ any) { delUpdate = u })
+	docA.Transact(func(txn *Transaction) { arrA.Delete(txn, 1, 1) })
+	require.NoError(t, ApplyUpdateV1(docB, delUpdate, nil)) // docB live: [A C D X E]
+
+	// Positioned insert; must land at live index 3 (before X) -> [A C D Y X E].
+	docB.Transact(func(txn *Transaction) { arrB.Insert(txn, 3, []any{"Y"}) })
+
+	got, err := arrB.ToJSON()
+	require.NoError(t, err)
+	require.JSONEq(t, `["A","C","D","Y","X","E"]`, string(got),
+		"positioned insert after a remote delete-only apply must not use a stale posCache")
+}
+
+func mustText(t *testing.T, d *Doc, name string) string {
+	b, err := d.GetText(name).ToJSON()
+	require.NoError(t, err)
+	// ToJSON returns a JSON-quoted string; strip the quotes.
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/crdt/delete_set.go
+++ b/crdt/delete_set.go
@@ -144,6 +144,16 @@ func (ds *DeleteSet) applyToPartial(txn *Transaction) DeleteSet {
 					end = itemEnd
 				}
 				item.delete(txn)
+				// Remote applies run with txn.Local==true (transactInternal
+				// hardcodes it), so item.delete's own posCache invalidation
+				// (guarded on !txn.Local) is dead here — and unlike local
+				// deleteRange, this path never cleared the cache. A stale
+				// posCache would then mis-resolve the next local positioned
+				// insert, since cached (index→item) entries for still-live items
+				// after the tombstone now carry an index that is too high (#160).
+				if item.Parent != nil && item.Content.IsCountable() {
+					item.Parent.invalidatePosCache()
+				}
 				applied = end - r.Clock
 			}
 			// Park the uncovered suffix of the range, if any.

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -183,6 +183,16 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 	} else {
 		item.Right = left.Right
 		left.Right = item
+		// Inserting a live item immediately after a deleted left neighbour can
+		// make it the first live item from t.start (or place it before the
+		// cached one) WITHOUT it becoming the list head — so the new-head branch
+		// above didn't fire. Invalidate firstLiveCache so firstLiveFromStart
+		// re-walks; otherwise deleteRange would start from a stale head and
+		// tombstone the wrong indices (#160). O(1); over-invalidation is safe
+		// (the cache self-heals on the next forward walk).
+		if left.Deleted {
+			item.Parent.invalidateFirstLiveCache()
+		}
 	}
 	// Back-pointer: if our right neighbour exists, point it back to us.
 	if item.Right != nil {

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -268,6 +268,8 @@ func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attribu
 		splitItem(txn, left, offset)
 		// left is now the left half; left.Right is the right half.
 	}
+	// Anchor after any adjacent tombstones (Yjs text-insert parity, #160).
+	left = t.skipDeletedForTextAnchor(left)
 
 	// Fast path: when caller passed nil/empty attrs, there's nothing to diff,
 	// no markers to emit, and the new text inherits surrounding formatting
@@ -462,6 +464,8 @@ func (txt *YText) InsertEmbed(txn *Transaction, index int, embed any, attrs Attr
 	if offset > 0 {
 		splitItem(txn, left, offset)
 	}
+	// Anchor after any adjacent tombstones (Yjs text-insert parity, #160).
+	left = t.skipDeletedForTextAnchor(left)
 
 	var origin *ID
 	var originRight *ID
@@ -804,6 +808,33 @@ func updateAttr(attrs Attributes, cf *ContentFormat) {
 	} else {
 		attrs[cf.Key] = cf.Val
 	}
+}
+
+// skipDeletedForTextAnchor advances a text/embed insert's left anchor past any
+// adjacent deleted items, so the new run is placed AFTER tombstoned content —
+// matching Yjs, whose text insert advances its cursor past deleted items before
+// anchoring (minimizeAttributeChanges). Without this, originRight would point at
+// a tombstone and a run inserted next to it would anchor BEFORE it; two peers
+// inserting next to the same tombstone would then order their runs differently
+// (a convergence divergence, the text-path mirror of the array Push fix). left
+// is the live neighbour from leftNeighbourAt (nil = document head); the returned
+// anchor is the last adjacent tombstone (or the original left when none).
+//
+// Only deleted items are skipped — not live ContentFormat markers. Yjs's full
+// minimizeAttributeChanges also skips redundant matching markers, but that
+// affects only concurrent *formatted*-text edits (not exercised here) and would
+// entangle the attribute-diff logic; the tombstone skip alone is what the
+// convergence bug requires.
+func (t *abstractType) skipDeletedForTextAnchor(left *Item) *Item {
+	next := t.start
+	if left != nil {
+		next = left.Right
+	}
+	for next != nil && next.Deleted {
+		left = next
+		next = next.Right
+	}
+	return left
 }
 
 // findTextPos returns a cursor at logical position index, splitting the

--- a/crdt/ytext_insert_tombstone_test.go
+++ b/crdt/ytext_insert_tombstone_test.go
@@ -1,0 +1,63 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestYText_InsertAdjacentTombstone_MatchesYjs is a #70 cross-impl regression
+// (the text-path mirror of the array Push fix #158).
+//
+// YText.Insert anchored a new run relative to the last LIVE item, leaving
+// originRight pointing AT an adjacent tombstone — so the run landed BEFORE the
+// tombstone. Yjs's text insert advances its cursor PAST deleted items before
+// anchoring (minimizeAttributeChanges), so the run lands AFTER them
+// (origin=tombstone, rightOrigin=next-live). When two peers concurrently insert
+// next to the same tombstone the two anchorings order the runs differently.
+//
+// Scenario (verified out-of-band against Yjs 13.6.30): peer0 (client1) inserts
+// "語"; peer3 (client4) receives it, deletes it (tombstone), inserts "fcd" at 0;
+// peer0 concurrently inserts "bba" after "語"; merge. Both anchor origin="語",
+// so it is a same-origin conflict resolved by clientID (1<4): "bbafcd". Before
+// the fix ygo produced "fcdbba".
+func TestYText_InsertAdjacentTombstone_MatchesYjs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		encode func(*Doc) []byte
+		apply  func(*Doc, []byte) error
+	}{
+		{"V1",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV1(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV1(d, u, nil) }},
+		{"V2",
+			func(d *Doc) []byte { return EncodeStateAsUpdateV2(d, nil) },
+			func(d *Doc, u []byte) error { return ApplyUpdateV2(d, u, nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// peer0 inserts "語".
+			c0 := New(WithClientID(1))
+			t0 := c0.GetText("t")
+			c0.Transact(func(txn *Transaction) { t0.Insert(txn, 0, "語", nil) })
+
+			// peer3 receives it, deletes it (tombstone), inserts "fcd" at 0.
+			c3 := New(WithClientID(4))
+			require.NoError(t, tc.apply(c3, tc.encode(c0)))
+			t3 := c3.GetText("t")
+			c3.Transact(func(txn *Transaction) { t3.Delete(txn, 0, 1) })
+			c3.Transact(func(txn *Transaction) { t3.Insert(txn, 0, "fcd", nil) })
+
+			// peer0 concurrently inserts "bba" after "語".
+			c0.Transact(func(txn *Transaction) { t0.Insert(txn, 1, "bba", nil) })
+
+			// Merge both onto a fresh peer.
+			m := New(WithClientID(9))
+			require.NoError(t, tc.apply(m, tc.encode(c0)))
+			require.NoError(t, tc.apply(m, tc.encode(c3)))
+			got, err := m.GetText("t").ToJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, `"bbafcd"`, string(got),
+				"text run inserted next to a tombstone must match Yjs ordering")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three related, tombstone-triggered fixes ([#160](https://github.com/reearth/ygo/issues/160)) found by the #70 cross-implementation convergence fuzzer, which replays randomized scenarios against **live Yjs 13.6.30** and compares results.

1. **`YText.Insert`/`InsertEmbed` anchored before an adjacent tombstone** (text-path mirror of #158). They anchored relative to the last **live** item, leaving `originRight` pointing at a tombstone → the run landed *before* it. Yjs advances past deleted items and lands *after*. Two peers inserting next to the same tombstone then ordered their runs differently. Fixed via `skipDeletedForTextAnchor`. Only text was affected (Yjs's array path also doesn't skip tombstones, so arrays/maps/XML already converged).

2. **Stale `firstLiveCache` after inserting past leading tombstones** (exposed by fix 1). A live run inserted after leading tombstones becomes the first live item without becoming the list head, so `integrate`'s new-head branch — the only insert-time invalidation — never fired, and `deleteRange` walked a stale head (a `Delete` could silently no-op). `integrate` now also invalidates when a live item lands after a deleted left neighbour.

3. **Stale `posCache` after a remote delete-only apply** (pre-existing, independent). Remote applies run with `Local==true`, so `item.delete`'s position-cache invalidation was dead and `applyToPartial` never cleared it. A remote update that only tombstoned an item left cached `(index → item)` entries for still-live items after it with an index too high, mis-resolving the next local positioned insert. `applyToPartial` now invalidates `posCache` after deleting a countable item.

## Verification

- Harness-free regressions, all RED→GREEN: `TestYText_InsertAdjacentTombstone_MatchesYjs`, `TestFirstLiveCache_StaleAfterInsertAfterTombstone`, `TestPosCache_StaleAfterRemoteDeleteOnlyApply`.
- Full `crdt` suite under `-race` passes, including all formatting/attribute tests and Go↔JS conformance.
- With all three fixes, the #70 cross-impl oracle converges with Yjs on seeds 0..599 (was 118 failing before fix 1, 49 after fix 1, 0 after fixes 2+3).
- `go vet` + `golangci-lint` clean.

## Compatibility

No API changes. Single-document behaviour is unchanged; only cross-peer merge ordering (toward the Yjs-correct result) and the two cache-correctness paths change. Patch release (`v1.31.6`). CHANGELOG + RELEASE_NOTES finalized in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)