### PR TITLE
fix(crdt): detached XML nodes reflect prelim content on read (#147 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     attributes. Building a tree bottom-up previously assigned child clocks
     below the container's, emitting same-client forward parent references
     that crash `Y.applyUpdate` in yjs (`findIndexSS` TypeError) and that
-    ygo itself parked forever on re-apply (fragment emptied). Detached
-    nodes read as uniformly EMPTY (`Len`, `Children`, attribute getters,
-    `ToXML`) until attached.
+    ygo itself parked forever on re-apply (fragment emptied). A detached
+    fragment/element **reflects its buffered prelim content** to readers
+    (`Len`, `Children`, attribute getters, `ToXML`), matching yjs's
+    `_prelimContent`-aware `length`/`toArray()` — so `Insert(txn, Len(),
+    node)` appends rather than prepending, and iteration sees what was
+    inserted before attach. Nested `YXmlText` content stays opaque until
+    attach (`Len` 0, empty `ToString`), mirroring yjs. (Reflecting prelim
+    *attributes* on read is intentionally more complete than yjs, which
+    hides `_prelimAttrs` until integrate; ygo keeps detached reads
+    consistent with the attached view. Wire bytes are unaffected either way.)
   - Non-string XML attribute values (e.g. a ProseMirror heading's
     `level=1`, a number) are no longer dropped by the attribute getters.
   - The V2 encoder no longer deduplicates keys, matching the yjs reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.33.0] — 2026-07-18
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.31.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.33.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,54 @@
+## v1.33.0
+
+A minor release that makes ygo's XML types (`Y.XmlFragment`/`Y.XmlElement`/
+`Y.XmlText`) **byte-conformant with yjs@13.6** over both V1 and V2 updates — the
+`y-prosemirror` shapes now round-trip and converge with real yjs — plus new
+typed XML attribute accessors. No breaking changes.
+
+### Fixed
+
+- **XML wire conformance with yjs**
+  ([#147](https://github.com/reearth/ygo/pull/147), thanks @frodex). Three fixes
+  make ygo's XML types byte-identical to the yjs reference over both update
+  formats: detached subtrees now buffer their mutations and materialise
+  top-down at attach (container-before-child clocks, so bottom-up authored
+  updates apply in yjs instead of crashing `Y.applyUpdate` in `findIndexSS`);
+  non-string attribute values (e.g. a ProseMirror heading's `level=1`) are no
+  longer dropped by the getters; and the V2 encoder no longer deduplicates keys,
+  matching yjs exactly (yjs ships `writeKey` with dedup disabled — older yjs
+  clients cannot read deduped updates). The decoder still accepts both shapes.
+
+- **Detached XML nodes reflect their buffered content on read**
+  ([#170](https://github.com/reearth/ygo/pull/170)). A detached fragment/element
+  now reports its true `Len()`/`Children()`/attributes (and `ToXML`), matching
+  yjs's `_prelimContent`-aware `length`/`toArray()` — so `Insert(txn, Len(),
+  node)` appends instead of prepending, and iteration sees what was inserted
+  before attach. Nested `YXmlText` content stays opaque until attach, mirroring
+  yjs. Detached `YText` op buffering also snapshots caller-provided attribute
+  maps / delta slices, so a later caller mutation can't diverge the replayed op
+  from the attached path.
+
+### Added
+
+- **Typed XML attribute accessors** — `YXmlElement.SetAttributeValue`,
+  `GetAttributeValue`, `GetAttributeValues` preserve the attribute's wire value
+  type end-to-end. The string-typed `GetAttribute`/`GetAttributes` now render
+  non-string scalars best-effort instead of dropping them.
+- **XML JS-fixture conformance suite** — `crdt/yxml_yjs_conformance_test.go`
+  applies genuine yjs@13.6 update bytes (decode, byte-identical re-encode in V1
+  and V2, byte-identical authoring against pinned clientIDs, diff-vs-state-vector,
+  concurrent merge in both orders), mirroring the existing Map/Text suites.
+
+### Changed
+
+- **V2 updates can be larger for XML-heavy documents**: with key dedup disabled
+  on encode (yjs parity), every repeated key — `ContentFormat` keys like
+  `strong`, repeated element node names like `paragraph` — is re-emitted rather
+  than back-referenced. This is the size cost of byte-compatibility with the yjs
+  reference encoder.
+
+---
+
 ## v1.32.0
 
 A minor release: one new public API for working inside transactions, plus two

--- a/crdt/content.go
+++ b/crdt/content.go
@@ -136,17 +136,27 @@ func (c *ContentBinary) Splice(_ int) Content { panic("crdt: ContentBinary is no
 // Used by YArray when storing heterogeneous elements.
 type ContentAny struct{ Vals []any }
 
+// normalizeAnyScalar maps a Go scalar to the type it will hold once it has
+// round-tripped through a V1/V2 update: Go int becomes int64 (ReadAny returns
+// int64 for VarInt-encoded integers). Everything else is returned unchanged.
+// It is the single source of truth for this normalisation so that values
+// buffered locally (e.g. detached XML prelim attributes) read back with the
+// exact same type as values that were actually encoded — see NewContentAny and
+// YXmlElement.SetAttributeValue.
+func normalizeAnyScalar(v any) any {
+	if n, ok := v.(int); ok {
+		return int64(n)
+	}
+	return v
+}
+
 // NewContentAny creates a ContentAny, normalising Go int values to int64 so
 // that locally-stored integers are wire-compatible with values decoded from
 // V1/V2 updates (ReadAny returns int64 for VarInt-encoded integers).
 func NewContentAny(vals ...any) *ContentAny {
 	normalized := make([]any, len(vals))
 	for i, v := range vals {
-		if n, ok := v.(int); ok {
-			normalized[i] = int64(n)
-		} else {
-			normalized[i] = v
-		}
+		normalized[i] = normalizeAnyScalar(v)
 	}
 	return &ContentAny{normalized}
 }

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -37,6 +37,39 @@ func (txt *YText) buffer(op func(txn *Transaction)) {
 	txt.pending = append(txt.pending, op)
 }
 
+// cloneAttributes returns a shallow copy of attrs (nil for nil/empty). Detached
+// YText ops buffer a closure that reads attrs at attach time; snapshotting the
+// caller's map here keeps detached semantics identical to the attached path,
+// which consumes attrs DURING the call — so a later caller mutation of the same
+// map is invisible on both paths. (#170, Copilot review)
+func cloneAttributes(attrs Attributes) Attributes {
+	if len(attrs) == 0 {
+		return nil
+	}
+	cp := make(Attributes, len(attrs))
+	for k, v := range attrs {
+		cp[k] = v
+	}
+	return cp
+}
+
+// cloneDelta shallow-copies a delta slice and each op's Attributes map, so a
+// buffered (detached) ApplyDelta replays exactly the ops passed at call time
+// even if the caller reuses or mutates the slice/maps before attach. The Insert
+// payload is left by reference — it is stored by reference on the attached path
+// too, so there is no detached-vs-attached divergence to protect against.
+func cloneDelta(delta []Delta) []Delta {
+	if len(delta) == 0 {
+		return nil
+	}
+	cp := make([]Delta, len(delta))
+	copy(cp, delta)
+	for i := range cp {
+		cp[i].Attributes = cloneAttributes(cp[i].Attributes)
+	}
+	return cp
+}
+
 // flushPrelim replays operations buffered while this text was detached.
 // Called by item.integrate when the container item integrates (prelimFlusher).
 func (txt *YText) flushPrelim(txn *Transaction) {
@@ -286,6 +319,7 @@ func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attribu
 		return
 	}
 	if txt.detached() {
+		attrs := cloneAttributes(attrs)
 		txt.buffer(func(txn *Transaction) { txt.Insert(txn, index, text, attrs) })
 		return
 	}
@@ -487,6 +521,7 @@ func (txt *YText) currentAttributesAt(anchor *Item) Attributes {
 // Added in v1.12.0 (#76).
 func (txt *YText) InsertEmbed(txn *Transaction, index int, embed any, attrs Attributes) {
 	if txt.detached() {
+		attrs := cloneAttributes(attrs)
 		txt.buffer(func(txn *Transaction) { txt.InsertEmbed(txn, index, embed, attrs) })
 		return
 	}
@@ -735,6 +770,7 @@ func (txt *YText) Format(txn *Transaction, index, length int, attrs Attributes) 
 		return
 	}
 	if txt.detached() {
+		attrs := cloneAttributes(attrs)
 		txt.buffer(func(txn *Transaction) { txt.Format(txn, index, length, attrs) })
 		return
 	}
@@ -1167,6 +1203,7 @@ func (txt *YText) Observe(fn func(YTextEvent)) func() {
 // Transact callback.
 func (txt *YText) ApplyDelta(txn *Transaction, delta []Delta) {
 	if txt.detached() {
+		delta := cloneDelta(delta)
 		txt.buffer(func(txn *Transaction) { txt.ApplyDelta(txn, delta) })
 		return
 	}

--- a/crdt/yxml.go
+++ b/crdt/yxml.go
@@ -61,11 +61,15 @@ func (f *YXmlFragment) prepareFire(txn *Transaction, keysChanged map[string]stru
 
 // Len returns the number of non-deleted child nodes (attributes are excluded).
 //
-// A DETACHED fragment/element reports 0: buffered prelim children are not
-// visible to any reader (Len, Children, attribute getters, ToXML) until the
-// subtree attaches — uniform with YText, whose detached Len/ToString likewise
-// ignore pending operations.
+// A DETACHED fragment/element reports its buffered prelim child count, matching
+// yjs's _prelimContent-aware length. This keeps index math consistent across
+// attach — in particular Insert(txn, Len(), node) appends rather than
+// prepending. (Nested TEXT content stays opaque until attach: a detached
+// YXmlText reports Len 0, mirroring yjs — see YText.) (#yxml-wire)
 func (f *YXmlFragment) Len() int {
+	if f.detached() {
+		return len(f.prelimChildren)
+	}
 	count := 0
 	for item := f.start; item != nil; item = item.Right {
 		if !item.Deleted && item.Content.IsCountable() && item.ParentSub == nil {
@@ -181,8 +185,17 @@ func (f *YXmlFragment) flushPrelim(txn *Transaction) {
 	}
 }
 
-// Children returns all non-deleted child XML nodes in document order.
+// Children returns all non-deleted child XML nodes in document order. A
+// DETACHED fragment/element returns a copy of its buffered prelim children (the
+// same node values that were inserted), so iteration and ToXML reflect the
+// subtree before it attaches. As everywhere in this package, buffer only FRESH
+// nodes into a detached parent: inserting an already-attached node is the usual
+// re-parenting misuse, and reading the detached parent's ToXML would then
+// recurse into that attached child's lock-taking serialisation. (#yxml-wire)
 func (f *YXmlFragment) Children() []xmlNode {
+	if f.detached() {
+		return append([]xmlNode(nil), f.prelimChildren...)
+	}
 	var result []xmlNode
 	for item := f.start; item != nil; item = item.Right {
 		if item.Deleted || item.ParentSub != nil {
@@ -317,6 +330,11 @@ func (e *YXmlElement) SetAttribute(txn *Transaction, key, value string) {
 func (e *YXmlElement) SetAttributeValue(txn *Transaction, key string, value any) {
 	t := &e.abstractType
 	if t.detached() {
+		// Store the wire-normalised value (int -> int64, the same transform
+		// NewContentAny applies below) so a detached GetAttributeValue reads
+		// back the exact type it would after attach. flushPrelim re-applies
+		// this value, so the encoded bytes are unaffected.
+		value = normalizeAnyScalar(value)
 		for i := range e.prelimAttrs {
 			if e.prelimAttrs[i].key == key {
 				e.prelimAttrs[i].value = value
@@ -388,9 +406,19 @@ func (e *YXmlElement) GetAttribute(key string) (string, bool) {
 }
 
 // GetAttributeValue returns the typed value of attribute key (string, int64,
-// float64, bool, … — whatever the CRDT holds) and whether it is present.
+// float64, bool, … — whatever the CRDT holds) and whether it is present. On a
+// DETACHED element it reads the buffered prelim attribute, already normalised
+// to its wire type, so the result is identical before and after attach.
 func (e *YXmlElement) GetAttributeValue(key string) (any, bool) {
 	t := &e.abstractType
+	if t.detached() {
+		for i := range e.prelimAttrs {
+			if e.prelimAttrs[i].key == key {
+				return e.prelimAttrs[i].value, true
+			}
+		}
+		return nil, false
+	}
 	item, ok := t.itemMap[key]
 	if !ok || item.Deleted {
 		return nil, false
@@ -413,9 +441,20 @@ func (e *YXmlElement) GetAttributes() map[string]string {
 }
 
 // GetAttributeValues returns all live attributes with their typed values,
-// mirroring Yjs's YXmlElement.getAttributes().
+// mirroring Yjs's YXmlElement.getAttributes(). A DETACHED element returns its
+// buffered prelim attributes (normalised to their wire types). Note this is
+// intentionally MORE complete than yjs, whose getAttribute does not surface
+// _prelimAttrs until integrate — ygo keeps detached reads consistent with the
+// attached view. Wire bytes are unaffected. (#yxml-wire)
 func (e *YXmlElement) GetAttributeValues() map[string]any {
 	t := &e.abstractType
+	if t.detached() {
+		result := make(map[string]any, len(e.prelimAttrs))
+		for _, kv := range e.prelimAttrs {
+			result[kv.key] = kv.value
+		}
+		return result
+	}
 	result := make(map[string]any)
 	for k, item := range t.itemMap {
 		if item.Deleted {

--- a/crdt/yxml_detached_test.go
+++ b/crdt/yxml_detached_test.go
@@ -6,15 +6,13 @@ import (
 	"github.com/reearth/ygo/crdt"
 )
 
-// Detached XML nodes buffer their mutations (prelim content/attrs) and are
-// uniformly EMPTY to every reader until the subtree attaches: Len, Children,
-// attribute getters and ToXML all see nothing. This mirrors YText in this
-// package (a detached YText's Len/ToString ignore pending ops) and keeps the
-// read API consistent — previously Len() alone consulted the prelim buffer,
-// so a detached node could report Len()==1 while Children() was empty
-// (an index loop over Children driven by Len would panic), and a value set
-// with SetAttributeValue read back as absent.
-func TestYXml_DetachedReadsAreEmptyUntilAttached(t *testing.T) {
+// A detached XML node reflects its buffered prelim content to readers, matching
+// yjs's _prelimContent-aware length/toArray(): Len, Children, the attribute
+// getters and ToXML all see what was inserted BEFORE the subtree attaches. The
+// one exception is nested TEXT content — a detached YXmlText is opaque (Len 0,
+// empty ToString), exactly as in yjs — so a detached element renders its tag
+// and attributes but an empty body until it attaches and the text materialises.
+func TestYXml_DetachedReadsReflectPrelim(t *testing.T) {
 	doc := crdt.New()
 	frag := doc.GetXmlFragment("f")
 
@@ -26,50 +24,109 @@ func TestYXml_DetachedReadsAreEmptyUntilAttached(t *testing.T) {
 		el.InsertText(txn, 0, txt)
 		el.SetAttributeValue(txn, "level", 1)
 
-		// Detached: every reader is empty — buffered writes are invisible.
-		if n := el.Len(); n != 0 {
-			t.Errorf("detached Len() = %d, want 0 (uniform empty-until-attached)", n)
+		// Detached: children and attributes are visible; the text child is
+		// present as a node but its content is still opaque.
+		if n := el.Len(); n != 1 {
+			t.Errorf("detached Len() = %d, want 1 (prelim child reflected)", n)
 		}
-		if kids := el.Children(); len(kids) != 0 {
-			t.Errorf("detached Children() = %d nodes, want 0", len(kids))
+		kids := el.Children()
+		if len(kids) != 1 {
+			t.Fatalf("detached Children() = %d nodes, want 1", len(kids))
 		}
-		if v, ok := el.GetAttributeValue("level"); ok {
-			t.Errorf("detached GetAttributeValue = %v, want absent", v)
+		if got, ok := kids[0].(*crdt.YXmlText); !ok || got != txt {
+			t.Errorf("detached Children()[0] is not the inserted text node (identity lost)")
 		}
-		if attrs := el.GetAttributes(); len(attrs) != 0 {
-			t.Errorf("detached GetAttributes = %v, want empty", attrs)
+		// Attribute value is reflected AND already normalized to the wire type
+		// (int -> int64), so it reads identically before and after attach.
+		if v, ok := el.GetAttributeValue("level"); !ok || v != int64(1) {
+			t.Errorf("detached GetAttributeValue = %v (%T), %v; want int64(1), true", v, v, ok)
 		}
-		if got, want := el.ToXML(), "<paragraph></paragraph>"; got != want {
+		if attrs := el.GetAttributes(); len(attrs) != 1 || attrs["level"] != "1" {
+			t.Errorf("detached GetAttributes = %v, want map[level:1]", attrs)
+		}
+		// Nested text opaque while detached -> empty body.
+		if got, want := el.ToXML(), `<paragraph level="1"></paragraph>`; got != want {
 			t.Errorf("detached ToXML() = %q, want %q", got, want)
 		}
 		if n := txt.Len(); n != 0 {
-			t.Errorf("detached YXmlText Len() = %d, want 0", n)
+			t.Errorf("detached YXmlText Len() = %d, want 0 (text prelim is opaque)", n)
 		}
 
 		frag.InsertElement(txn, 0, el)
 	}, nil)
 
-	// Attached: the buffered writes materialised; all readers agree.
+	// Attached: the text materialised; the body fills in. Everything else is
+	// unchanged from the detached reads — that's the point.
 	// (Asserted OUTSIDE the transaction: ToXML on an attached tree recurses
 	// into YXmlText.ToString, which takes the doc read lock that Transact
 	// still holds inside the callback.)
 	if n := el.Len(); n != 1 {
 		t.Errorf("attached Len() = %d, want 1", n)
 	}
-	if kids := el.Children(); len(kids) != 1 {
-		t.Errorf("attached Children() = %d nodes, want 1", len(kids))
-	}
-	// NewContentAny normalizes Go ints to int64 (wire-number parity).
 	if v, ok := el.GetAttributeValue("level"); !ok || v != int64(1) {
 		t.Errorf("attached GetAttributeValue = %v (%T), %v; want int64(1), true", v, v, ok)
 	}
 	if got, want := el.ToXML(), `<paragraph level="1">hello</paragraph>`; got != want {
-		t.Errorf("attached ToXML() = %q, want %q", got, want)
-	}
-	if n := frag.Len(); n != 1 {
-		t.Errorf("root fragment Len() = %d, want 1", n)
+		t.Errorf("attached ToXML() = %q, want %q (text now materialised)", got, want)
 	}
 	if got, want := frag.ToXML(), `<paragraph level="1">hello</paragraph>`; got != want {
 		t.Errorf("final ToXML() = %q, want %q", got, want)
+	}
+}
+
+// Reflection is recursive: a detached element built entirely from nested
+// elements (no text) renders byte-for-byte the same ToXML detached as attached,
+// proving Children()/attributes reflect prelim all the way down.
+func TestYXml_DetachedNestedElementsReflectRecursively(t *testing.T) {
+	doc := crdt.New()
+	frag := doc.GetXmlFragment("f")
+
+	ul := crdt.NewYXmlElement("bullet_list")
+	li := crdt.NewYXmlElement("list_item")
+	p := crdt.NewYXmlElement("paragraph")
+
+	const want = `<bullet_list tight="true"><list_item><paragraph></paragraph></list_item></bullet_list>`
+
+	doc.Transact(func(txn *crdt.Transaction) {
+		li.InsertElement(txn, 0, p)
+		ul.SetAttributeValue(txn, "tight", true)
+		ul.InsertElement(txn, 0, li)
+
+		// Detached, fully recursive read — no text anywhere, so ToXML is total.
+		if got := ul.ToXML(); got != want {
+			t.Errorf("detached recursive ToXML() = %q, want %q", got, want)
+		}
+		if n := ul.Len(); n != 1 {
+			t.Errorf("detached ul.Len() = %d, want 1", n)
+		}
+		frag.InsertElement(txn, 0, ul)
+	}, nil)
+
+	// Identical after attach.
+	if got := ul.ToXML(); got != want {
+		t.Errorf("attached recursive ToXML() = %q, want %q", got, want)
+	}
+}
+
+// Regression: because a detached element now reports its true Len(), the
+// idiomatic append `el.Insert(txn, el.Len(), child)` appends in order. Under
+// the previous empty-until-attached behavior Len() was always 0, so every
+// insert landed at position 0 and the children came out reversed.
+func TestYXml_DetachedInsertAtLenAppends(t *testing.T) {
+	doc := crdt.New()
+	frag := doc.GetXmlFragment("f")
+	ul := crdt.NewYXmlElement("ul")
+
+	doc.Transact(func(txn *crdt.Transaction) {
+		for _, s := range []string{"a", "b", "c"} {
+			txt := crdt.NewYXmlText()
+			txt.Insert(txn, 0, s, nil)
+			ul.InsertText(txn, ul.Len(), txt) // append at current end
+		}
+		frag.InsertElement(txn, 0, ul)
+	}, nil)
+
+	if got, want := ul.ToXML(), "<ul>abc</ul>"; got != want {
+		t.Errorf("ToXML() = %q, want %q (Len()-relative append must preserve order)", got, want)
 	}
 }

--- a/crdt/yxml_prelim_ops_test.go
+++ b/crdt/yxml_prelim_ops_test.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -225,4 +226,48 @@ func TestUnit_YXmlText_DetachedBufferedOpsMatchAttached(t *testing.T) {
 	assert.Equal(t, att.ToString(), det.ToString())
 	assert.Equal(t, att.ToDelta(), det.ToDelta(),
 		"detached buffering must be semantically transparent")
+}
+
+// Detached YText buffering must SNAPSHOT caller-provided Attributes (and delta
+// slices): mutating the map/slice after the buffered call but before attach
+// must not change the replayed op — matching the attached path, which consumes
+// them during the call. (#170, Copilot review)
+func TestUnit_YText_DetachedBufferingSnapshotsAttrs(t *testing.T) {
+	doc := newTestDoc(9)
+	frag := doc.GetXmlFragment("root")
+	ins, fmtT, delT := NewYXmlText(), NewYXmlText(), NewYXmlText()
+
+	insAttrs := Attributes{"bold": true}
+	fmtAttrs := Attributes{"em": true}
+	delta := []Delta{{Op: DeltaOpInsert, Insert: "x", Attributes: Attributes{"code": true}}}
+
+	doc.Transact(func(txn *Transaction) {
+		// Buffer while detached...
+		ins.Insert(txn, 0, "hi", insAttrs)
+		fmtT.Insert(txn, 0, "hi", nil)
+		fmtT.Format(txn, 0, 2, fmtAttrs)
+		delT.ApplyDelta(txn, delta)
+
+		// ...then mutate the caller's maps/slice BEFORE attach/flush.
+		insAttrs["bold"] = false
+		insAttrs["italic"] = true
+		fmtAttrs["em"] = false
+		delta[0].Attributes["code"] = false
+		delta[0].Insert = "MUT"
+
+		frag.InsertText(txn, 0, ins)
+		frag.InsertText(txn, 1, fmtT)
+		frag.InsertText(txn, 2, delT)
+	})
+
+	// Replays must reflect the snapshot at call time, not the later mutations.
+	if d := ins.ToDelta(); len(d) != 1 || !reflect.DeepEqual(d[0].Attributes, Attributes{"bold": true}) {
+		t.Errorf("Insert attrs = %+v, want {bold:true} (snapshot, not mutated)", d)
+	}
+	if d := fmtT.ToDelta(); len(d) != 1 || !reflect.DeepEqual(d[0].Attributes, Attributes{"em": true}) {
+		t.Errorf("Format attrs = %+v, want {em:true} (snapshot, not mutated)", d)
+	}
+	if d := delT.ToDelta(); len(d) != 1 || d[0].Insert != "x" || !reflect.DeepEqual(d[0].Attributes, Attributes{"code": true}) {
+		t.Errorf("ApplyDelta op = %+v, want insert=x attrs={code:true} (snapshot)", d)
+	}
 }


### PR DESCRIPTION
> **Stacks on #147** (`fix/yxml-wire-conformance`). It depends on the `prelimChildren`/`prelimAttrs` buffers introduced there, so until #147 merges this PR's diff also shows #147's commits. Review/merge **after** #147; the diff collapses to just these ~5 files once #147 lands. Intended to ship **together with #147 as the next minor release**.

## Problem

#147 made every reader on a **detached** XML node return empty until the subtree attaches (`Len`, `Children`, attribute getters, `ToXML`). That diverges from yjs — whose `_prelimContent` is reflected by `length`/`toArray()` — and hides a silent footgun:

```go
el.Insert(txn, el.Len(), child) // detached el: Len()==0 → PREPENDS, reversing child order
```

The idiomatic "append at end" reverses children on any detached (bottom-up) build.

## Fix

A detached `YXmlFragment`/`YXmlElement` now **reflects its buffered prelim content** on read:

| Reader | Before (#147) | After |
|---|---|---|
| `Len()` | `0` | prelim child count |
| `Children()` | `[]` | buffered child nodes (same identities) |
| `GetAttribute(s)` / `GetAttributeValue(s)` | absent/empty | reflect prelim attrs |
| `ToXML()` | tag only | composes the above (no code change) |
| `YXmlText.Len()`/`ToString()` | empty | **unchanged — stays empty** |

Nested `YXmlText` content stays **opaque until attach** (`Len` 0, empty `ToString`), mirroring yjs, so a detached element renders its tag + attributes with an empty body (`<p level="1"></p>`) until the text materialises.

### Notes
- **Type consistency across attach:** prelim attribute values are normalised (`int`→`int64`) at buffer time via a new shared `normalizeAnyScalar` helper reused by `NewContentAny`, so a detached read returns the exact type a post-attach read does. `flushPrelim` re-applies the normalised value → **byte output unaffected**.
- Reflecting prelim **attributes** on read is intentionally *more complete* than yjs (which hides `_prelimAttrs` until integrate). ygo keeps detached reads consistent with the attached view; documented in-code so it isn't "corrected" back later.
- Detached `ToXML` is now recursive — insert only **fresh** nodes into a detached parent (re-parenting an already-attached node is the usual misuse; documented).

## Zero wire-format change

This is a **read-only** reflection over the same prelim buffers #147 already flushes at attach. Proven by the full yjs byte-identity suite staying green:

- `TestConformance_YXml_DecodeYjsProsemirrorBytes`, `…_ReencodeByteIdentical`, `…_AuthorBytesMatchYjs`, `…_AuthorDiffMatchesYjs`, `…_AuthorSelfRoundTrip`, `…_ConcurrentMerge` (V1 + V2)
- Full `./...` suite, `crdt -race`, `go vet`, `golangci-lint` — all clean.

## Tests

- Rewrote `TestYXml_DetachedReadsAreEmptyUntilAttached` → `…ReadsReflectPrelim` (reflects children + attrs; nested text opaque; `ToXML` transition `<p level="1"></p>` → `<p level="1">hello</p>` after attach).
- Added recursive-nested-element reflection test and a `Insert(txn, Len(), child)` append regression (RED before this change: produced `<ul>cba</ul>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)