### PR TITLE
feat(awareness): reclaim removal tombstones via PurgeTombstones (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.34.0] — 2026-07-18
+
+### Added
+
+- **`Awareness.PurgeTombstones(grace)` reclaims aged removal tombstones**
+  ([#166](https://github.com/reearth/ygo/issues/166)). When a client is removed
+  or expires, its entry is kept as a null-state tombstone so its clock can still
+  encode removals and reject stale re-adds. These tombstones were never
+  reclaimed: because they count toward `SetMaxClients` (deliberately, to bound a
+  peer inventing null-state client IDs), a high-churn room's entry count grew
+  monotonically and could eventually **refuse new, legitimate clients** — and
+  every full `EncodeUpdate(nil)` kept re-broadcasting them. `PurgeTombstones`
+  drops tombstones older than `grace` (a non-positive `grace` is a no-op; the
+  local client is never purged; no observer event fires). `StartAutoExpiry` now
+  runs it automatically each tick as a second stage — `RemoveExpired(timeout)`
+  then `PurgeTombstones(2*timeout)` — so `grace` outlives normal update
+  reordering before a tombstone's clock is forgotten. Callers driving expiry
+  manually should pair `RemoveExpired` with `PurgeTombstones`.
+
 ## [1.33.0] — 2026-07-18
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,101 +1,26 @@
-## v1.33.0
+## v1.34.0
 
-A minor release that makes ygo's XML types (`Y.XmlFragment`/`Y.XmlElement`/
-`Y.XmlText`) **byte-conformant with yjs@13.6** over both V1 and V2 updates — the
-`y-prosemirror` shapes now round-trip and converge with real yjs — plus new
-typed XML attribute accessors. No breaking changes.
-
-### Fixed
-
-- **XML wire conformance with yjs**
-  ([#147](https://github.com/reearth/ygo/pull/147), thanks @frodex). Three fixes
-  make ygo's XML types byte-identical to the yjs reference over both update
-  formats: detached subtrees now buffer their mutations and materialise
-  top-down at attach (container-before-child clocks, so bottom-up authored
-  updates apply in yjs instead of crashing `Y.applyUpdate` in `findIndexSS`);
-  non-string attribute values (e.g. a ProseMirror heading's `level=1`) are no
-  longer dropped by the getters; and the V2 encoder no longer deduplicates keys,
-  matching yjs exactly (yjs ships `writeKey` with dedup disabled — older yjs
-  clients cannot read deduped updates). The decoder still accepts both shapes.
-
-- **Detached XML nodes reflect their buffered content on read**
-  ([#170](https://github.com/reearth/ygo/pull/170)). A detached fragment/element
-  now reports its true `Len()`/`Children()`/attributes (and `ToXML`), matching
-  yjs's `_prelimContent`-aware `length`/`toArray()` — so `Insert(txn, Len(),
-  node)` appends instead of prepending, and iteration sees what was inserted
-  before attach. Nested `YXmlText` content stays opaque until attach, mirroring
-  yjs. Detached `YText` op buffering also snapshots caller-provided attribute
-  maps / delta slices, so a later caller mutation can't diverge the replayed op
-  from the attached path.
+A minor release: one new public awareness API that fixes a latent tombstone-
+accumulation bug. No breaking changes.
 
 ### Added
 
-- **Typed XML attribute accessors** — `YXmlElement.SetAttributeValue`,
-  `GetAttributeValue`, `GetAttributeValues` preserve the attribute's wire value
-  type end-to-end. The string-typed `GetAttribute`/`GetAttributes` now render
-  non-string scalars best-effort instead of dropping them.
-- **XML JS-fixture conformance suite** — `crdt/yxml_yjs_conformance_test.go`
-  applies genuine yjs@13.6 update bytes (decode, byte-identical re-encode in V1
-  and V2, byte-identical authoring against pinned clientIDs, diff-vs-state-vector,
-  concurrent merge in both orders), mirroring the existing Map/Text suites.
+- **`Awareness.PurgeTombstones(grace)` reclaims aged removal tombstones**
+  ([#166](https://github.com/reearth/ygo/issues/166)). When a client is removed
+  or expires, its entry is kept as a null-state tombstone so its clock can still
+  encode removals and reject stale re-adds. These tombstones were never
+  reclaimed: because they count toward `SetMaxClients` (deliberately, to bound a
+  peer inventing null-state client IDs), a high-churn room's entry count grew
+  monotonically and could eventually **refuse new, legitimate clients** — and
+  every full `EncodeUpdate(nil)` kept re-broadcasting them. `PurgeTombstones`
+  drops tombstones older than `grace` (a non-positive `grace` is a no-op; the
+  local client is never purged; no observer event fires).
 
-### Changed
-
-- **V2 updates can be larger for XML-heavy documents**: with key dedup disabled
-  on encode (yjs parity), every repeated key — `ContentFormat` keys like
-  `strong`, repeated element node names like `paragraph` — is re-emitted rather
-  than back-referenced. This is the size cost of byte-compatibility with the yjs
-  reference encoder.
-
----
-
-## v1.32.0
-
-A minor release: one new public API for working inside transactions, plus two
-substantial testing/CI hardening efforts that lock in ygo's convergence and
-cross-language Yjs conformance. No breaking changes.
-
-### Added
-
-- **Transaction-scoped root accessors** — `Transaction.GetText`, `GetMap`,
-  `GetArray`, `GetXmlFragment` resolve (and create on first use) root types from
-  inside a `Transact` callback without re-locking, reusing the lock the
-  transaction already holds ([#138](https://github.com/reearth/ygo/issues/138),
-  thanks @frodex). Previously the natural `doc.GetText(...)` call inside a
-  callback self-deadlocked the non-reentrant document lock. The accessors are
-  valid only inside the callback that received the transaction and **panic once
-  the transaction has committed** (e.g. from an `OnAfterTransaction` observer or
-  a retained `*Transaction`) rather than silently touching document state
-  without the lock.
-
-- **Randomized convergence fuzz framework
-  ([#70](https://github.com/reearth/ygo/issues/70)).** `testutil/fuzz` generates
-  seed-reproducible multi-peer scenarios (random ops across Text/Array/Map/XML,
-  nested containers, delivery via Apply/Merge/Diff on V1 and V2, plus GC),
-  asserts all ygo peers converge, and — when Node + `yjs` are present — checks
-  ygo against real Yjs both logically and by round-trip. Failures print a seed
-  (`FUZZ_SEED=<n>` to replay) and shrink to a minimal scenario; a regression
-  corpus locks in known cases. CI runs a fixed 1,000-seed set. This framework
-  found the convergence divergences fixed in v1.31.5 and v1.31.6.
-
-- **Cross-language Yjs conformance is now enforced in CI
-  ([#99](https://github.com/reearth/ygo/issues/99)).** Cross-impl tests hard-fail
-  (no silent skip) under `YGO_REQUIRE_NODE=1`; a symmetric Map/Array/Text/XML
-  fixture matrix (V1+V2) decodes genuine `yjs@13.6.30` bytes node-free; and a
-  fixture-drift CI job regenerates from the pinned yjs and fails on divergence.
-
-### Changed
-
-- **Documented the locking contract honestly** on `Transact` and the Doc-level
-  accessors: anything that takes the document lock still deadlocks silently when
-  called inside a `Transact` callback (Go exposes no goroutine identity with
-  which to detect it). Use the transaction accessors above, or resolve handles
-  before the transaction.
-
-## Install
-
-```
-go get github.com/reearth/ygo@v1.32.0
-```
-
-See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+  `StartAutoExpiry` now runs it automatically each tick as a second stage —
+  `RemoveExpired(timeout)` then `PurgeTombstones(2*timeout)` — so `grace`
+  outlives normal update reordering before a tombstone's clock is forgotten.
+  Callers driving expiry manually should pair `RemoveExpired` with
+  `PurgeTombstones`. Awareness remains best-effort presence (not a convergent
+  CRDT): a delayed low-clock update for an already-forgotten client is accepted
+  as new and self-heals on the next broadcast, matching y-protocols' "forget
+  after outdatedTimeout" semantics.

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -124,6 +124,12 @@ type Awareness struct {
 	activeBytes int64 // sum of wireBytes values
 	maxBytes    int64 // 0 = unlimited (default; backward compatible)
 	maxClients  int   // 0 = unlimited (default; backward compatible)
+	// removedAt records when each REMOTE client became a null-state tombstone,
+	// so PurgeTombstones can reclaim ones older than a grace period. The local
+	// client is never tracked here (its "leaving" tombstone must persist). An
+	// entry exists iff states[id] is a remote tombstone; it is cleared when the
+	// client reactivates and deleted when the tombstone is purged.
+	removedAt map[uint64]time.Time
 }
 
 // New creates an Awareness instance for the given client.
@@ -133,6 +139,7 @@ func New(clientID uint64) *Awareness {
 		states:    make(map[uint64]ClientState),
 		meta:      make(map[uint64]time.Time),
 		wireBytes: make(map[uint64]int),
+		removedAt: make(map[uint64]time.Time),
 	}
 }
 
@@ -537,6 +544,13 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 			// Store nil state with incoming clock to prevent stale re-application.
 			a.states[e.clientID] = ClientState{Clock: e.clock, State: nil}
 			delete(a.meta, e.clientID)
+			// Record the tombstone's age so PurgeTombstones can reclaim it later.
+			// Remote clients only — the local client's leaving-tombstone must
+			// persist (it is never counted here). A non-null remote update for our
+			// own clientID that gets nulled by a resource cap must not add us.
+			if e.clientID != a.clientID {
+				a.removedAt[e.clientID] = time.Now()
+			}
 			// Release any wire-bytes the previous active state held for this client.
 			if oldSize > 0 {
 				a.activeBytes -= int64(oldSize)
@@ -551,6 +565,9 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 				State: state,
 			}
 			a.meta[e.clientID] = time.Now()
+			// The client is live again — drop any tombstone-age record so a later
+			// purge won't reclaim it. No-op if it was never a tombstone.
+			delete(a.removedAt, e.clientID)
 			// Update byte accounting: replace the old size with the new size.
 			a.activeBytes += int64(newSize - oldSize)
 			a.wireBytes[e.clientID] = newSize
@@ -584,9 +601,12 @@ func (a *Awareness) ApplyUpdateContext(ctx context.Context, update []byte, origi
 	return a.ApplyUpdate(update, origin)
 }
 
-// StartAutoExpiry starts a background goroutine that periodically calls
-// RemoveExpired(timeout). The goroutine ticks at timeout/2 so that clients
-// are expired within one tick period after their deadline. The returned
+// StartAutoExpiry starts a background goroutine that periodically runs both
+// awareness-cleanup stages: RemoveExpired(timeout) to tombstone silent clients,
+// then PurgeTombstones(2*timeout) to reclaim tombstones whose removal has aged
+// out (so a high-churn room does not accumulate tombstones against the client
+// cap). The goroutine ticks at timeout/2 so that clients are expired within one
+// tick period after their deadline. The returned
 // function stops the goroutine; it must be called to avoid a goroutine leak.
 // The stop function is also stored internally and will be called by Destroy.
 func (a *Awareness) StartAutoExpiry(timeout time.Duration) func() {
@@ -615,6 +635,10 @@ func (a *Awareness) StartAutoExpiry(timeout time.Duration) func() {
 			select {
 			case <-ticker.C:
 				a.RemoveExpired(timeout)
+				// Second stage: reclaim tombstones once their clock has outlived
+				// normal update reordering. 2*timeout keeps a removal encodable
+				// and gate-effective well past propagation before it is forgotten.
+				a.PurgeTombstones(2 * timeout)
 			case <-done:
 				return
 			}
@@ -649,6 +673,11 @@ func (a *Awareness) Destroy() {
 // silent, so it's our job to broadcast presence via SetLocalState or
 // Heartbeat. Self-expiry would create false offline signals on quiet rooms.
 // Matches y-protocols / yrs behavior (#73 vector C4).
+//
+// Expiring a client converts it to a retained null-state tombstone (its clock
+// is kept for removal encoding and the clock gate); it does NOT free the entry.
+// Callers driving expiry manually should pair this with PurgeTombstones to
+// reclaim aged tombstones, or use StartAutoExpiry, which runs both stages.
 func (a *Awareness) RemoveExpired(timeout time.Duration) {
 	now := time.Now()
 	a.mu.Lock()
@@ -658,10 +687,13 @@ func (a *Awareness) RemoveExpired(timeout time.Duration) {
 			continue // never self-expire
 		}
 		if now.Sub(t) >= timeout {
-			// Mark as removed (keep clock for future clock comparisons).
+			// Mark as removed (keep clock for future clock comparisons) and
+			// record the tombstone's age for PurgeTombstones. id is always
+			// remote here (the local client is skipped above).
 			if cs, ok := a.states[id]; ok {
 				a.states[id] = ClientState{Clock: cs.Clock, State: nil}
 			}
+			a.removedAt[id] = now
 			delete(a.meta, id)
 			// Release any wire-bytes the expired client held (#48 vector B).
 			if size, ok := a.wireBytes[id]; ok {
@@ -678,4 +710,50 @@ func (a *Awareness) RemoveExpired(timeout time.Duration) {
 		evt := ChangeEvent{Removed: removed}
 		fireObservers(obs, evt)
 	}
+}
+
+// PurgeTombstones reclaims removal tombstones (clients with a null State) that
+// became tombstones longer than grace ago, freeing both their slot against
+// SetMaxClients and their memory. Without it, a high-churn room accumulates
+// tombstones without bound — each retained entry counts toward the client cap,
+// so the room can eventually refuse new, legitimate clients — and every full
+// EncodeUpdate(nil) keeps re-broadcasting them as null.
+//
+// grace MUST exceed the RemoveExpired timeout (and the provider's full-state
+// re-broadcast interval): a tombstone's clock is what encodes removals and
+// rejects stale re-adds, so it must outlive normal update reordering before it
+// is forgotten. A non-positive grace is a no-op. The local client is never
+// purged. Purging fires no observer event — a purged tombstone was either
+// already signalled removed or never signalled present, so no consumer is
+// tracking it (GetStates already hides tombstones).
+//
+// Cross-peer note: after a tombstone is forgotten, a delayed low-clock update
+// for that id is accepted as a new client, whereas a peer that has not yet
+// purged would drop it. This transient divergence self-heals on the next
+// broadcast and matches y-protocols' "forget after outdatedTimeout" semantics;
+// awareness is best-effort presence, not a convergent CRDT.
+//
+// Returns the number of tombstones reclaimed.
+func (a *Awareness) PurgeTombstones(grace time.Duration) int {
+	if grace <= 0 {
+		return 0
+	}
+	now := time.Now()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	purged := 0
+	for id, t := range a.removedAt {
+		if id == a.clientID {
+			continue // never purge the local client's own tombstone
+		}
+		if now.Sub(t) < grace {
+			continue
+		}
+		delete(a.states, id)
+		delete(a.removedAt, id)
+		delete(a.meta, id)      // defensive: tombstones carry no meta entry
+		delete(a.wireBytes, id) // defensive: released when the tombstone formed
+		purged++
+	}
+	return purged
 }

--- a/awareness/tombstone_test.go
+++ b/awareness/tombstone_test.go
@@ -1,0 +1,207 @@
+package awareness
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/encoding"
+)
+
+// encodeAt builds a single-client awareness frame at an explicit clock, mirroring
+// EncodeUpdate's wire layout: varuint(count) then varuint(id) varuint(clock)
+// varstring(json). Pass "null" for a removal frame. Lets a test drive clocks the
+// encodeOneEntry helper (fixed clock 1/2) can't reach — e.g. reactivating a
+// tombstone that sits at clock 2.
+func encodeAt(id, clock uint64, stateJSON string) []byte {
+	enc := encoding.NewEncoder()
+	enc.WriteVarUint(1)
+	enc.WriteVarUint(id)
+	enc.WriteVarUint(clock)
+	enc.WriteVarString(stateJSON)
+	return enc.Bytes()
+}
+
+// makeTombstone creates a remote tombstone for id and backdates its removal by
+// age, so PurgeTombstones sees it as older than a grace shorter than age.
+func makeTombstone(t *testing.T, a *Awareness, id uint64, age time.Duration) {
+	t.Helper()
+	applyEntry(t, a, id, "null")
+	if _, ok := a.removedAt[id]; !ok {
+		t.Fatalf("tombstone for id %d did not record removedAt", id)
+	}
+	a.removedAt[id] = time.Now().Add(-age)
+}
+
+func TestPurgeTombstones_ReclaimsAgedTombstones(t *testing.T) {
+	a := New(0)
+	makeTombstone(t, a, 1, time.Hour)
+	makeTombstone(t, a, 2, time.Hour)
+	applyEntry(t, a, 3, "null") // fresh tombstone, removedAt == now
+	a.removedAt[3] = time.Now() // ensure fresh
+
+	purged := a.PurgeTombstones(time.Minute)
+
+	if purged != 2 {
+		t.Fatalf("purged = %d, want 2", purged)
+	}
+	if _, ok := a.states[1]; ok {
+		t.Error("aged tombstone 1 should be purged")
+	}
+	if _, ok := a.states[2]; ok {
+		t.Error("aged tombstone 2 should be purged")
+	}
+	if _, ok := a.states[3]; !ok {
+		t.Error("fresh tombstone 3 should be retained")
+	}
+	if _, ok := a.removedAt[1]; ok {
+		t.Error("removedAt entry for purged id 1 should be deleted")
+	}
+}
+
+func TestPurgeTombstones_PreservesLiveAndLocalClients(t *testing.T) {
+	a := New(0)
+	a.SetLocalState(map[string]any{"me": true})
+	a.SetLocalState(nil)                        // local becomes a tombstone (id 0) — must never be purged
+	a.removedAt[0] = time.Now().Add(-time.Hour) // even if aged (it never gets one, but be adversarial)
+
+	applyEntry(t, a, 1, "hi")         // live remote
+	makeTombstone(t, a, 2, time.Hour) // aged remote tombstone
+
+	purged := a.PurgeTombstones(time.Minute)
+
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (only remote tombstone 2)", purged)
+	}
+	if _, ok := a.states[0]; !ok {
+		t.Error("local client (id 0) must never be purged")
+	}
+	if _, ok := a.states[1]; !ok {
+		t.Error("live remote client 1 must be retained")
+	}
+	if _, ok := a.states[2]; ok {
+		t.Error("aged remote tombstone 2 should be purged")
+	}
+}
+
+func TestPurgeTombstones_FreesCapForNewClients(t *testing.T) {
+	a := New(0)
+	a.SetMaxClients(2)
+	makeTombstone(t, a, 1, time.Hour)
+	makeTombstone(t, a, 2, time.Hour)
+
+	// Cap is full of tombstones — a previously-unseen client is refused.
+	applyEntry(t, a, 3, "hi")
+	if _, ok := a.states[3]; ok {
+		t.Fatal("precondition: new client 3 should be refused while cap is full")
+	}
+
+	if purged := a.PurgeTombstones(time.Minute); purged != 2 {
+		t.Fatalf("purged = %d, want 2", purged)
+	}
+
+	// Cap freed — the same client is now accepted.
+	applyEntry(t, a, 3, "hi")
+	cs, ok := a.states[3]
+	if !ok || cs.State == nil {
+		t.Error("after reclamation, new client 3 should be accepted with live state")
+	}
+}
+
+func TestPurgeTombstones_ClearsRemovedAtOnReactivation(t *testing.T) {
+	a := New(0)
+	makeTombstone(t, a, 1, time.Hour) // tombstone at clock 2, aged
+
+	// Reactivate at a higher clock than the tombstone (clock 2).
+	if err := a.ApplyUpdate(encodeAt(1, 3, `{"v":"back"}`), nil); err != nil {
+		t.Fatalf("reactivation ApplyUpdate: %v", err)
+	}
+	if _, ok := a.removedAt[1]; ok {
+		t.Fatal("removedAt must be cleared when a tombstone reactivates")
+	}
+
+	// A now-live client must survive a purge even though it was once aged.
+	if purged := a.PurgeTombstones(time.Minute); purged != 0 {
+		t.Fatalf("purged = %d, want 0 (client is live again)", purged)
+	}
+	if cs, ok := a.states[1]; !ok || cs.State == nil {
+		t.Error("reactivated client 1 must remain live")
+	}
+}
+
+func TestPurgeTombstones_FiresNoObserverEvent(t *testing.T) {
+	a := New(0)
+	var events int
+	a.OnChange(func(ChangeEvent) { events++ })
+
+	applyEntry(t, a, 1, "hi")   // Added event
+	applyEntry(t, a, 1, "null") // Removed event (was active)
+	a.removedAt[1] = time.Now().Add(-time.Hour)
+	before := events
+
+	if purged := a.PurgeTombstones(time.Minute); purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if events != before {
+		t.Errorf("PurgeTombstones fired %d observer event(s); want 0", events-before)
+	}
+}
+
+func TestPurgeTombstones_EncodeUpdateNilDropsPurged(t *testing.T) {
+	a := New(0)
+	makeTombstone(t, a, 1, time.Hour) // aged tombstone
+	applyEntry(t, a, 2, "hi")         // live client
+
+	a.PurgeTombstones(time.Minute)
+
+	// A full-state broadcast must no longer carry the purged id.
+	peer := New(99)
+	if err := peer.ApplyUpdate(a.EncodeUpdate(nil), nil); err != nil {
+		t.Fatalf("peer ApplyUpdate: %v", err)
+	}
+	if _, ok := peer.states[1]; ok {
+		t.Error("EncodeUpdate(nil) should not emit the purged tombstone (id 1)")
+	}
+	if _, ok := peer.states[2]; !ok {
+		t.Error("EncodeUpdate(nil) must still emit the live client (id 2)")
+	}
+}
+
+func TestStartAutoExpiry_ReclaimsTombstones(t *testing.T) {
+	a := New(0)
+	applyEntry(t, a, 1, "hi") // live remote client; never heartbeats again
+
+	stop := a.StartAutoExpiry(20 * time.Millisecond)
+	defer stop()
+
+	exists := func(id uint64) bool {
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+		_, ok := a.states[id]
+		return ok
+	}
+
+	// The client expires into a tombstone (~20ms) and is then purged by the
+	// second stage once its removal is older than 2*timeout (~40ms). The raw
+	// states entry must eventually disappear entirely, not linger as a tombstone.
+	deadline := time.Now().Add(2 * time.Second)
+	for exists(1) {
+		if time.Now().After(deadline) {
+			t.Fatal("StartAutoExpiry did not reclaim the tombstone for id 1 within 2s")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestPurgeTombstones_NonPositiveGraceIsNoOp(t *testing.T) {
+	a := New(0)
+	makeTombstone(t, a, 1, time.Hour)
+
+	for _, grace := range []time.Duration{0, -time.Second} {
+		if purged := a.PurgeTombstones(grace); purged != 0 {
+			t.Errorf("PurgeTombstones(%v) = %d, want 0 (no-op)", grace, purged)
+		}
+		if _, ok := a.states[1]; !ok {
+			t.Fatalf("tombstone must survive PurgeTombstones(%v)", grace)
+		}
+	}
+}

--- a/cluster/mem_relay_test.go
+++ b/cluster/mem_relay_test.go
@@ -76,11 +76,18 @@ func newFakeSinkClient(room string, relay cluster.Relay, clientID uint64) *fakeS
 func (s *fakeSink) Inject(_ context.Context, in cluster.Inbound) error {
 	switch in.Kind {
 	case cluster.KindSync:
+		// Apply BEFORE bumping the counter. Tests wait on the counter and then
+		// read the doc/awareness, so the counter must be the happens-before
+		// signal that the state is already applied. Bumping first let a test
+		// observe count>=1 while ApplyUpdate was still in flight on the relay
+		// goroutine, racing GetStates()/ToString() (flaky NoEcho tests).
+		err := crdt.ApplyUpdateV1(s.doc, in.Data, relaySentinel)
 		s.injectedSync.Add(1)
-		return crdt.ApplyUpdateV1(s.doc, in.Data, relaySentinel)
+		return err
 	case cluster.KindAwareness:
+		err := s.aw.ApplyUpdate(in.Data, relaySentinel)
 		s.injectedAwareness.Add(1)
-		return s.aw.ApplyUpdate(in.Data, relaySentinel)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #166.

## Problem

When a client is removed or expires, `Awareness` keeps its entry as a null-state
**tombstone** so the clock can still encode removals and reject stale re-adds.
These tombstones were **never reclaimed**. Because they deliberately count toward
`SetMaxClients` (the cap exists to bound a peer inventing unbounded null-state
client IDs, which bypass the byte cap), a high-churn room's entry count grows
**monotonically** and can eventually **refuse new, legitimate clients**. Every
full `EncodeUpdate(nil)` also keeps re-broadcasting the dead entries.

Confirmed in current code: `RemoveExpired` (`awareness.go`) turns an expired
client into a permanent null-state entry and drops its `meta` timestamp; the cap
gate counts `len(a.states)` including tombstones.

## Fix

- New **`Awareness.PurgeTombstones(grace time.Duration) int`** — reclaims remote
  tombstones older than `grace`, freeing both the `MaxClients` slot and memory.
  Non-positive `grace` is a no-op; the local client is never purged; **no
  observer event fires** (a purged tombstone was either already signalled removed
  or never signalled present).
- Track a private `removedAt` timestamp per remote tombstone — set at both
  tombstone sites (`RemoveExpired` and the `ApplyUpdate` null / cap-rejected
  branch, guarded so the local id is never tracked), cleared on reactivation,
  deleted on purge.
- **DoS bound preserved:** tombstones still count toward the cap; reclamation is
  what keeps legitimate churn from wedging it.
- `StartAutoExpiry` now runs a second stage each tick: `RemoveExpired(timeout)`
  then `PurgeTombstones(2*timeout)`, so `grace` outlives normal update reordering
  before a tombstone's clock is forgotten. `RemoveExpired`'s godoc now notes that
  manual callers should pair it with `PurgeTombstones`.

`grace` must exceed the expiry timeout (and the provider's full-state
re-broadcast interval). Awareness stays best-effort presence: a delayed low-clock
update for a forgotten client is accepted as new and self-heals on the next
broadcast, matching y-protocols' "forget after outdatedTimeout" semantics.

## Tests (TDD, red-first)

New internal white-box `awareness/tombstone_test.go`, all deterministic (the one
timing test aside): reclaims aged tombstones; preserves live + local clients;
frees the cap for new clients; clears `removedAt` on reactivation; fires no
observer event; `EncodeUpdate(nil)` drops purged ids; non-positive grace is a
no-op; and `StartAutoExpiry` reclaims automatically. `go test ./awareness -race`,
`go vet`, `gofmt`, and `golangci-lint` all clean; consumers
(`provider/`, `cluster/`, `sync/`) unaffected.

## ⚠️ Version-ordering note for the maintainer

Branched off `main` (currently **v1.32.0**) and labelled **v1.34.0**, assuming the
in-flight `feat/mobile-bindings-v2` branch (which claims **v1.33.0** for #118/#119/#109)
merges first. **If this PR merges before that branch, renumber the CHANGELOG /
RELEASE_NOTES heading here to v1.33.0** (and the other branch to v1.34.0). Adds a
public method, so it's a minor bump either way.
