### PR TITLE
feat(websocket): add SlowPeerResync policy for graceful slow-peer recovery

### DIFF
--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -518,8 +518,9 @@ func (p *peer) runWriter() {
 		// SlowPeerResync: if a broadcast was dropped while this peer was behind,
 		// resync it now that the backlog has drained. Gated on the policy so the
 		// default SlowPeerDisconnect path takes no extra lock per write.
-		// SlowPeerPolicy is set once at construction and never mutated, so this
-		// read needs no lock.
+		// SlowPeerPolicy, like the other Server config fields, is expected to be
+		// set before ServeHTTP and not mutated while serving, so this read is
+		// unsynchronised.
 		if p.server.SlowPeerPolicy == SlowPeerResync && !p.maybeResync() {
 			return
 		}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -516,8 +516,11 @@ func (p *peer) runWriter() {
 		}
 
 		// SlowPeerResync: if a broadcast was dropped while this peer was behind,
-		// resync it now that the backlog has drained.
-		if !p.maybeResync() {
+		// resync it now that the backlog has drained. Gated on the policy so the
+		// default SlowPeerDisconnect path takes no extra lock per write.
+		// SlowPeerPolicy is set once at construction and never mutated, so this
+		// read needs no lock.
+		if p.server.SlowPeerPolicy == SlowPeerResync && !p.maybeResync() {
 			return
 		}
 	}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -511,22 +511,9 @@ func (p *peer) write(data []byte) {
 func (p *peer) runWriter() {
 	defer close(p.writerDone)
 	for data := range p.writeCh {
-		p.wmu.Lock()
-		if p.closed {
-			p.wmu.Unlock()
+		if !p.writeToConn(data) {
 			return
 		}
-		if err := p.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-			p.server.log().Debug("set write deadline failed", "err", err)
-			p.wmu.Unlock()
-			return
-		}
-		if err := p.conn.WriteMessage(gws.BinaryMessage, data); err != nil {
-			p.server.log().Warn("write to peer failed; closing", "room", p.roomName, "err", err)
-			p.wmu.Unlock()
-			return
-		}
-		p.wmu.Unlock()
 
 		// SlowPeerResync: if a broadcast was dropped while this peer was behind,
 		// resync it now that the backlog has drained.
@@ -536,14 +523,41 @@ func (p *peer) runWriter() {
 	}
 }
 
+// writeToConn performs one conn write for the runWriter goroutine. wmu is held
+// only long enough to read the closed flag; the (possibly blocking) WriteMessage
+// runs WITHOUT wmu so that a slow peer cannot stall broadcast(), which must take
+// the same wmu to enqueue frames for OTHER peers. This is safe because runWriter
+// is the sole goroutine that ever calls conn.WriteMessage (all sends funnel
+// through writeCh), and gorilla/websocket permits conn.Close() — used by the
+// disconnect path and teardown — to run concurrently with a write. Returns false
+// when the writer goroutine should exit.
+func (p *peer) writeToConn(data []byte) bool {
+	p.wmu.Lock()
+	closed := p.closed
+	p.wmu.Unlock()
+	if closed {
+		return false
+	}
+	if err := p.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		p.server.log().Debug("set write deadline failed", "err", err)
+		return false
+	}
+	if err := p.conn.WriteMessage(gws.BinaryMessage, data); err != nil {
+		p.server.log().Warn("write to peer failed; closing", "room", p.roomName, "err", err)
+		return false
+	}
+	return true
+}
+
 // maybeResync sends a one-shot full-state resync (SyncStep2 + current awareness)
 // when a broadcast was dropped under SlowPeerResync and the write queue has since
 // drained. The full state supersedes the dropped incremental updates, so the peer
 // converges without a reconnect. Returns false if the connection is dead and the
 // writer goroutine should exit.
 //
-// This runs only in the runWriter goroutine, so the direct conn writes here do not
-// race other writers; wmu still guards the closed flag and serialises with teardown.
+// This runs only in the runWriter goroutine, so the frame writes here cannot race
+// another conn writer; wmu is taken only to read the closed/needsResync flags,
+// never held across a write (see writeToConn for why).
 func (p *peer) maybeResync() bool {
 	p.wmu.Lock()
 	// Wait until the backlog has fully drained so the resync is not immediately
@@ -568,18 +582,10 @@ func (p *peer) maybeResync() bool {
 		enc.WriteVarBytes(p.room.awareness.EncodeUpdate(nil))
 	})
 
-	p.wmu.Lock()
-	defer p.wmu.Unlock()
-	if p.closed {
-		return false
-	}
+	// Send the frames via the same wmu-free write path as normal broadcasts, so a
+	// slow peer cannot stall broadcast() during the resync either.
 	for _, frame := range [][]byte{syncFrame, awFrame} {
-		if err := p.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-			p.server.log().Debug("set write deadline failed", "err", err)
-			return false
-		}
-		if err := p.conn.WriteMessage(gws.BinaryMessage, frame); err != nil {
-			p.server.log().Warn("resync write to peer failed; closing", "room", p.roomName, "err", err)
+		if !p.writeToConn(frame) {
 			return false
 		}
 	}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/reearth/ygo/awareness"
+	"github.com/reearth/ygo/crdt"
 	"github.com/reearth/ygo/encoding"
 	ygsync "github.com/reearth/ygo/sync"
 )
@@ -26,8 +27,12 @@ type peer struct {
 	cidMu      sync.Mutex
 	writeCh    chan []byte   // buffered queue drained by runWriter goroutine
 	writerDone chan struct{} // closed when runWriter exits
-	limiter    *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
-	readOnly   bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
+	// needsResync is set (under wmu) when a broadcast is dropped because writeCh
+	// was full under SlowPeerResync. runWriter clears it and sends a full-state
+	// resync once the queue drains, so the peer converges without a reconnect.
+	needsResync bool
+	limiter     *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
+	readOnly    bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
 
 	// disconnectOnce ensures the full teardown sequence in handleDisconnect
 	// runs exactly once, regardless of how many callers race (e.g. broadcast's
@@ -447,13 +452,22 @@ func (p *peer) broadcast(data []byte, excludeSelf bool) {
 		case other.writeCh <- data:
 			// queued
 		default:
-			// Queue full — disconnect the slow peer.
-			p.server.log().Warn("peer write queue full; closing slow peer",
-				"room", other.roomName,
-				"queueSize", cap(other.writeCh))
-			_ = other.conn.Close()
-			// The peer's read loop will detect the close and run
-			// handleDisconnect to clean up room state.
+			// Queue full.
+			if p.server.SlowPeerPolicy == SlowPeerResync {
+				// Drop this stale delta and flag an in-place resync; runWriter
+				// sends a full-state SyncStep2 once the queue drains, so the peer
+				// converges without a reconnect.
+				other.needsResync = true
+				p.server.log().Debug("peer write queue full; scheduling in-place resync",
+					"room", other.roomName,
+					"queueSize", cap(other.writeCh))
+			} else {
+				// Disconnect the slow peer; the read loop runs handleDisconnect.
+				p.server.log().Warn("peer write queue full; closing slow peer",
+					"room", other.roomName,
+					"queueSize", cap(other.writeCh))
+				_ = other.conn.Close()
+			}
 		}
 		other.wmu.Unlock()
 	}
@@ -513,5 +527,62 @@ func (p *peer) runWriter() {
 			return
 		}
 		p.wmu.Unlock()
+
+		// SlowPeerResync: if a broadcast was dropped while this peer was behind,
+		// resync it now that the backlog has drained.
+		if !p.maybeResync() {
+			return
+		}
 	}
