### PR TITLE
release: v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.32.0] — 2026-07-17
 
 ### Added
 
+- **Transaction-scoped root accessors** — `Transaction.GetText`, `GetMap`,
+  `GetArray`, `GetXmlFragment` resolve (and create on first use) root types from
+  inside a `Transact` callback without re-locking, reusing the lock the
+  transaction already holds. Previously the natural `doc.GetText(...)` call
+  inside a callback self-deadlocked the non-reentrant document lock, silently
+  and permanently ([#138](https://github.com/reearth/ygo/issues/138)). The
+  accessors are valid only inside the callback that received the transaction and
+  **panic once the transaction has committed** (e.g. from an
+  `OnAfterTransaction` observer or a retained `*Transaction`) instead of
+  silently touching document state without the lock.
 - **Randomized convergence fuzz framework
   ([#70](https://github.com/reearth/ygo/issues/70)).** `testutil/fuzz`
   generates seed-reproducible multi-peer scenarios (random ops across
@@ -26,21 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (no silent skip) under `YGO_REQUIRE_NODE=1`; a symmetric Map/Array/Text/XML
   fixture matrix (V1+V2) decodes genuine `yjs@13.6.30` bytes node-free; and a
   fixture-drift CI job regenerates from the pinned yjs and fails on divergence.
-
-### Added
-
-- **Transaction-scoped root accessors** — `Transaction.GetText`,
-  `GetMap`, `GetArray`, `GetXmlFragment` resolve (and create on first
-  use) root types from inside a `Transact` callback without re-locking,
-  reusing the lock the transaction already holds. Previously the natural
-  `doc.GetText(...)` call inside a callback self-deadlocked the
-  non-reentrant document lock, silently and permanently (#138). The
-  `examples/peer-sync` example did exactly that on every run; it now uses
-  the transaction accessors and completes. The accessors are valid only
-  inside the callback that received the transaction and **panic once the
-  transaction has committed** (e.g. from an `OnAfterTransaction` observer
-  or a retained `*Transaction`) instead of silently touching document
-  state without the lock.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,34 +1,50 @@
-## v1.31.6
+## v1.32.0
 
-A CRDT convergence + correctness patch. No API changes. Found by ygo's
-cross-implementation convergence fuzzer (#70), which replays randomized
-scenarios against live Yjs and compares the results. Three related,
-tombstone-triggered fixes ([#160](https://github.com/reearth/ygo/issues/160)).
-Recommended for anyone editing text (or arrays) that also gets deletions.
+A minor release: one new public API for working inside transactions, plus two
+substantial testing/CI hardening efforts that lock in ygo's convergence and
+cross-language Yjs conformance. No breaking changes.
 
-### Fixed
+### Added
 
-- **`YText.Insert` anchored a run before an adjacent tombstone, diverging from
-  Yjs (text-path mirror of #158).** It anchored relative to the last **live**
-  item (leaving `originRight` pointing at a tombstone) and landed *before* the
-  tombstone; Yjs advances past deleted items and lands *after*. Two peers
-  inserting next to the same tombstone then ordered their runs differently.
-  `Insert`/`InsertEmbed` now advance the anchor past adjacent deleted items.
-  Only text was affected; arrays/maps/XML already converged.
-- **Stale `firstLiveCache` after inserting past leading tombstones.** A live run
-  inserted after leading tombstones became the first live item without becoming
-  the list head, so the cache was never invalidated and a later `Delete` walked
-  a stale head and removed the wrong indices (it could silently no-op). Now
-  invalidated when a live item lands after a deleted left neighbour.
-- **Stale `posCache` after a remote delete-only apply (pre-existing).** A remote
-  update that only tombstoned an item left the position cache stale, so the next
-  local positioned insert resolved the wrong neighbour. The remote delete-set
-  path now invalidates the position cache after deleting a countable item.
+- **Transaction-scoped root accessors** — `Transaction.GetText`, `GetMap`,
+  `GetArray`, `GetXmlFragment` resolve (and create on first use) root types from
+  inside a `Transact` callback without re-locking, reusing the lock the
+  transaction already holds ([#138](https://github.com/reearth/ygo/issues/138),
+  thanks @frodex). Previously the natural `doc.GetText(...)` call inside a
+  callback self-deadlocked the non-reentrant document lock. The accessors are
+  valid only inside the callback that received the transaction and **panic once
+  the transaction has committed** (e.g. from an `OnAfterTransaction` observer or
+  a retained `*Transaction`) rather than silently touching document state
+  without the lock.
+
+- **Randomized convergence fuzz framework
+  ([#70](https://github.com/reearth/ygo/issues/70)).** `testutil/fuzz` generates
+  seed-reproducible multi-peer scenarios (random ops across Text/Array/Map/XML,
+  nested containers, delivery via Apply/Merge/Diff on V1 and V2, plus GC),
+  asserts all ygo peers converge, and — when Node + `yjs` are present — checks
+  ygo against real Yjs both logically and by round-trip. Failures print a seed
+  (`FUZZ_SEED=<n>` to replay) and shrink to a minimal scenario; a regression
+  corpus locks in known cases. CI runs a fixed 1,000-seed set. This framework
+  found the convergence divergences fixed in v1.31.5 and v1.31.6.
+
+- **Cross-language Yjs conformance is now enforced in CI
+  ([#99](https://github.com/reearth/ygo/issues/99)).** Cross-impl tests hard-fail
+  (no silent skip) under `YGO_REQUIRE_NODE=1`; a symmetric Map/Array/Text/XML
+  fixture matrix (V1+V2) decodes genuine `yjs@13.6.30` bytes node-free; and a
+  fixture-drift CI job regenerates from the pinned yjs and fails on divergence.
+
+### Changed
+
+- **Documented the locking contract honestly** on `Transact` and the Doc-level
+  accessors: anything that takes the document lock still deadlocks silently when
+  called inside a `Transact` callback (Go exposes no goroutine identity with
+  which to detect it). Use the transaction accessors above, or resolve handles
+  before the transaction.
 
 ## Install
 
 ```
-go get github.com/reearth/ygo@v1.31.6
+go get github.com/reearth/ygo@v1.32.0
 ```
 
 See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.


### PR DESCRIPTION
Rolls up the accumulated `[Unreleased]` work into **v1.32.0** and finalizes `CHANGELOG.md` + `RELEASE_NOTES.md` in-branch (so no second docs PR is needed before tagging).

Minor bump — it adds new public API (the `Transaction.GetText`/`GetMap`/`GetArray`/`GetXmlFragment` accessors from #148).

Bundled:
- **#138** transaction-scoped root accessors (contributor @frodex, merged in #148)
- **#70** randomized convergence fuzz framework (#162)
- **#99** cross-language Yjs conformance enforced in CI (#163)

Docs-only diff on top of `main`. After this merges, tag `v1.32.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)