### PR TITLE
release: v1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.35.0] — 2026-07-20
+
+### Fixed
+
+- **Head-of-line blocking in the websocket broadcast writer**
+  ([#172](https://github.com/reearth/ygo/issues/172)): `runWriter` held the
+  per-peer write mutex (`wmu`) across the blocking `conn.WriteMessage`. Because
+  `broadcast()` takes the same `wmu` to enqueue frames for *other* peers, a
+  single slow or stalled peer could block the broadcasting peer for up to
+  `writeTimeout`, and the write-queue-overflow branch could never be reached
+  while a write was in flight. The write path now holds `wmu` only long enough to
+  read the `closed` flag, then runs `SetWriteDeadline` + `WriteMessage` without
+  it — safe because `runWriter` is the sole goroutine that calls
+  `conn.WriteMessage`, and gorilla/websocket permits `conn.Close()` concurrently
+  with a write. This also fixes a false-positive slow-peer test that only ever
+  passed on its own client read-deadline expiring.
+
+### Added
+
+- **`SlowPeerResync` policy for graceful slow-peer recovery**
+  ([#172](https://github.com/reearth/ygo/issues/172)): new
+  `provider/websocket.Server.SlowPeerPolicy` field of type `SlowPeerPolicy`.
+  `SlowPeerDisconnect` (default) is unchanged — it closes a peer whose bounded
+  broadcast queue (`PeerWriteQueueSize`) overflows, forcing reconnect-and-resync.
+  `SlowPeerResync` instead keeps the connection open: it drops the now-stale
+  delta, flags the peer, and has `runWriter` send a full-state `SyncStep2` (plus
+  current awareness) once the write queue drains, so a transiently-slow peer (a
+  brief GC pause, a busy tab, a burst of large updates) converges in place
+  without reconnect churn. Set it before the server starts serving.
+
+### Changed
+
+- **Default `PeerWriteQueueSize` bumped 256 → 512**: a larger per-peer broadcast
+  queue gives transiently-slow peers more slack before overflowing (matching the
+  yrs shared broadcast ring of 512), so the slow-peer path is hit less often;
+  the `SlowPeerResync` policy then handles the overflows that still occur.
+  Callers can still override via `Server.PeerWriteQueueSize`.
+
 ## [1.34.0] — 2026-07-18
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+## v1.35.0
+
+A minor release hardening the websocket broadcast path against slow peers. It
+fixes head-of-line blocking in the writer and adds an opt-in in-place resync
+policy so a transiently-slow peer recovers without reconnect churn. No breaking
+changes; the default behaviour is unchanged.
+
+### Fixed
+
+- **Head-of-line blocking in the websocket broadcast writer**
+  ([#172](https://github.com/reearth/ygo/issues/172)): the per-peer write mutex
+  (`wmu`) was held across the blocking `conn.WriteMessage`, so a single slow or
+  stalled peer could block broadcasts to every other peer for up to
+  `writeTimeout`, and the queue-overflow branch could never fire while a write
+  was in flight. The write path now holds `wmu` only to read the `closed` flag,
+  then writes without it.
+
+### Added
+
+- **`SlowPeerResync` policy for graceful slow-peer recovery**
+  ([#172](https://github.com/reearth/ygo/issues/172)): new
+  `Server.SlowPeerPolicy`. `SlowPeerDisconnect` (default) closes a peer whose
+  broadcast queue overflows; `SlowPeerResync` keeps the connection open, drops
+  the stale delta, and sends a full-state resync once the queue drains, so the
+  peer converges in place without a reconnect.
+
+### Changed
+
+- **Default `PeerWriteQueueSize` bumped 256 → 512**: more slack before a
+  transiently-slow peer overflows (matching the yrs broadcast ring of 512);
+  override via `Server.PeerWriteQueueSize`.
+
+## Install
+
+```
+go get github.com/reearth/ygo@v1.35.0
+```
+
+See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+
+---
+
 ## v1.34.0
 
 A minor release bundling a full mobile on-device editor with an awareness


### PR DESCRIPTION
Rolls up the merged websocket slow-peer work ([#173](https://github.com/reearth/ygo/pull/173)) into **v1.35.0** and finalizes `CHANGELOG.md` + `RELEASE_NOTES.md` in-branch (so no second docs PR is needed before tagging).

Minor bump — it adds new public API (`provider/websocket.Server.SlowPeerPolicy` and the `SlowPeerResync`/`SlowPeerDisconnect` constants).

Bundled:
- **#172** graceful slow-peer handling — fixes head-of-line blocking in the broadcast writer (the per-peer `wmu` was held across `conn.WriteMessage`) and adds the opt-in `SlowPeerResync` policy that re-syncs a transiently-slow peer in place instead of forcing a reconnect. Default `PeerWriteQueueSize` bumped 256 → 512.

Docs-only diff on top of `main`. After this merges, tag `v1.35.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)