+}
+
+// maybeResync sends a one-shot full-state resync (SyncStep2 + current awareness)
+// when a broadcast was dropped under SlowPeerResync and the write queue has since
+// drained. The full state supersedes the dropped incremental updates, so the peer
+// converges without a reconnect. Returns false if the connection is dead and the
+// writer goroutine should exit.
+//
+// This runs only in the runWriter goroutine, so the direct conn writes here do not
+// race other writers; wmu still guards the closed flag and serialises with teardown.
+func (p *peer) maybeResync() bool {
+	p.wmu.Lock()
+	// Wait until the backlog has fully drained so the resync is not immediately
+	// followed by now-stale queued deltas.
+	if p.closed || !p.needsResync || len(p.writeCh) > 0 {
+		notClosed := !p.closed
+		p.wmu.Unlock()
+		return notClosed
+	}
+	p.needsResync = false
+	p.wmu.Unlock()
+
+	// Build resync frames without holding wmu: crdt.Doc and Awareness are
+	// internally synchronised (mirrors the initial-sync path).
+	step2 := encodeSyncStep2Msg(crdt.EncodeStateAsUpdateV1(p.room.doc, nil))
+	syncFrame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgSync)
+		enc.WriteRaw(step2)
+	})
+	awFrame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgAwareness)
+		enc.WriteVarBytes(p.room.awareness.EncodeUpdate(nil))
+	})
+
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	if p.closed {
+		return false
+	}
+	for _, frame := range [][]byte{syncFrame, awFrame} {
+		if err := p.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+			p.server.log().Debug("set write deadline failed", "err", err)
+			return false
+		}
+		if err := p.conn.WriteMessage(gws.BinaryMessage, frame); err != nil {
+			p.server.log().Warn("resync write to peer failed; closing", "room", p.roomName, "err", err)
+			return false
+		}
+	}
+	p.server.log().Debug("sent in-place resync to recovered slow peer", "room", p.roomName)
+	return true
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -444,7 +444,10 @@ type Server struct {
 
 	// SlowPeerPolicy selects the reaction when a peer's broadcast write queue
 	// overflows: SlowPeerDisconnect (default) closes the connection; SlowPeerResync
-	// keeps it open and re-syncs the peer in place. See SlowPeerPolicy.
+	// keeps it open and re-syncs the peer in place. See SlowPeerPolicy. Like the
+	// other config fields, set it before serving; it is read without
+	// synchronisation and must not be mutated while the server is handling
+	// connections.
 	SlowPeerPolicy SlowPeerPolicy
 
 	// MaxPendingItems caps the per-document pending-items queue depth. The

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -116,6 +116,22 @@ func (s *Server) peerWriteQueueSize() int {
 	return defaultPeerWriteQueueSize
 }
 
+// SlowPeerPolicy selects how the server reacts when a peer's broadcast write
+// queue overflows.
+type SlowPeerPolicy int
+
+const (
+	// SlowPeerDisconnect closes the slow peer's connection, forcing a
+	// reconnect-and-resync. Default; preserves the original behavior.
+	SlowPeerDisconnect SlowPeerPolicy = iota
+	// SlowPeerResync keeps the connection open: the now-stale backlog is dropped
+	// and the peer is re-synced in place with a full-state SyncStep2 (plus current
+	// awareness) once its write queue drains. Avoids reconnect churn for
+	// transiently-slow peers while still converging (the full state supersedes the
+	// dropped incremental updates).
+	SlowPeerResync
+)
+
 // maxAwarenessClientsPerPeer caps the number of awareness clientIDs one peer
 // may claim ownership of. Without this cap an attacker can send an awareness
 // update listing 1,000,000 clientIDs and cause an OOM when handleDisconnect
@@ -422,6 +438,11 @@ type Server struct {
 	//
 	// Zero (the default) uses 256, sized for typical sync workloads.
 	PeerWriteQueueSize int
+
+	// SlowPeerPolicy selects the reaction when a peer's broadcast write queue
+	// overflows: SlowPeerDisconnect (default) closes the connection; SlowPeerResync
+	// keeps it open and re-syncs the peer in place. See SlowPeerPolicy.
+	SlowPeerPolicy SlowPeerPolicy
 
 	// MaxPendingItems caps the per-document pending-items queue depth. The
 	// queue holds items whose dependencies have not yet arrived, waiting for

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -124,11 +124,12 @@ const (
 	// SlowPeerDisconnect closes the slow peer's connection, forcing a
 	// reconnect-and-resync. Default; preserves the original behavior.
 	SlowPeerDisconnect SlowPeerPolicy = iota
-	// SlowPeerResync keeps the connection open: the now-stale backlog is dropped
-	// and the peer is re-synced in place with a full-state SyncStep2 (plus current
-	// awareness) once its write queue drains. Avoids reconnect churn for
-	// transiently-slow peers while still converging (the full state supersedes the
-	// dropped incremental updates).
+	// SlowPeerResync keeps the connection open: only the overflowing update is
+	// dropped and the peer is flagged. Its existing backlog is left to drain
+	// normally; once the write queue is empty the peer is re-synced in place with
+	// a full-state SyncStep2 (plus current awareness), which supersedes any stale
+	// deltas that were still queued. Avoids reconnect churn for transiently-slow
+	// peers while still converging.
 	SlowPeerResync
 )
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -139,8 +139,10 @@ const (
 const maxAwarenessClientsPerPeer = 10_000
 
 // defaultPeerWriteQueueSize is the default capacity of each peer's broadcast
-// write channel when PeerWriteQueueSize is not set.
-const defaultPeerWriteQueueSize = 256
+// write channel when PeerWriteQueueSize is not set. 512 gives transiently-slow
+// peers more slack before the queue overflows (matching the yrs shared broadcast
+// ring), reducing how often the slow-peer path is hit at all.
+const defaultPeerWriteQueueSize = 512
 
 // PersistenceAdapter is implemented by storage backends that want to persist
 // room state across server restarts. It is called on every committed update so
@@ -436,7 +438,7 @@ type Server struct {
 	// CRDT's pending-structs machinery. Matches yrs-warp's bounded-broadcast
 	// pattern.
 	//
-	// Zero (the default) uses 256, sized for typical sync workloads.
+	// Zero (the default) uses 512, sized for typical sync workloads.
 	PeerWriteQueueSize int
 
 	// SlowPeerPolicy selects the reaction when a peer's broadcast write queue

--- a/provider/websocket/server_internal_test.go
+++ b/provider/websocket/server_internal_test.go
@@ -75,6 +75,66 @@ func TestServer_PeerWriteQueueSize_ConfigurableDefault(t *testing.T) {
 	assert.Equal(t, 16, s2.peerWriteQueueSize(), "configured value used")
 }
 
+func TestServer_SlowPeerPolicy_DefaultsToDisconnect(t *testing.T) {
+	// The zero value must be the backward-compatible disconnect behaviour, so a
+	// Server that never sets the field keeps evicting slow peers.
+	s := &Server{}
+	assert.Equal(t, SlowPeerDisconnect, s.SlowPeerPolicy, "zero value is disconnect")
+}
+
+func TestPeer_Broadcast_ResyncPolicy_FlagsSlowPeerWithoutClosing(t *testing.T) {
+	// Under SlowPeerResync a full write queue must flag the peer for an in-place
+	// resync and drop the stale delta, NOT close the connection. This drives the
+	// overflow branch directly by pre-filling writeCh with no runWriter draining
+	// it, so no fake conn is needed (the resync branch never touches conn).
+	var buf bytes.Buffer
+	srv := &Server{SlowPeerPolicy: SlowPeerResync, Logger: captureDebugLogger(&buf)}
+	rm := &room{peers: map[*peer]struct{}{}}
+
+	target := &peer{server: srv, roomName: "r", writeCh: make(chan []byte, 1)}
+	target.writeCh <- []byte{0x00} // fill to capacity
+
+	src := &peer{server: srv, room: rm}
+	rm.peers[target] = struct{}{}
+	rm.peers[src] = struct{}{}
+
+	src.broadcast([]byte{0x01}, true)
+
+	target.wmu.Lock()
+	needsResync, closed := target.needsResync, target.closed
+	target.wmu.Unlock()
+
+	assert.True(t, needsResync, "overflow under SlowPeerResync should flag the peer for resync")
+	assert.False(t, closed, "overflow under SlowPeerResync must not disconnect the peer")
+	assert.Len(t, target.writeCh, 1, "the stale delta is dropped, not enqueued")
+	assert.Contains(t, buf.String(), "in-place resync", "expected a resync-scheduling log line")
+}
+
+func TestPeer_MaybeResync_GatingWithoutConn(t *testing.T) {
+	// maybeResync's decision branches must be reachable without a live conn: it
+	// only performs a write once the peer is flagged AND the backlog has drained.
+
+	t.Run("not flagged is a no-op", func(t *testing.T) {
+		p := &peer{server: &Server{}, writeCh: make(chan []byte, 1)}
+		assert.True(t, p.maybeResync(), "an un-flagged, open peer keeps its writer alive")
+	})
+
+	t.Run("closed peer stops the writer", func(t *testing.T) {
+		p := &peer{server: &Server{}, writeCh: make(chan []byte, 1), closed: true, needsResync: true}
+		assert.False(t, p.maybeResync(), "a closed peer signals runWriter to exit")
+	})
+
+	t.Run("deferred while queue is non-empty", func(t *testing.T) {
+		p := &peer{server: &Server{}, writeCh: make(chan []byte, 2), needsResync: true}
+		p.writeCh <- []byte{0x01} // backlog not yet drained
+		assert.True(t, p.maybeResync(), "resync waits until the queue drains")
+		p.wmu.Lock()
+		still := p.needsResync
+		p.wmu.Unlock()
+		assert.True(t, still, "needsResync stays set until the backlog clears")
+	})
+}
+
 func TestPeer_Broadcast_DisconnectsSlowPeer(t *testing.T) {
 	// Integration-level coverage lives in TestServer_SlowPeer_GetsDisconnectedOnQueueOverflow
 	// in server_test.go, which uses net.Pipe() connections to make the overflow deterministic.

--- a/provider/websocket/server_internal_test.go
+++ b/provider/websocket/server_internal_test.go
@@ -68,7 +68,8 @@ func TestServer_Logger_FallsBackToDefault(t *testing.T) {
 func TestServer_PeerWriteQueueSize_ConfigurableDefault(t *testing.T) {
 	// Default: zero in config means use the defaultPeerWriteQueueSize constant.
 	s := &Server{}
-	assert.Equal(t, defaultPeerWriteQueueSize, s.peerWriteQueueSize(), "default is 256")
+	assert.Equal(t, defaultPeerWriteQueueSize, s.peerWriteQueueSize(), "default is 512")
+	assert.Equal(t, 512, s.peerWriteQueueSize(), "default bumped from 256 to 512")
 
 	// Configured: positive value overrides default.
 	s2 := &Server{PeerWriteQueueSize: 16}

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -2,6 +2,7 @@ package websocket_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -462,6 +463,7 @@ func TestServer_SlowPeer_GetsDisconnectedOnQueueOverflow(t *testing.T) {
 		})
 		update := crdt.EncodeStateAsUpdateV1(fastDoc, nil)
 		enc := encoding.NewEncoder()
+		enc.WriteVarUint(0) // outer msgSync wrapper
 		enc.WriteVarUint(ygsync.MsgUpdate)
 		enc.WriteVarBytes(update)
 		if err := fastConn.WriteMessage(gws.BinaryMessage, enc.Bytes()); err != nil {
@@ -470,10 +472,121 @@ func TestServer_SlowPeer_GetsDisconnectedOnQueueOverflow(t *testing.T) {
 		time.Sleep(5 * time.Millisecond) // let the server process + broadcast each message
 	}
 
-	// slowConn should get an error because the server closed its connection.
-	_ = slowConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	// slowConn should get an error because the SERVER closed its connection, not
+	// because the client's own read deadline expired. Give a generous deadline and
+	// assert the error is a real close (not a timeout): if the overflow branch did
+	// not fire, the read would sit idle until the deadline and return a timeout,
+	// failing this assertion.
+	_ = slowConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	start := time.Now()
 	_, _, readErr := slowConn.ReadMessage()
-	assert.Error(t, readErr, "slow peer should be disconnected by the server after queue overflow")
+	require.Error(t, readErr, "slow peer should be disconnected by the server after queue overflow")
+	assert.False(t, isTimeout(readErr),
+		"disconnect must be a server-initiated close, not a client read-deadline timeout (got %v after %s)",
+		readErr, time.Since(start))
+}
+
+// isTimeout reports whether err is a deadline-exceeded (i/o timeout) error, used
+// to distinguish a client-side read-deadline expiry from a server-initiated close.
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+func TestServer_SlowPeer_ResyncPolicy_StaysConnectedAndConverges(t *testing.T) {
+	// Same overflow setup as the disconnect test, but with SlowPeerResync: the
+	// overflow must NOT close the connection. The stale delta is dropped, the peer
+	// is flagged, and once it resumes reading runWriter delivers a full-state
+	// SyncStep2 so it converges in place without a reconnect.
+	srv := ygws.NewServer()
+	srv.PeerWriteQueueSize = 4
+	srv.SlowPeerPolicy = ygws.SlowPeerResync
+
+	ln := newPipeListener()
+	ts := httptest.NewUnstartedServer(srv)
+	ts.Listener = ln
+	ts.Start()
+	defer ts.Close()
+
+	dialer := pipeDialer(ln)
+	const wsBase = "ws://pipe"
+
+	// Fast peer: connects, drains handshake, keeps draining in the background.
+	fastConn, _, err := dialer.Dial(wsBase+"/resync-room", nil)
+	require.NoError(t, err)
+	defer fastConn.Close()
+	fastDoc := crdt.New(crdt.WithClientID(1))
+	_ = fastConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for i := 0; i < 3; i++ {
+		if _, _, e := fastConn.ReadMessage(); e != nil {
+			break
+		}
+	}
+	_ = fastConn.SetReadDeadline(time.Time{})
+	go func() {
+		for {
+			if _, _, e := fastConn.ReadMessage(); e != nil {
+				return
+			}
+		}
+	}()
+
+	// Slow peer: connects, drains its 3-message handshake, then stops reading so
+	// the server-side write queue overflows.
+	slowConn, _, err := dialer.Dial(wsBase+"/resync-room", nil)
+	require.NoError(t, err)
+	defer slowConn.Close()
+	slowDoc := crdt.New(crdt.WithClientID(2))
+	_ = slowConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for i := 0; i < 3; i++ {
+		if _, data, e := slowConn.ReadMessage(); e == nil {
+			dec := encoding.NewDecoder(data)
+			if ot, e2 := dec.ReadVarUint(); e2 == nil && ot == 0 {
+				_, _ = ygsync.ApplySyncMessage(slowDoc, dec.RemainingBytes(), nil)
+			}
+		}
+	}
+	_ = slowConn.SetReadDeadline(time.Time{}) // stop reading — writes now overflow
+
+	// Fast peer bursts updates; broadcasts to the slow peer overflow its queue.
+	const inserts = 20
+	fastTxt := fastDoc.GetText("t")
+	for i := 0; i < inserts; i++ {
+		fastDoc.Transact(func(txn *crdt.Transaction) {
+			fastTxt.Insert(txn, 0, "x", nil)
+		})
+		update := crdt.EncodeStateAsUpdateV1(fastDoc, nil)
+		enc := encoding.NewEncoder()
+		enc.WriteVarUint(0) // outer msgSync wrapper
+		enc.WriteVarUint(ygsync.MsgUpdate)
+		enc.WriteVarBytes(update)
+		if err := fastConn.WriteMessage(gws.BinaryMessage, enc.Bytes()); err != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	want := fastTxt.ToString()
+
+	// Resume reading. The peer must NOT have been disconnected, and applying the
+	// frames it now receives (queued deltas + the full-state resync) must bring
+	// slowDoc up to the fast peer's state.
+	deadline := time.Now().Add(5 * time.Second)
+	for slowDoc.GetText("t").ToString() != want {
+		_ = slowConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, readErr := slowConn.ReadMessage()
+		require.NoError(t, readErr, "slow peer must stay connected under SlowPeerResync")
+		dec := encoding.NewDecoder(data)
+		if ot, e := dec.ReadVarUint(); e == nil && ot == 0 {
+			_, _ = ygsync.ApplySyncMessage(slowDoc, dec.RemainingBytes(), nil)
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+	_ = slowConn.SetReadDeadline(time.Time{})
+
+	assert.Equal(t, want, slowDoc.GetText("t").ToString(),
+		"slow peer should converge to the fast peer's state via in-place resync")
 }
 
 func TestServer_RunWriter_NoLeakOnConnectChurn(t *testing.T) {


### PR DESCRIPTION
## Summary

Graceful slow-peer handling for the websocket provider, addressing #172, plus a root-cause fix to the per-peer write locking that was causing head-of-line blocking (and hiding it from the tests).

Today, when a peer's bounded broadcast write queue (`PeerWriteQueueSize`) overflows, the provider closes the connection and relies on reconnect-and-resync. For a transiently-slow peer (a brief GC pause, a busy tab, a burst of large updates) this causes reconnect churn: we observed a two-peer room emitting a steady stream of "peer write queue full; closing slow peer" warnings in production.

## Changes

### 1. `wmu` is no longer held across the conn write (root-cause fix)

`runWriter` held the per-peer write mutex (`wmu`) across the blocking `conn.WriteMessage`. Because `broadcast()` takes the same `wmu` to enqueue frames for *other* peers, a single slow or stalled peer blocked the broadcasting peer for up to `writeTimeout` — head-of-line blocking — and the `writeCh`-overflow branch could never be reached while a write was in flight.

`writeToConn` now holds `wmu` only long enough to read the `closed` flag, then runs `SetWriteDeadline` + `WriteMessage` **without** `wmu`. This is safe because:

- `runWriter` is the **sole** goroutine that calls `conn.WriteMessage` — every send (handshake, direct replies, broadcasts) funnels through `writeCh`;
- gorilla/websocket explicitly permits `conn.Close()` (used by the disconnect path and by teardown) to run concurrently with a write;
- teardown already serialises via `<-writerDone`, not via `wmu`.

`maybeResync` uses the same `wmu`-free write path, so a slow peer can't stall `broadcast` during a resync either.

### 2. `SlowPeerResync` policy (addresses #172)

New `Server.SlowPeerPolicy`:

- `SlowPeerDisconnect` (default, `iota` 0): unchanged; closes the slow peer.
- `SlowPeerResync`: on overflow, drop the now-stale delta, flag the peer, and have `runWriter` send a full-state `SyncStep2` (plus current awareness) once the write queue drains. The full state supersedes the dropped incremental updates, so the peer converges in place without a reconnect.

The resync write happens only from `runWriter`, and is deferred until the backlog fully drains (`len(writeCh) == 0`) so it isn't immediately followed by now-stale queued deltas. Full state is built without `wmu` (the `crdt.Doc` and `Awareness` are internally synchronised, mirroring the initial-sync path).

### 3. Default `PeerWriteQueueSize` bumped 256 → 512

A larger per-peer queue gives transiently-slow peers more slack before overflowing (matching the yrs shared broadcast ring of 512), so the slow-peer path is hit less often in the first place; the `SlowPeerResync` policy then handles the overflows that still occur. Callers can override via `Server.PeerWriteQueueSize`.

## Tests

The existing `TestServer_SlowPeer_GetsDisconnectedOnQueueOverflow` was a false positive on two counts: the burst frames were mis-encoded (no outer `msgSync` wrapper, so the server read them as `msgAuth` and ignored them — no broadcast ever happened), and even with correct framing the `wmu`-across-write meant the overflow branch never fired, so the test passed only when its own client read deadline expired (`i/o timeout`).

This PR:

- fixes the framing and asserts the disconnect is a **server-initiated close** (not a client-deadline timeout);
- adds `TestServer_SlowPeer_ResyncPolicy_StaysConnectedAndConverges`, which drives a real overflow and verifies the peer stays connected and converges via in-place resync;
- adds internal unit tests: policy default is `SlowPeerDisconnect`; broadcast overflow under `SlowPeerResync` flags the peer and drops the delta without closing; `maybeResync` gating (no-op when unflagged, defers while the queue is non-empty, exits on `closed`).

Both integration tests now complete in ~0.1s (genuine close) instead of hitting the deadline, and were verified to **fail** when `wmu` is held across the write. `go test -race -count=3 ./provider/websocket/...` passes.

Closes #172.
