### PR TITLE
test(fuzz): randomized convergence fuzz framework + live Yjs cross-impl oracle (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - run: go mod download
       - run: go mod verify
       - run: go vet ./...
+      # `./...` includes the #70 convergence fuzzer: TestFuzzConvergence (1000
+      # seeds, Go-vs-Go), TestFuzzCorpus (frozen reproducers), and
+      # TestFuzzCrossImpl (vs real Yjs — runs here because `npm ci` above
+      # installs yjs; it self-skips only when node/yjs are absent).
       - run: go test -race -timeout 120s -coverprofile=coverage.txt -covermode=atomic ./...
       - name: CGo-free build (pure Go)
         run: CGO_ENABLED=0 go build ./persistence/sqlite/... ./cmd/ygo-server/... ./mobile/...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Randomized convergence fuzz framework
+  ([#70](https://github.com/reearth/ygo/issues/70)).** `testutil/fuzz`
+  generates seed-reproducible multi-peer scenarios (random ops across
+  Text/Array/Map/XML, nested containers, delivery via Apply/Merge/Diff on V1 and
+  V2, plus GC), asserts all ygo peers converge, and — when Node + `yjs` are
+  present — checks ygo against real Yjs both logically and by round-trip
+  (`TestFuzzCrossImpl`). Failures print a seed (`FUZZ_SEED=<n>` to replay) and
+  shrink to a minimal scenario (`fuzz.Shrink`); a regression corpus
+  (`testutil/fuzz/corpus`) locks in known cases. CI runs a fixed 1,000-seed set;
+  `FUZZ_ITER=50000` drives heavier local soak runs. This framework found the
+  YArray.Push (#158) and YText tombstone-anchoring + cache-invalidation (#160)
+  divergences fixed in v1.31.5 and v1.31.6.
+
 ## [1.31.6] — 2026-07-13
 
 CRDT convergence + correctness patch. No API changes. Found by ygo's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,3 +188,21 @@ Before opening a PR ensure:
 - [ ] Wire-format changes regenerate fixtures (`make fixtures`) and update `TestCompat_` tests
 - [ ] Doc comments updated for any changed public API
 - [ ] PR description links the related issue (`Closes #NNN`)
+
+## Reproducing a convergence fuzz failure (#70)
+
+`testutil/fuzz` runs a randomized, seed-reproducible convergence fuzzer as part
+of `go test ./...` (see `crdt/fuzz_test.go`). On failure it prints a seed. To
+replay that one scenario:
+
+    FUZZ_SEED=<seed> go test ./crdt/ -run TestFuzzSeed -v
+
+To explore more of the space locally (nightly-style), raise the iteration count:
+
+    FUZZ_ITER=50000 go test ./crdt/ -run TestFuzzConvergence -timeout 30m
+
+`TestFuzzCrossImpl` additionally replays each scenario against real Yjs and
+compares the results; it needs Node + `yjs` (`cd testutil && npm ci`) and skips
+automatically when they are absent. A minimized failing scenario (from
+`fuzz.Shrink`) should be saved as a JSON file under `testutil/fuzz/corpus/` so
+it is replayed on every run.

--- a/crdt/fuzz_test.go
+++ b/crdt/fuzz_test.go
@@ -18,3 +18,24 @@ func TestFuzzConvergence(t *testing.T) {
 		}
 	}
 }
+
+// TestFuzzCrossImpl replays each scenario against real Yjs (node) and asserts
+// ygo's own replay matches Yjs both logically (per-peer ToJSON/ToXML) and by
+// round-trip (a fresh ygo doc that decodes Yjs's encoded update must produce
+// the same logical view). Catches "ygo is self-consistent but disagrees with
+// Yjs" bugs the Go-vs-Go Converged oracle cannot. Skips when node/yjs absent.
+func TestFuzzCrossImpl(t *testing.T) {
+	var scen []fuzz.Scenario
+	for seed := uint64(0); seed < 200; seed++ {
+		scen = append(scen, fuzz.Generate(seed))
+	}
+	results, ok := fuzz.RunNode(scen)
+	if !ok {
+		t.Skip("node/yjs unavailable — skipping cross-impl oracle")
+	}
+	for i, s := range scen {
+		if err := fuzz.CrossImplEqual(s, results[i]); err != nil {
+			t.Fatalf("seed %d: %v (reproduce: FUZZ_SEED=%d)", s.Seed, err, s.Seed)
+		}
+	}
+}

--- a/crdt/fuzz_test.go
+++ b/crdt/fuzz_test.go
@@ -1,0 +1,20 @@
+package crdt_test
+
+import (
+	"testing"
+
+	"github.com/reearth/ygo/testutil/fuzz"
+)
+
+// TestFuzzConvergence runs the fixed CI seed set; deterministic, no node.
+func TestFuzzConvergence(t *testing.T) {
+	for seed := uint64(0); seed < 1000; seed++ {
+		peers, err := fuzz.RunGo(fuzz.Generate(seed))
+		if err != nil {
+			t.Fatalf("seed %d: %v", seed, err)
+		}
+		if err := fuzz.Converged(peers); err != nil {
+			t.Fatalf("seed %d: %v (reproduce: FUZZ_SEED=%d)", seed, err, seed)
+		}
+	}
+}

--- a/crdt/fuzz_test.go
+++ b/crdt/fuzz_test.go
@@ -1,17 +1,33 @@
 package crdt_test
 
 import (
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/reearth/ygo/testutil/fuzz"
 )
 
+// fuzzIter is the number of seeds TestFuzzConvergence sweeps. Defaults to 1000
+// (the CI set); override for a heavy soak run, e.g.
+//
+//	FUZZ_ITER=50000 go test ./crdt/ -run TestFuzzConvergence -timeout 30m
+func fuzzIter() uint64 {
+	if v := os.Getenv("FUZZ_ITER"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 1000
+}
+
 // TestFuzzConvergence runs the fixed CI seed set; deterministic, no node.
 func TestFuzzConvergence(t *testing.T) {
-	for seed := uint64(0); seed < 1000; seed++ {
+	n := fuzzIter()
+	for seed := uint64(0); seed < n; seed++ {
 		peers, err := fuzz.RunGo(fuzz.Generate(seed))
 		if err != nil {
-			t.Fatalf("seed %d: %v", seed, err)
+			t.Fatalf("seed %d: %v (reproduce: FUZZ_SEED=%d)", seed, err, seed)
 		}
 		if err := fuzz.Converged(peers); err != nil {
 			t.Fatalf("seed %d: %v (reproduce: FUZZ_SEED=%d)", seed, err, seed)
@@ -37,5 +53,46 @@ func TestFuzzCrossImpl(t *testing.T) {
 		if err := fuzz.CrossImplEqual(s, results[i]); err != nil {
 			t.Fatalf("seed %d: %v (reproduce: FUZZ_SEED=%d)", s.Seed, err, s.Seed)
 		}
+	}
+}
+
+// TestFuzzCorpus replays every frozen scenario under testutil/fuzz/corpus,
+// each a minimized reproducer for a bug that once diverged. Node-free.
+func TestFuzzCorpus(t *testing.T) {
+	scen, err := fuzz.LoadCorpus("../testutil/fuzz/corpus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scen) == 0 {
+		t.Fatal("corpus is empty")
+	}
+	for _, s := range scen {
+		peers, err := fuzz.RunGo(s)
+		if err != nil {
+			t.Fatalf("corpus seed %d: %v", s.Seed, err)
+		}
+		if err := fuzz.Converged(peers); err != nil {
+			t.Fatalf("corpus seed %d: %v", s.Seed, err)
+		}
+	}
+}
+
+// TestFuzzSeed replays a single generated scenario for debugging. Set
+// FUZZ_SEED=<n> (the value printed by a TestFuzzConvergence failure).
+func TestFuzzSeed(t *testing.T) {
+	sv := os.Getenv("FUZZ_SEED")
+	if sv == "" {
+		t.Skip("set FUZZ_SEED=<n> to replay one scenario")
+	}
+	n, err := strconv.ParseUint(sv, 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peers, err := fuzz.RunGo(fuzz.Generate(n))
+	if err != nil {
+		t.Fatalf("seed %d: %v", n, err)
+	}
+	if err := fuzz.Converged(peers); err != nil {
+		t.Fatalf("seed %d: %v", n, err)
 	}
 }

--- a/testutil/fuzz/corpus.go
+++ b/testutil/fuzz/corpus.go
@@ -1,0 +1,38 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// LoadCorpus reads every *.json scenario in dir (sorted by filename) into a
+// slice of Scenarios. Each corpus file is a frozen reproducer for a bug that
+// once diverged; the fuzz suite replays them as fast, node-free regressions.
+func LoadCorpus(dir string) ([]Scenario, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+	var out []Scenario
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		var s Scenario
+		if err := json.Unmarshal(b, &s); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/testutil/fuzz/corpus/README.md
+++ b/testutil/fuzz/corpus/README.md
@@ -1,0 +1,22 @@
+# Convergence fuzz corpus
+
+Each `*.json` file is a frozen fuzz `Scenario` (see `../op.go`) that once
+exposed a real convergence bug. `TestFuzzCorpus` (in `crdt/fuzz_test.go`)
+replays every file through `RunGo` + `Converged` on each run, so a regression
+in the same shape fails fast and node-free.
+
+**Do not delete entries.** Add new ones by saving the minimized output of
+`Shrink` (see `../shrink.go`) after a fuzzer or oracle failure.
+
+`TestFuzzCorpus` checks *internal* (ygo-vs-ygo) convergence. Cross-implementation
+(ygo-vs-Yjs) regressions are guarded separately by `TestFuzzCrossImpl` and by the
+hand-written regressions in `crdt/` (e.g. `TestYArrayPush_TombstonedTail_MatchesYjs`,
+`TestYText_InsertAdjacentTombstone_MatchesYjs`).
+
+## Entries
+
+- **`parent-by-id-mergev2.json`** — a low-client peer creates an XML `<div>`; a
+  high-client peer sets an attribute on it (a keyed child resolved by
+  parent-item-ID); delivery back uses `MergeV2`. Exercises the parent-by-ID
+  resolution + V2 merge path behind the rightOrigin / parent-by-ID convergence
+  work (#65, #68).

--- a/testutil/fuzz/corpus/parent-by-id-mergev2.json
+++ b/testutil/fuzz/corpus/parent-by-id-mergev2.json
@@ -1,0 +1,10 @@
+{
+  "seed": 900001,
+  "numPeers": 2,
+  "steps": [
+    {"kind":"op","peer":0,"root":"x","typeKind":"xmlfrag","op":"addchild","posHint":0,"childXml":"elem:div"},
+    {"kind":"sync","from":0,"to":1,"method":"applyv1"},
+    {"kind":"op","peer":1,"root":"x","typeKind":"xmlfrag","op":"setattr","key":"class","strVal":"hello","target":[0]},
+    {"kind":"sync","from":1,"to":0,"method":"mergev2"}
+  ]
+}

--- a/testutil/fuzz/generate.go
+++ b/testutil/fuzz/generate.go
@@ -16,7 +16,7 @@ func Generate(seed uint64) Scenario {
 		name string
 		kind TypeKind
 	}{
-		{"t", KindText}, {"a", KindArray}, {"m", KindMap},
+		{"t", KindText}, {"a", KindArray}, {"m", KindMap}, {"x", KindXmlFragment},
 	}
 	s := Scenario{Seed: seed, NumPeers: numPeers}
 	for i := 0; i < numSteps; i++ {
@@ -67,8 +67,43 @@ func genLocalOp(r *rand.Rand, n int, root string, kind TypeKind) Step {
 		} else {
 			st.Op, st.Key = OpDelKey, randKey(r)
 		}
+	case KindXmlFragment:
+		genXmlOp(r, &st)
 	}
 	return st
+}
+
+var xmlTags = []string{"div", "p", "span"}
+var xmlAttrKeys = []string{"class", "id", "style"}
+
+// genXmlOp populates an XML op on st: insert an element/text child, delete a
+// child, or set/delete an attribute on a (possibly nested, up to depth 3)
+// element addressed by Target.
+func genXmlOp(r *rand.Rand, st *Step) {
+	switch pct := r.Intn(100); {
+	case pct < 50: // 50%: add child (element or text)
+		st.Op, st.PosHint = OpAddChild, r.Intn(20)
+		if r.Intn(3) == 0 {
+			st.ChildXml = "text"
+		} else {
+			st.ChildXml = "elem:" + xmlTags[r.Intn(len(xmlTags))]
+		}
+	case pct < 70: // 20%: delete a child
+		st.Op, st.PosHint = OpDelete, r.Intn(20)
+	default: // 30%: set/del attribute on a nested element (Target path)
+		if r.Intn(5) == 0 {
+			st.Op = OpDelAttr
+		} else {
+			st.Op = OpSetAttr
+			st.StrVal = randRunes(r, "abcXYZ-", 1+r.Intn(6))
+		}
+		st.Key = xmlAttrKeys[r.Intn(len(xmlAttrKeys))]
+		depth := r.Intn(4) // 0..3
+		st.Target = make([]int, depth)
+		for i := range st.Target {
+			st.Target[i] = r.Intn(20)
+		}
+	}
 }
 
 func randRunes(r *rand.Rand, alphabet string, n int) string {

--- a/testutil/fuzz/generate.go
+++ b/testutil/fuzz/generate.go
@@ -1,0 +1,102 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"math/rand"
+)
+
+var textAlphabets = []string{"abcdef", "αβγδ日本語", "🙂🎉ABC"} // ascii, multi-byte, emoji
+
+// Generate builds a deterministic Scenario from seed.
+func Generate(seed uint64) Scenario {
+	r := rand.New(rand.NewSource(int64(seed))) //nolint:gosec // deterministic fuzz seed, not crypto
+	numPeers := 3 + r.Intn(3)                  // 3..5
+	numSteps := 60 + r.Intn(141)               // 60..200
+	roots := []struct {
+		name string
+		kind TypeKind
+	}{
+		{"t", KindText}, {"a", KindArray}, {"m", KindMap},
+	}
+	s := Scenario{Seed: seed, NumPeers: numPeers}
+	for i := 0; i < numSteps; i++ {
+		switch {
+		case r.Intn(100) < 15: // 15% sync
+			s.Steps = append(s.Steps, genSync(r, numPeers))
+		case r.Intn(100) < 5: // ~4% GC
+			s.Steps = append(s.Steps, Step{Kind: StepGC, Peer: r.Intn(numPeers)})
+		default:
+			root := roots[r.Intn(len(roots))]
+			s.Steps = append(s.Steps, genLocalOp(r, numPeers, root.name, root.kind))
+		}
+	}
+	return s
+}
+
+func genSync(r *rand.Rand, n int) Step {
+	from := r.Intn(n)
+	to := (from + 1 + r.Intn(n-1)) % n // distinct peer
+	// Biased: 60% merge/diff, 40% apply.
+	methods := []SyncMethod{MergeV1, MergeV2, DiffV1, DiffV2, MergeV1, MergeV2, ApplyV1, ApplyV2, ApplyV1, ApplyV2}
+	return Step{Kind: StepSync, From: from, To: to, Method: methods[r.Intn(len(methods))]}
+}
+
+func genLocalOp(r *rand.Rand, n int, root string, kind TypeKind) Step {
+	st := Step{Kind: StepLocalOp, Peer: r.Intn(n), Root: root, TypeKind: kind}
+	switch kind {
+	case KindText:
+		if r.Intn(100) < 70 {
+			st.Op, st.PosHint = OpInsert, r.Intn(50)
+			ab := textAlphabets[r.Intn(len(textAlphabets))]
+			st.StrVal = randRunes(r, ab, 1+r.Intn(5))
+		} else {
+			st.Op, st.PosHint, st.LenHint = OpDelete, r.Intn(50), 1+r.Intn(3)
+		}
+	case KindArray:
+		switch r.Intn(3) {
+		case 0:
+			st.Op, st.PosHint, st.JSONVal = OpInsert, r.Intn(50), randScalarJSON(r)
+		case 1:
+			st.Op, st.JSONVal = OpPush, randScalarJSON(r)
+		default:
+			st.Op, st.PosHint, st.LenHint = OpDelete, r.Intn(50), 1+r.Intn(3)
+		}
+	case KindMap:
+		if r.Intn(100) < 70 {
+			st.Op, st.Key, st.JSONVal = OpSetKey, randKey(r), randScalarJSON(r)
+		} else {
+			st.Op, st.Key = OpDelKey, randKey(r)
+		}
+	}
+	return st
+}
+
+func randRunes(r *rand.Rand, alphabet string, n int) string {
+	rs := []rune(alphabet)
+	out := make([]rune, n)
+	for i := range out {
+		out[i] = rs[r.Intn(len(rs))]
+	}
+	return string(out)
+}
+
+func randKey(r *rand.Rand) string {
+	keys := []string{"k0", "k1", "k2", "k3"} // small keyspace → forces set/delete conflicts
+	return keys[r.Intn(len(keys))]
+}
+
+func randScalarJSON(r *rand.Rand) string {
+	var v any
+	switch r.Intn(4) {
+	case 0:
+		v = r.Intn(1000)
+	case 1:
+		v = r.Float64()
+	case 2:
+		v = r.Intn(2) == 1
+	default:
+		v = randRunes(r, "abcXYZ", 1+r.Intn(4))
+	}
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/testutil/fuzz/generate_test.go
+++ b/testutil/fuzz/generate_test.go
@@ -1,0 +1,43 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGenerate_Deterministic(t *testing.T) {
+	a := Generate(12345)
+	b := Generate(12345)
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	if string(ab) != string(bb) {
+		t.Fatal("same seed must produce identical scenario")
+	}
+	if Generate(1).Seed != 1 || Generate(1).NumPeers < 3 || Generate(1).NumPeers > 5 {
+		t.Fatalf("bad peers: %d", Generate(1).NumPeers)
+	}
+	if len(a.Steps) < 60 {
+		t.Fatalf("too few steps: %d", len(a.Steps))
+	}
+}
+
+func TestGenerate_MergeBias(t *testing.T) {
+	// Across many seeds, Merge/Diff sync methods should dominate Apply.
+	var merge, apply int
+	for s := uint64(0); s < 50; s++ {
+		for _, st := range Generate(s).Steps {
+			if st.Kind != StepSync {
+				continue
+			}
+			switch st.Method {
+			case MergeV1, MergeV2, DiffV1, DiffV2:
+				merge++
+			case ApplyV1, ApplyV2:
+				apply++
+			}
+		}
+	}
+	if merge <= apply {
+		t.Fatalf("expected merge/diff bias, got merge=%d apply=%d", merge, apply)
+	}
+}

--- a/testutil/fuzz/interpret.go
+++ b/testutil/fuzz/interpret.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sort"
 
 	"github.com/reearth/ygo/crdt"
 )
@@ -77,7 +76,7 @@ func applyLocalOp(p *peerState, st Step) {
 			case OpInsert:
 				arr.Insert(txn, clampIndex(st.PosHint, arr.Len(), true), []any{decodeScalar(st.JSONVal)})
 			case OpPush:
-				arr.Insert(txn, arr.Len(), []any{decodeScalar(st.JSONVal)})
+				arr.Push(txn, []any{decodeScalar(st.JSONVal)})
 			case OpDelete:
 				if arr.Len() > 0 {
 					arr.Delete(txn, clampIndex(st.PosHint, arr.Len(), false), minInt(st.LenHint, arr.Len()))
@@ -164,35 +163,6 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
-}
-
-// rootsOf returns the (name, kind) roots a scenario touches, sorted by name.
-func rootsOf(s Scenario) []struct {
-	name string
-	kind TypeKind
-} {
-	seen := map[string]TypeKind{}
-	for _, st := range s.Steps {
-		if st.Kind == StepLocalOp {
-			seen[st.Root] = st.TypeKind
-		}
-	}
-	names := make([]string, 0, len(seen))
-	for n := range seen {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	out := make([]struct {
-		name string
-		kind TypeKind
-	}, len(names))
-	for i, n := range names {
-		out[i] = struct {
-			name string
-			kind TypeKind
-		}{n, seen[n]}
-	}
-	return out
 }
 
 // RunGo builds NumPeers peers, replays every step of the scenario against

--- a/testutil/fuzz/interpret.go
+++ b/testutil/fuzz/interpret.go
@@ -2,13 +2,27 @@ package fuzz
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
 
 	"github.com/reearth/ygo/crdt"
 )
 
 type peerState struct {
-	doc   *crdt.Doc
-	inbox [][]byte
+	doc *crdt.Doc
+	// inboxV1/inboxV2 stage Diff*-produced update bytes until a Merge* step
+	// (or final drain) folds them into doc. Kept as two separate queues
+	// because V1 and V2 are distinct, non-interchangeable wire encodings: a
+	// real transport tags each message with its encoding (or a peer pair
+	// negotiates one encoding up front), so a receiver never needs to guess.
+	// A single untyped queue would let a DiffV2 blob and a MergeV1 step land
+	// in the same MergeUpdatesV1 call, corrupting the byte stream — this bit
+	// the first implementation (see interpret_test.go's TestApplySync_
+	// DoesNotMixV1AndV2Inboxes, added after triaging that exact crash on
+	// fuzz seed 0).
+	inboxV1 [][]byte
+	inboxV2 [][]byte
 }
 
 func newPeers(n int) []*peerState {
@@ -88,4 +102,232 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// rootsOf returns the (name, kind) roots a scenario touches, sorted by name.
+func rootsOf(s Scenario) []struct {
+	name string
+	kind TypeKind
+} {
+	seen := map[string]TypeKind{}
+	for _, st := range s.Steps {
+		if st.Kind == StepLocalOp {
+			seen[st.Root] = st.TypeKind
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]struct {
+		name string
+		kind TypeKind
+	}, len(names))
+	for i, n := range names {
+		out[i] = struct {
+			name string
+			kind TypeKind
+		}{n, seen[n]}
+	}
+	return out
+}
+
+// RunGo builds NumPeers peers, replays every step of the scenario against
+// them, drains any pending inbox updates (from Diff/Merge sync steps), forces
+// a final full-mesh sync, and returns the resulting peers for convergence
+// checking.
+func RunGo(s Scenario) ([]*peerState, error) {
+	peers := newPeers(s.NumPeers)
+	for _, st := range s.Steps {
+		switch st.Kind {
+		case StepLocalOp:
+			applyLocalOp(peers[st.Peer%s.NumPeers], st)
+		case StepSync:
+			if err := applySync(peers, st, s.NumPeers); err != nil {
+				return nil, err
+			}
+		case StepGC:
+			// GC is triggered by re-encoding; ygo auto-GCs at commit. A no-op
+			// local transaction forces a commit pass. (If a public GC() exists,
+			// call it here instead — grep crdt for "func (d *Doc) GC".)
+			peers[st.Peer%s.NumPeers].doc.Transact(func(*crdt.Transaction) {})
+		}
+	}
+	if err := drainInboxes(peers); err != nil {
+		return nil, err
+	}
+	if err := finalSync(peers); err != nil {
+		return nil, err
+	}
+	return peers, nil
+}
+
+// finalSync forces full transitive connectivity across every peer,
+// regardless of which sync edges the scenario's random walk happened to
+// exercise. Because Step.Kind==StepSync picks a random directed (from, to)
+// pair each time, a peer's local edit can easily go un-routed to some other
+// peer by the time the step list ends (observed on fuzz seed 0: peer 1's
+// step-116 array push never reached peer 0 because no sync edge — direct or
+// transitive — existed from peer 1 to peer 0 after that step). That is an
+// artifact of the random walk's connectivity, not a CRDT defect, and
+// asserting equality across a possibly-disconnected peer graph would make
+// Converged flag false positives unrelated to ygo's correctness.
+//
+// Mirrors Yjs's own fuzz-test harness, which reconnects and syncs every user
+// before comparing (see yjs/testHelper.js's compareUsers, always invoked
+// after a full reconnect). Each peer's complete since-genesis state is
+// merged into one update and applied to every peer, so whatever Converged
+// later compares reflects "did Merge/Apply/Diff compute the right result
+// once all information was exchanged" — the property this fuzzer exists to
+// check — rather than "did the random graph happen to be connected."
+func finalSync(peers []*peerState) error {
+	updates := make([][]byte, len(peers))
+	for i, p := range peers {
+		updates[i] = crdt.EncodeStateAsUpdateV1(p.doc, nil)
+	}
+	merged, err := crdt.MergeUpdatesV1(updates...)
+	if err != nil {
+		return err
+	}
+	for _, p := range peers {
+		if err := crdt.ApplyUpdateV1(p.doc, merged, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applySync drives one sync step across the from->to peer pair over the
+// wire path named by st.Method. Apply* steps sync immediately; Diff*/Merge*
+// steps stage the update in the destination's version-tagged inbox (drained
+// later by drainInboxes), modeling store-and-forward transports. DiffV1/
+// MergeV1 only ever touch inboxV1, and DiffV2/MergeV2 only ever touch
+// inboxV2 — V1 and V2 are distinct byte encodings, so entries must never be
+// merged or applied across the wrong decoder (see the peerState doc comment).
+func applySync(peers []*peerState, st Step, n int) error {
+	from, to := peers[st.From%n], peers[st.To%n]
+	switch st.Method {
+	case ApplyV1:
+		return crdt.ApplyUpdateV1(to.doc, crdt.EncodeStateAsUpdateV1(from.doc, to.doc.StateVector()), nil)
+	case ApplyV2:
+		return crdt.ApplyUpdateV2(to.doc, crdt.EncodeStateAsUpdateV2(from.doc, to.doc.StateVector()), nil)
+	case DiffV1:
+		u, err := crdt.DiffUpdateV1(crdt.EncodeStateAsUpdateV1(from.doc, nil), to.doc.StateVector())
+		if err != nil {
+			return err
+		}
+		to.inboxV1 = append(to.inboxV1, u)
+		return nil
+	case DiffV2:
+		u, err := crdt.DiffUpdateV2(crdt.EncodeStateAsUpdateV2(from.doc, nil), to.doc.StateVector())
+		if err != nil {
+			return err
+		}
+		to.inboxV2 = append(to.inboxV2, u)
+		return nil
+	case MergeV1:
+		to.inboxV1 = append(to.inboxV1, crdt.EncodeStateAsUpdateV1(from.doc, nil))
+		merged, err := crdt.MergeUpdatesV1(to.inboxV1...)
+		if err != nil {
+			return err
+		}
+		to.inboxV1 = nil
+		return crdt.ApplyUpdateV1(to.doc, merged, nil)
+	case MergeV2:
+		to.inboxV2 = append(to.inboxV2, crdt.EncodeStateAsUpdateV2(from.doc, nil))
+		merged, err := crdt.MergeUpdatesV2(to.inboxV2...)
+		if err != nil {
+			return err
+		}
+		to.inboxV2 = nil
+		return crdt.ApplyUpdateV2(to.doc, merged, nil)
+	}
+	return nil
+}
+
+// drainInboxes applies every pending update left in each peer's inboxes
+// after the step list has been replayed, so Diff-staged updates that were
+// never followed by another sync step still land before convergence is
+// checked. Each queue is drained through its own decoder — never guessed —
+// since a V1 blob fed to the V2 decoder (or vice versa) is a format error,
+// not a recoverable one.
+func drainInboxes(peers []*peerState) error {
+	for _, p := range peers {
+		for _, u := range p.inboxV1 {
+			if err := crdt.ApplyUpdateV1(p.doc, u, nil); err != nil {
+				return fmt.Errorf("drain v1: %w", err)
+			}
+		}
+		p.inboxV1 = nil
+		for _, u := range p.inboxV2 {
+			if err := crdt.ApplyUpdateV2(p.doc, u, nil); err != nil {
+				return fmt.Errorf("drain v2: %w", err)
+			}
+		}
+		p.inboxV2 = nil
+	}
+	return nil
+}
+
+// stateJSON normalizes peer p's state across roots into a JSON-comparable
+// map, keyed by root name.
+func stateJSON(p *peerState, roots []struct {
+	name string
+	kind TypeKind
+}) (map[string]any, error) {
+	out := map[string]any{}
+	for _, r := range roots {
+		var raw []byte
+		var err error
+		switch r.kind {
+		case KindText:
+			raw, err = p.doc.GetText(r.name).ToJSON()
+		case KindArray:
+			raw, err = p.doc.GetArray(r.name).ToJSON()
+		case KindMap:
+			raw, err = p.doc.GetMap(r.name).ToJSON()
+		case KindXmlFragment:
+			raw = []byte(fmt.Sprintf("%q", p.doc.GetXmlFragment(r.name).ToXML()))
+		}
+		if err != nil {
+			return nil, err
+		}
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, err
+		}
+		out[r.name] = v
+	}
+	return out, nil
+}
+
+// Converged asserts every peer holds structurally identical state across the
+// well-known roots the generator drives ("t"/"a"/"m"/"x"). Verified: YText/
+// YArray/YMap.ToJSON never error on an empty/untouched root — each is a bare
+// json.Marshal of ToString()/ToSlice()/Entries(), which give "", a non-nil
+// []any{}, and a non-nil map[string]any{} respectively, i.e. "", "[]", "{}" —
+// all valid JSON — and YXmlFragment.ToXML() returns "" for an empty fragment.
+func Converged(peers []*peerState) error {
+	if len(peers) < 2 {
+		return nil
+	}
+	roots := []struct {
+		name string
+		kind TypeKind
+	}{{"t", KindText}, {"a", KindArray}, {"m", KindMap}, {"x", KindXmlFragment}}
+	ref, err := stateJSON(peers[0], roots)
+	if err != nil {
+		return err
+	}
+	for i := 1; i < len(peers); i++ {
+		got, err := stateJSON(peers[i], roots)
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(ref, got) {
+			return fmt.Errorf("peer 0 vs peer %d diverged:\n 0=%v\n %d=%v", i, ref, i, got)
+		}
+	}
+	return nil
 }

--- a/testutil/fuzz/interpret.go
+++ b/testutil/fuzz/interpret.go
@@ -1,0 +1,91 @@
+package fuzz
+
+import (
+	"encoding/json"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+type peerState struct {
+	doc   *crdt.Doc
+	inbox [][]byte
+}
+
+func newPeers(n int) []*peerState {
+	ps := make([]*peerState, n)
+	for i := range ps {
+		ps[i] = &peerState{doc: crdt.New(crdt.WithClientID(crdt.ClientID(i + 1)))}
+	}
+	return ps
+}
+
+func clampIndex(pos, length int, forInsert bool) int {
+	if pos < 0 {
+		pos = -pos
+	}
+	m := length
+	if forInsert {
+		m = length + 1
+	}
+	if m <= 0 {
+		return 0
+	}
+	return pos % m
+}
+
+func decodeScalar(js string) any {
+	if js == "" {
+		return nil
+	}
+	var v any
+	_ = json.Unmarshal([]byte(js), &v)
+	return v
+}
+
+func applyLocalOp(p *peerState, st Step) {
+	switch st.TypeKind {
+	case KindText:
+		txt := p.doc.GetText(st.Root)
+		p.doc.Transact(func(txn *crdt.Transaction) {
+			switch st.Op {
+			case OpInsert:
+				txt.Insert(txn, clampIndex(st.PosHint, txt.Len(), true), st.StrVal, nil)
+			case OpDelete:
+				if txt.Len() > 0 {
+					txt.Delete(txn, clampIndex(st.PosHint, txt.Len(), false), minInt(st.LenHint, txt.Len()))
+				}
+			}
+		})
+	case KindArray:
+		arr := p.doc.GetArray(st.Root)
+		p.doc.Transact(func(txn *crdt.Transaction) {
+			switch st.Op {
+			case OpInsert:
+				arr.Insert(txn, clampIndex(st.PosHint, arr.Len(), true), []any{decodeScalar(st.JSONVal)})
+			case OpPush:
+				arr.Insert(txn, arr.Len(), []any{decodeScalar(st.JSONVal)})
+			case OpDelete:
+				if arr.Len() > 0 {
+					arr.Delete(txn, clampIndex(st.PosHint, arr.Len(), false), minInt(st.LenHint, arr.Len()))
+				}
+			}
+		})
+	case KindMap:
+		m := p.doc.GetMap(st.Root)
+		p.doc.Transact(func(txn *crdt.Transaction) {
+			switch st.Op {
+			case OpSetKey:
+				m.Set(txn, st.Key, decodeScalar(st.JSONVal))
+			case OpDelKey:
+				m.Delete(txn, st.Key)
+			}
+		})
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/testutil/fuzz/interpret.go
+++ b/testutil/fuzz/interpret.go
@@ -94,7 +94,69 @@ func applyLocalOp(p *peerState, st Step) {
 				m.Delete(txn, st.Key)
 			}
 		})
+	case KindXmlFragment:
+		frag := p.doc.GetXmlFragment(st.Root)
+		p.doc.Transact(func(txn *crdt.Transaction) {
+			switch st.Op {
+			case OpAddChild:
+				idx := clampIndex(st.PosHint, frag.Len(), true)
+				if st.ChildXml == "text" {
+					frag.InsertText(txn, idx, crdt.NewYXmlText())
+				} else { // "elem:<tag>"
+					tag := "div"
+					if len(st.ChildXml) > 5 {
+						tag = st.ChildXml[5:]
+					}
+					frag.InsertElement(txn, idx, crdt.NewYXmlElement(tag))
+				}
+			case OpDelete:
+				if frag.Len() > 0 {
+					frag.Delete(txn, clampIndex(st.PosHint, frag.Len(), false), 1)
+				}
+			case OpSetAttr, OpDelAttr:
+				if el := resolveXmlElem(frag, st.Target); el != nil {
+					if st.Op == OpSetAttr {
+						el.SetAttribute(txn, st.Key, st.StrVal)
+					} else {
+						el.DeleteAttribute(txn, st.Key)
+					}
+				}
+			}
+		})
 	}
+}
+
+// resolveXmlElem walks target (a 0-3-deep child-index path) from frag's
+// top-level children down through nested elements, returning the element at
+// the end of the path. Returns nil if target is empty, frag has no children,
+// or the path steps into a non-element (e.g. a YXmlText) child — in which
+// case the caller treats the op as a no-op rather than panicking.
+//
+// YXmlElement embeds YXmlFragment (verified in crdt/yxml.go), so
+// (*crdt.YXmlElement).Children() is promoted from YXmlFragment.Children() —
+// nesting is walked uniformly at every depth, capped at len(target) by the
+// generator (genXmlOp caps depth at 3).
+func resolveXmlElem(frag *crdt.YXmlFragment, target []int) *crdt.YXmlElement {
+	children := frag.Children()
+	if len(children) == 0 || len(target) == 0 {
+		return nil
+	}
+	el, ok := children[target[0]%len(children)].(*crdt.YXmlElement)
+	if !ok {
+		return nil
+	}
+	for _, idx := range target[1:] {
+		cc := el.Children()
+		if len(cc) == 0 {
+			return el
+		}
+		next, ok := cc[idx%len(cc)].(*crdt.YXmlElement)
+		if !ok {
+			return el
+		}
+		el = next
+	}
+	return el
 }
 
 func minInt(a, b int) int {

--- a/testutil/fuzz/interpret_test.go
+++ b/testutil/fuzz/interpret_test.go
@@ -1,0 +1,25 @@
+package fuzz
+
+import (
+	"testing"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+func TestApplyLocalOp_TextInsertClamped(t *testing.T) {
+	p := &peerState{doc: crdt.New(crdt.WithClientID(1))}
+	applyLocalOp(p, Step{Kind: StepLocalOp, Peer: 0, Root: "t", TypeKind: KindText, Op: OpInsert, PosHint: 999, StrVal: "ab"})
+	applyLocalOp(p, Step{Kind: StepLocalOp, Peer: 0, Root: "t", TypeKind: KindText, Op: OpInsert, PosHint: 1, StrVal: "X"})
+	if got := p.doc.GetText("t").ToString(); got != "aXb" {
+		t.Fatalf("got %q, want aXb", got)
+	}
+}
+
+func TestClampIndex(t *testing.T) {
+	if clampIndex(999, 3, true) != 999%4 {
+		t.Fatal("insert clamp")
+	}
+	if clampIndex(5, 0, false) != 0 {
+		t.Fatal("empty clamp")
+	}
+}

--- a/testutil/fuzz/interpret_test.go
+++ b/testutil/fuzz/interpret_test.go
@@ -23,3 +23,29 @@ func TestClampIndex(t *testing.T) {
 		t.Fatal("empty clamp")
 	}
 }
+
+func TestRunGo_Converges(t *testing.T) {
+	for seed := uint64(0); seed < 200; seed++ {
+		peers, err := RunGo(Generate(seed))
+		if err != nil {
+			t.Fatalf("seed %d: RunGo error: %v", seed, err)
+		}
+		if err := Converged(peers); err != nil {
+			t.Fatalf("seed %d: not converged: %v", seed, err)
+		}
+	}
+}
+
+// TestApplySync_DoesNotMixV1AndV2Inboxes pins the peerState.inboxV1/inboxV2
+// split. Before that split, a single untyped inbox let a DiffV2-staged blob
+// and a later MergeV1 step land in the same MergeUpdatesV1(...) call, which
+// corrupts the byte stream (V1 decoder fed V2 bytes) and returns an error
+// from RunGo rather than a mere convergence mismatch. fuzz seed 0 hits this
+// exact interleaving (a diffv2 step targeting peer 1's inbox followed by
+// three mergev1 steps to the same peer before any drain): RunGo must return
+// a nil error here regardless of whether the peers end up converged.
+func TestApplySync_DoesNotMixV1AndV2Inboxes(t *testing.T) {
+	if _, err := RunGo(Generate(0)); err != nil {
+		t.Fatalf("RunGo returned an error (V1/V2 inbox mixing regression): %v", err)
+	}
+}

--- a/testutil/fuzz/interpret_test.go
+++ b/testutil/fuzz/interpret_test.go
@@ -36,6 +36,23 @@ func TestRunGo_Converges(t *testing.T) {
 	}
 }
 
+// TestRunGo_XmlConverges exercises the "x" (KindXmlFragment) root added in
+// Task 5: nested element/text children plus attribute set/delete, replayed
+// through RunGo's Sync/GC machinery same as every other root, and checked by
+// the shared Converged oracle (which already probes "x" via ToXML()).
+func TestRunGo_XmlConverges(t *testing.T) {
+	for seed := uint64(0); seed < 200; seed++ {
+		s := Generate(seed)
+		peers, err := RunGo(s)
+		if err != nil {
+			t.Fatalf("seed %d: %v", seed, err)
+		}
+		if err := Converged(peers); err != nil {
+			t.Fatalf("seed %d XML: %v", seed, err)
+		}
+	}
+}
+
 // TestApplySync_DoesNotMixV1AndV2Inboxes pins the peerState.inboxV1/inboxV2
 // split. Before that split, a single untyped inbox let a DiffV2-staged blob
 // and a later MergeV1 step land in the same MergeUpdatesV1(...) call, which

--- a/testutil/fuzz/op.go
+++ b/testutil/fuzz/op.go
@@ -1,0 +1,83 @@
+// Package fuzz implements a randomized convergence fuzzer for ygo's CRDT
+// types (#70). A Scenario is a seed-reproducible, JSON-serializable script
+// replayed identically by the Go interpreter and the Node/Yjs oracle.
+package fuzz
+
+// StepKind tags the Step union.
+type StepKind string
+
+const (
+	StepLocalOp StepKind = "op"
+	StepSync    StepKind = "sync"
+	StepGC      StepKind = "gc"
+)
+
+// TypeKind identifies a shared-type root.
+type TypeKind string
+
+const (
+	KindText        TypeKind = "text"
+	KindArray       TypeKind = "array"
+	KindMap         TypeKind = "map"
+	KindXmlFragment TypeKind = "xmlfrag"
+	KindXmlElement  TypeKind = "xmlelem"
+	KindXmlText     TypeKind = "xmltext"
+)
+
+// OpCode is a per-type mutation.
+type OpCode string
+
+const (
+	OpInsert   OpCode = "insert"   // text/array/xmltext
+	OpDelete   OpCode = "delete"   // text/array/xml children
+	OpFormat   OpCode = "format"   // text
+	OpPush     OpCode = "push"     // array
+	OpSetKey   OpCode = "setkey"   // map
+	OpDelKey   OpCode = "delkey"   // map
+	OpSetAttr  OpCode = "setattr"  // xmlelem
+	OpDelAttr  OpCode = "delattr"  // xmlelem
+	OpAddChild OpCode = "addchild" // xmlfrag/xmlelem: insert element or text child
+)
+
+// SyncMethod is the wire path a Sync step drives.
+type SyncMethod string
+
+const (
+	ApplyV1 SyncMethod = "applyv1"
+	ApplyV2 SyncMethod = "applyv2"
+	MergeV1 SyncMethod = "mergev1"
+	MergeV2 SyncMethod = "mergev2"
+	DiffV1  SyncMethod = "diffv1"
+	DiffV2  SyncMethod = "diffv2"
+)
+
+// Step is one action. Only the fields relevant to Kind are populated; the
+// rest stay zero. Flat (not an interface) so it JSON-encodes as one object.
+type Step struct {
+	Kind StepKind `json:"kind"`
+
+	// StepLocalOp
+	Peer     int      `json:"peer,omitempty"`
+	Root     string   `json:"root,omitempty"`
+	TypeKind TypeKind `json:"typeKind,omitempty"`
+	Op       OpCode   `json:"op,omitempty"`
+	PosHint  int      `json:"posHint,omitempty"`
+	LenHint  int      `json:"lenHint,omitempty"`  // delete length
+	StrVal   string   `json:"strVal,omitempty"`   // text/xmltext content
+	Key      string   `json:"key,omitempty"`      // map key / attr name
+	JSONVal  string   `json:"jsonVal,omitempty"`  // JSON-encoded scalar value for map-set/array-insert
+	ChildXml string   `json:"childXml,omitempty"` // "elem:<tag>" or "text" for OpAddChild
+	Target   []int    `json:"target,omitempty"`   // path to nested container ([] = root)
+
+	// StepSync
+	From   int        `json:"from,omitempty"`
+	To     int        `json:"to,omitempty"`
+	Method SyncMethod `json:"method,omitempty"`
+}
+
+// Scenario is a full fuzz run: a seed, a peer count, and an ordered step list.
+type Scenario struct {
+	Seed     uint64 `json:"seed"`
+	NumPeers int    `json:"numPeers"`
+	Steps    []Step `json:"steps"`
+}

--- a/testutil/fuzz/op_test.go
+++ b/testutil/fuzz/op_test.go
@@ -1,0 +1,31 @@
+package fuzz
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestScenario_JSONRoundTrip(t *testing.T) {
+	s := Scenario{
+		Seed: 42, NumPeers: 3,
+		Steps: []Step{
+			{Kind: StepLocalOp, Peer: 0, Root: "t", TypeKind: KindText, Op: OpInsert, PosHint: 5, StrVal: "hi"},
+			{Kind: StepSync, From: 0, To: 1, Method: MergeV2},
+			{Kind: StepGC, Peer: 1},
+		},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Scenario
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Seed != 42 || got.NumPeers != 3 || len(got.Steps) != 3 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.Steps[0].StrVal != "hi" || got.Steps[1].Method != MergeV2 || got.Steps[2].Kind != StepGC {
+		t.Fatalf("field mismatch: %+v", got.Steps)
+	}
+}

--- a/testutil/fuzz/oracle_node.go
+++ b/testutil/fuzz/oracle_node.go
@@ -47,12 +47,13 @@ func oracleScriptDir() (dir, script string, ok bool) {
 
 // RunNode replays every scenario against real Yjs by piping one NDJSON line per
 // scenario into a single persistent node worker and reading one NDJSON reply
-// per scenario back. It returns (nil, false) — signalling the caller should
-// skip — when node is not on PATH, the yjs dependency is not installed, or the
-// worker script is missing. Otherwise it returns one NodeResult per scenario in
-// order; a result whose Err is non-nil means the worker died before producing
-// that scenario's output (its stderr is attached), which the caller surfaces as
-// a failure rather than a skip.
+// per scenario back. It returns ok=false — signalling the caller should skip —
+// ONLY when the environment is genuinely absent: node is not on PATH, the
+// worker script is missing, or the yjs dependency is not installed. Once those
+// checks pass, node+yjs are present, so any later worker setup/spawn or runtime
+// failure is returned with ok=true and a non-nil per-scenario Err, which the
+// caller surfaces as a test failure (not a skip) — otherwise a broken oracle
+// would pass silently in CI. It returns one NodeResult per scenario in order.
 func RunNode(scenarios []Scenario) ([]NodeResult, bool) {
 	nodePath, err := exec.LookPath("node")
 	if err != nil {
@@ -70,20 +71,33 @@ func RunNode(scenarios []Scenario) ([]NodeResult, bool) {
 		return nil, false
 	}
 
+	// Past this point node AND yjs are confirmed present, so a worker
+	// setup/spawn failure is a genuine error — not an "environment absent" skip.
+	// Surface it through per-scenario Err (with ok=true) so the caller reports a
+	// failure instead of silently skipping (which would hide a broken oracle in
+	// CI). fail returns one errored result per scenario.
+	fail := func(err error) ([]NodeResult, bool) {
+		rs := make([]NodeResult, len(scenarios))
+		for i := range rs {
+			rs[i].Err = err
+		}
+		return rs, true
+	}
+
 	cmd := exec.Command(nodePath, script)
 	cmd.Dir = dir
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, false
+		return fail(fmt.Errorf("node worker StdinPipe: %w", err))
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, false
+		return fail(fmt.Errorf("node worker StdoutPipe: %w", err))
 	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
-		return nil, false
+		return fail(fmt.Errorf("node worker start: %w", err))
 	}
 
 	// Feed scenarios from a goroutine so a full OS pipe buffer can't deadlock

--- a/testutil/fuzz/oracle_node.go
+++ b/testutil/fuzz/oracle_node.go
@@ -1,0 +1,219 @@
+package fuzz
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+// NodeResult is the per-scenario reply from the Node/Yjs oracle worker
+// (testutil/fuzz_oracle.js). PeerJSON[i] is peer i's logical view across the
+// well-known roots ("t"/"a"/"m"/"x"); PeerUpdateB64[i] is peer i's full
+// since-genesis state as a base64-encoded V1 update. Err is set (non-JSON)
+// when the worker failed to produce a result for this scenario.
+type NodeResult struct {
+	PeerJSON      []map[string]any `json:"peerJSON"`
+	PeerUpdateB64 []string         `json:"peerUpdateB64"`
+	Err           error            `json:"-"`
+}
+
+// oracleScriptDir returns the directory holding fuzz_oracle.js (testutil/) and
+// the absolute path to the script. The directory is used as the worker's cwd
+// so that require('yjs') resolves testutil/node_modules regardless of the test
+// binary's own working directory.
+func oracleScriptDir() (dir, script string, ok bool) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", "", false
+	}
+	dir = filepath.Dir(filepath.Dir(self)) // .../testutil/fuzz -> .../testutil
+	script = filepath.Join(dir, "fuzz_oracle.js")
+	if _, err := os.Stat(script); err != nil {
+		return "", "", false
+	}
+	return dir, script, true
+}
+
+// RunNode replays every scenario against real Yjs by piping one NDJSON line per
+// scenario into a single persistent node worker and reading one NDJSON reply
+// per scenario back. It returns (nil, false) — signalling the caller should
+// skip — when node is not on PATH, the yjs dependency is not installed, or the
+// worker script is missing. Otherwise it returns one NodeResult per scenario in
+// order; a result whose Err is non-nil means the worker died before producing
+// that scenario's output (its stderr is attached), which the caller surfaces as
+// a failure rather than a skip.
+func RunNode(scenarios []Scenario) ([]NodeResult, bool) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		return nil, false
+	}
+	dir, script, ok := oracleScriptDir()
+	if !ok {
+		return nil, false
+	}
+	// Probe that yjs resolves from the worker's cwd; a missing dependency is a
+	// skip, not a failure, so headless environments without it stay green.
+	probe := exec.Command(nodePath, "-e", "require('yjs')")
+	probe.Dir = dir
+	if err := probe.Run(); err != nil {
+		return nil, false
+	}
+
+	cmd := exec.Command(nodePath, script)
+	cmd.Dir = dir
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, false
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, false
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, false
+	}
+
+	// Feed scenarios from a goroutine so a full OS pipe buffer can't deadlock
+	// us against the worker's output we haven't read yet.
+	go func() {
+		w := bufio.NewWriter(stdin)
+		for _, s := range scenarios {
+			b, mErr := json.Marshal(s)
+			if mErr != nil {
+				break
+			}
+			if _, wErr := w.Write(append(b, '\n')); wErr != nil {
+				break
+			}
+		}
+		_ = w.Flush()
+		_ = stdin.Close()
+	}()
+
+	results := make([]NodeResult, len(scenarios))
+	for i := range results {
+		results[i].Err = errors.New("node worker produced no output for this scenario")
+	}
+	reader := bufio.NewReader(stdout)
+	for i := range scenarios {
+		line, rErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			var nr NodeResult
+			if uErr := json.Unmarshal(line, &nr); uErr == nil {
+				results[i] = nr // clears the sentinel Err
+			} else {
+				results[i].Err = fmt.Errorf("decode worker output: %w", uErr)
+			}
+		}
+		if rErr != nil {
+			break // EOF or read error: remaining results keep their sentinel Err
+		}
+	}
+	_, _ = io.Copy(io.Discard, stdout)
+	waitErr := cmd.Wait()
+
+	// If the worker exited badly, attach its stderr to any still-unfilled
+	// results so the caller reports a meaningful failure.
+	if waitErr != nil || stderr.Len() > 0 {
+		for i := range results {
+			if results[i].Err != nil {
+				results[i].Err = fmt.Errorf("%w (node stderr: %s)", results[i].Err, stderr.String())
+			}
+		}
+	}
+	return results, true
+}
+
+// crossImplRoots are the well-known roots the generator drives, in the same
+// order used by Converged/stateJSON.
+var crossImplRoots = []struct {
+	name string
+	kind TypeKind
+}{{"t", KindText}, {"a", KindArray}, {"m", KindMap}, {"x", KindXmlFragment}}
+
+// CrossImplEqual replays s with the Go interpreter and asserts ygo agrees with
+// Yjs (nr) two ways:
+//
+//  1. Logical: each ygo peer's per-root view (stateJSON) equals the
+//     corresponding Yjs peer's view.
+//  2. Round-trip: a fresh ygo doc that decodes each Yjs peer's encoded V1
+//     update produces the same view Yjs reports for that peer — i.e. ygo can
+//     read Yjs's own bytes and see what Yjs sees.
+//
+// Both comparisons run through normalize so number/collection representations
+// are compared by value, not by Go/JS encoding quirks.
+func CrossImplEqual(s Scenario, nr NodeResult) error {
+	if nr.Err != nil {
+		return nr.Err
+	}
+	peers, err := RunGo(s)
+	if err != nil {
+		return fmt.Errorf("RunGo: %w", err)
+	}
+	if len(nr.PeerJSON) != len(peers) {
+		return fmt.Errorf("peer count mismatch: go=%d yjs=%d", len(peers), len(nr.PeerJSON))
+	}
+	if len(nr.PeerUpdateB64) != len(peers) {
+		return fmt.Errorf("peer update count mismatch: go=%d yjs=%d", len(peers), len(nr.PeerUpdateB64))
+	}
+
+	// (1) logical parity, per peer.
+	for i, p := range peers {
+		goState, err := stateJSON(p, crossImplRoots)
+		if err != nil {
+			return fmt.Errorf("go stateJSON peer %d: %w", i, err)
+		}
+		if g, j := normalize(goState), normalize(nr.PeerJSON[i]); !reflect.DeepEqual(g, j) {
+			return fmt.Errorf("logical mismatch at peer %d:\n  go=%v\n  js=%v", i, g, j)
+		}
+	}
+
+	// (2) round-trip parity: ygo decodes Yjs's bytes, must see what Yjs sees.
+	for i, b64 := range nr.PeerUpdateB64 {
+		raw, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return fmt.Errorf("peer %d update b64 decode: %w", i, err)
+		}
+		fresh := crdt.New()
+		if err := crdt.ApplyUpdateV1(fresh, raw, nil); err != nil {
+			return fmt.Errorf("peer %d round-trip apply: %w", i, err)
+		}
+		rtState, err := stateJSON(&peerState{doc: fresh}, crossImplRoots)
+		if err != nil {
+			return fmt.Errorf("round-trip stateJSON peer %d: %w", i, err)
+		}
+		if g, j := normalize(rtState), normalize(nr.PeerJSON[i]); !reflect.DeepEqual(g, j) {
+			return fmt.Errorf("round-trip mismatch at peer %d (ygo decode of yjs update):\n  ygo=%v\n  js=%v", i, g, j)
+		}
+	}
+	return nil
+}
+
+// normalize canonicalises a decoded-JSON value by round-tripping it through
+// encoding/json, so a Go-built map[string]any and a worker-emitted one compare
+// equal by value (all numbers become float64, empty vs nil collections align)
+// under reflect.DeepEqual.
+func normalize(v any) any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return v
+	}
+	return out
+}

--- a/testutil/fuzz/shrink.go
+++ b/testutil/fuzz/shrink.go
@@ -1,0 +1,53 @@
+package fuzz
+
+// Shrink returns a minimal sub-scenario for which stillFails stays true, using
+// ddmin-style removal (contiguous chunks of decreasing size, converging on
+// single steps) followed by payload simplification. Deterministic: stillFails
+// must be a pure function of the scenario. Because the predicate typically
+// wraps the (expensive) cross-impl oracle, chunk removal is preferred over
+// one-step-at-a-time so a 200-step scenario collapses in O(log n) passes rather
+// than O(n^2) predicate calls.
+func Shrink(s Scenario, stillFails func(Scenario) bool) Scenario {
+	steps := append([]Step(nil), s.Steps...)
+	mk := func(st []Step) Scenario {
+		return Scenario{Seed: s.Seed, NumPeers: s.NumPeers, Steps: st}
+	}
+	remove := func(src []Step, i, size int) []Step {
+		out := make([]Step, 0, len(src)-size)
+		out = append(out, src[:i]...)
+		out = append(out, src[i+size:]...)
+		return out
+	}
+
+	// Phase 1: remove contiguous chunks. Halve the granularity each sweep and
+	// loop the whole thing until a full sweep removes nothing.
+	changed := true
+	for changed {
+		changed = false
+		for size := len(steps) / 2; size >= 1; size /= 2 {
+			for i := 0; i+size <= len(steps); {
+				if cand := remove(steps, i, size); stillFails(mk(cand)) {
+					steps = cand
+					changed = true
+					// Keep i; the window now holds the following steps.
+				} else {
+					i += size
+				}
+			}
+		}
+	}
+
+	// Phase 2: payload simplification — shorten string values while the failure
+	// persists (never to empty, which would change the op's semantics).
+	for i := range steps {
+		for len(steps[i].StrVal) > 1 {
+			cand := append([]Step(nil), steps...)
+			cand[i].StrVal = cand[i].StrVal[:len(cand[i].StrVal)-1]
+			if !stillFails(mk(cand)) {
+				break
+			}
+			steps = cand
+		}
+	}
+	return mk(steps)
+}

--- a/testutil/fuzz/shrink.go
+++ b/testutil/fuzz/shrink.go
@@ -38,11 +38,18 @@ func Shrink(s Scenario, stillFails func(Scenario) bool) Scenario {
 	}
 
 	// Phase 2: payload simplification — shorten string values while the failure
-	// persists (never to empty, which would change the op's semantics).
+	// persists (never to empty, which would change the op's semantics). Truncate
+	// by rune, not byte: generated StrVal holds multi-byte UTF-8 (Greek/Japanese/
+	// emoji), and slicing mid-rune would produce invalid UTF-8 and change the
+	// scenario's behaviour rather than shrink it.
 	for i := range steps {
-		for len(steps[i].StrVal) > 1 {
+		for {
+			r := []rune(steps[i].StrVal)
+			if len(r) <= 1 {
+				break
+			}
 			cand := append([]Step(nil), steps...)
-			cand[i].StrVal = cand[i].StrVal[:len(cand[i].StrVal)-1]
+			cand[i].StrVal = string(r[:len(r)-1])
 			if !stillFails(mk(cand)) {
 				break
 			}

--- a/testutil/fuzz/shrink_test.go
+++ b/testutil/fuzz/shrink_test.go
@@ -1,0 +1,27 @@
+package fuzz
+
+import "testing"
+
+// The predicate "fails" iff a step with StrVal=="BUG" remains.
+func TestShrink_RemovesIrrelevantSteps(t *testing.T) {
+	s := Scenario{Seed: 1, NumPeers: 3}
+	for i := 0; i < 20; i++ {
+		s.Steps = append(s.Steps, Step{Kind: StepLocalOp, Root: "t", TypeKind: KindText, Op: OpInsert, StrVal: "x"})
+	}
+	s.Steps[10].StrVal = "BUG"
+	fails := func(sc Scenario) bool {
+		for _, st := range sc.Steps {
+			if st.StrVal == "BUG" {
+				return true
+			}
+		}
+		return false
+	}
+	min := Shrink(s, fails)
+	if !fails(min) {
+		t.Fatal("shrunk scenario must still fail")
+	}
+	if len(min.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(min.Steps))
+	}
+}

--- a/testutil/fuzz_oracle.js
+++ b/testutil/fuzz_oracle.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// fuzz_oracle.js — replays fuzz Scenarios against Yjs, one NDJSON line in/out.
+//
+// This worker MUST mirror testutil/fuzz/interpret.go semantics EXACTLY so that
+// any difference between its output and ygo's replay is a genuine ygo↔Yjs CRDT
+// divergence, not a harness artifact. In particular the transport discipline
+// matches RunGo/applySync/drainInboxes/finalSync:
+//
+//   * Diff*/Merge* updates are staged in per-peer inboxes keyed by wire version
+//     (inboxV1/inboxV2). V1 and V2 are distinct, non-interchangeable encodings,
+//     so an update is only ever merged/applied through its own decoder — never
+//     guessed (mirrors peerState.inboxV1/inboxV2, see interpret.go).
+//   * Apply* syncs land immediately using an sv-diff of the source against the
+//     destination's state vector.
+//   * Merge* pushes the source's FULL state into the version bucket, merges the
+//     WHOLE bucket, applies it, and clears the bucket (so it also drains any
+//     Diff* entries already staged in that bucket) — exactly like Go's MergeV1/
+//     MergeV2 cases.
+//   * After the step list: drainInboxes applies every staged update one at a
+//     time through its own decoder, then finalSync forces a full-mesh V1 sync
+//     (encode each peer's full state, mergeUpdates all, apply the merge to every
+//     peer). Without this final full-mesh sync the peers would be left in a
+//     partially-connected state and disagree with Go's converged peers for
+//     reasons unrelated to CRDT correctness.
+//
+// clamp mirrors clampIndex(pos,length,forInsert). ygo's YText.Len() is UTF-16
+// code-unit length, matching Yjs's .length, so index math agrees on emoji/
+// multi-byte text.
+const Y = require('yjs')
+const readline = require('readline')
+
+const clamp = (pos, len, ins) => {
+  if (pos < 0) pos = -pos
+  const m = ins ? len + 1 : len
+  return m <= 0 ? 0 : pos % m
+}
+
+// resolveElem mirrors resolveXmlElem: walk the child-index path from the
+// fragment's top-level children down through nested elements. Returns null if
+// target is empty, the fragment has no children, or the first hop is not an
+// element; stops and returns the current element if a deeper hop steps into a
+// non-element (e.g. an XmlText) or an empty element.
+const resolveElem = (f, target) => {
+  const cs = f.toArray()
+  if (!cs.length || !target.length) return null
+  let el = cs[target[0] % cs.length]
+  if (!(el instanceof Y.XmlElement)) return null
+  for (const idx of target.slice(1)) {
+    const cc = el.toArray()
+    if (!cc.length) return el
+    const nx = cc[idx % cc.length]
+    if (!(nx instanceof Y.XmlElement)) return el
+    el = nx
+  }
+  return el
+}
+
+// delCount mirrors ygo's deleteRange: from `idx` it removes up to `want`
+// elements OR stops at the end of the list, never past it. Yjs's delete throws
+// "Length exceeded" when idx+want > length, so we clamp want to length-idx —
+// the exact number of elements ygo would have tombstoned.
+const delCount = (want, len, idx) => Math.min(want || 1, len - idx)
+
+const applyLocal = (d, st) => {
+  if (st.typeKind === 'text') {
+    const t = d.getText(st.root)
+    if (st.op === 'insert') t.insert(clamp(st.posHint || 0, t.length, true), st.strVal)
+    else if (st.op === 'delete' && t.length > 0) {
+      const idx = clamp(st.posHint || 0, t.length, false)
+      t.delete(idx, delCount(st.lenHint, t.length, idx))
+    }
+  } else if (st.typeKind === 'array') {
+    const a = d.getArray(st.root)
+    if (st.op === 'insert') a.insert(clamp(st.posHint || 0, a.length, true), [JSON.parse(st.jsonVal)])
+    else if (st.op === 'push') a.push([JSON.parse(st.jsonVal)])
+    else if (st.op === 'delete' && a.length > 0) {
+      const idx = clamp(st.posHint || 0, a.length, false)
+      a.delete(idx, delCount(st.lenHint, a.length, idx))
+    }
+  } else if (st.typeKind === 'map') {
+    const m = d.getMap(st.root)
+    if (st.op === 'setkey') m.set(st.key, JSON.parse(st.jsonVal))
+    else if (st.op === 'delkey') m.delete(st.key)
+  } else if (st.typeKind === 'xmlfrag') {
+    const f = d.getXmlFragment(st.root)
+    if (st.op === 'addchild') {
+      const idx = clamp(st.posHint || 0, f.length, true)
+      if (st.childXml === 'text') f.insert(idx, [new Y.XmlText()])
+      else f.insert(idx, [new Y.XmlElement((st.childXml || 'elem:div').slice(5) || 'div')])
+    } else if (st.op === 'delete') {
+      if (f.length > 0) f.delete(clamp(st.posHint || 0, f.length, false), 1)
+    } else if (st.op === 'setattr' || st.op === 'delattr') {
+      const el = resolveElem(f, st.target || [])
+      if (el) {
+        if (st.op === 'setattr') el.setAttribute(st.key, st.strVal)
+        else el.removeAttribute(st.key)
+      }
+    }
+  }
+}
+
+// svApply mirrors the Apply* cases: sv-diff of `from` against `to`'s state
+// vector, applied immediately.
+const svApply = (from, to, ver) => {
+  if (ver === 1) Y.applyUpdate(to, Y.encodeStateAsUpdate(from, Y.encodeStateVector(to)))
+  else Y.applyUpdateV2(to, Y.encodeStateAsUpdateV2(from, Y.encodeStateVector(to)))
+}
+
+const runScenario = (s) => {
+  const n = s.numPeers
+  const docs = []
+  const inboxV1 = []
+  const inboxV2 = []
+  for (let i = 0; i < n; i++) {
+    // NB: the Y.Doc constructor has NO clientID option — passing one is
+    // silently ignored and Yjs assigns a RANDOM clientID (generateNewClientId).
+    // clientID is YATA's concurrent-insert tie-breaker, so a random one both
+    // makes replays non-deterministic and stops them matching ygo's
+    // WithClientID(i+1). Assign it explicitly, before any struct is created.
+    const d = new Y.Doc()
+    d.clientID = i + 1
+    docs.push(d)
+    inboxV1.push([])
+    inboxV2.push([])
+  }
+
+  for (const st of s.steps) {
+    if (st.kind === 'op') {
+      applyLocal(docs[(st.peer || 0) % n], st)
+    } else if (st.kind === 'gc') {
+      // ygo forces a commit pass; Yjs GCs at transaction end. No observable
+      // logical effect — no-op here.
+    } else if (st.kind === 'sync') {
+      const fi = (st.from || 0) % n
+      const ti = (st.to || 0) % n
+      const from = docs[fi]
+      const to = docs[ti]
+      switch (st.method) {
+        case 'applyv1':
+          svApply(from, to, 1)
+          break
+        case 'applyv2':
+          svApply(from, to, 2)
+          break
+        case 'diffv1':
+          inboxV1[ti].push(Y.diffUpdate(Y.encodeStateAsUpdate(from), Y.encodeStateVector(to)))
+          break
+        case 'diffv2':
+          inboxV2[ti].push(Y.diffUpdateV2(Y.encodeStateAsUpdateV2(from), Y.encodeStateVector(to)))
+          break
+        case 'mergev1':
+          inboxV1[ti].push(Y.encodeStateAsUpdate(from))
+          Y.applyUpdate(to, Y.mergeUpdates(inboxV1[ti]))
+          inboxV1[ti] = []
+          break
+        case 'mergev2':
+          inboxV2[ti].push(Y.encodeStateAsUpdateV2(from))
+          Y.applyUpdateV2(to, Y.mergeUpdatesV2(inboxV2[ti]))
+          inboxV2[ti] = []
+          break
+      }
+    }
+  }
+
+  // drainInboxes: apply every staged update one at a time through its own
+  // decoder, then clear.
+  for (let i = 0; i < n; i++) {
+    for (const u of inboxV1[i]) Y.applyUpdate(docs[i], u)
+    inboxV1[i] = []
+    for (const u of inboxV2[i]) Y.applyUpdateV2(docs[i], u)
+    inboxV2[i] = []
+  }
+
+  // finalSync: full-mesh V1 sync so every peer holds identical state.
+  const fullStates = docs.map((d) => Y.encodeStateAsUpdate(d))
+  const merged = Y.mergeUpdates(fullStates)
+  for (const d of docs) Y.applyUpdate(d, merged)
+
+  const roots = [['t', 'text'], ['a', 'array'], ['m', 'map'], ['x', 'xmlfrag']]
+  const out = { peerJSON: [], peerUpdateB64: [] }
+  for (const d of docs) {
+    const j = {}
+    for (const [name, kind] of roots) {
+      if (kind === 'text') j[name] = d.getText(name).toString()
+      else if (kind === 'array') j[name] = d.getArray(name).toJSON()
+      else if (kind === 'map') j[name] = d.getMap(name).toJSON()
+      else if (kind === 'xmlfrag') j[name] = d.getXmlFragment(name).toString()
+    }
+    out.peerJSON.push(j)
+    out.peerUpdateB64.push(Buffer.from(Y.encodeStateAsUpdate(d)).toString('base64'))
+  }
+  return out
+}
+
+const rl = readline.createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  if (!line.trim()) return
+  const s = JSON.parse(line)
+  process.stdout.write(JSON.stringify(runScenario(s)) + '\n')
+})


### PR DESCRIPTION
## Summary

Implements the #70 convergence fuzz framework: a seed-reproducible, multi-peer randomized fuzzer that asserts ygo peers converge, and — when Node + `yjs` are present — checks ygo against **live Yjs** both logically and by round-trip. All test-only; **no library API changes**.

This is the tool that found and drove the three CRDT convergence fixes shipped this cycle: `YArray.Push` tombstone-tail (#158 → v1.31.5) and the YText tombstone-anchoring + `firstLiveCache`/`posCache` bugs (#160 → v1.31.6).

## What's in `testutil/fuzz`

- **Generator** (`generate.go`) — deterministic per-seed scenarios: random ops across Text/Array/Map/XML (incl. nested elements + attributes), delivery via Apply/Merge/Diff on V1 and V2, plus GC, biased toward merge/diff.
- **Go interpreter** (`interpret.go`) — replays a scenario across N peers with a per-peer inbox transport, total self-resolving index clamping, a full-mesh `finalSync`, and a structural `Converged` oracle.
- **Live Yjs cross-impl oracle** (`oracle_node.go` + `fuzz_oracle.js`) — a persistent Node NDJSON worker mirroring the Go interpreter exactly; `CrossImplEqual` asserts per-peer `ToJSON`/`ToXML` equality plus round-trip acceptance of Yjs's encoded update. Catches "both ygo peers agree with each other but disagree with Yjs" bugs the Go-vs-Go oracle structurally cannot.
- **Shrinker** (`shrink.go`) — ddmin-style minimization of a failing scenario.
- **Regression corpus** (`corpus/`) — frozen JSON reproducers replayed every run.

## Test entry points (`crdt/fuzz_test.go`)

- `TestFuzzConvergence` — 1,000 seeds, Go-vs-Go, deterministic, node-free (`FUZZ_ITER` to scale).
- `TestFuzzCrossImpl` — 200 seeds vs live Yjs (skips if node/yjs absent; CI installs yjs via `npm ci`).
- `TestFuzzCorpus` — frozen reproducers.
- `TestFuzzSeed` — `FUZZ_SEED=<n>` single-scenario replay for debugging.

## Verification

- `go vet ./...`, `golangci-lint` clean; full `crdt -race` green.
- Converges with live Yjs on seeds 0..599 (after the v1.31.5/v1.31.6 fixes).
- CI already runs it under `go test ./...`; CONTRIBUTING documents reproduction.

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)