### PR TITLE
fix(websocket): coalesce persistence writes to cut latency + version churn (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.36.0] — 2026-07-22
+
+### Changed
+
+- **Websocket persistence writes are now coalesced by default (behaviour
+  change)** ([#175](https://github.com/reearth/ygo/issues/175)): the per-room
+  persistence worker debounces backing-store writes — a 2s window that resets
+  on every new update, capped by a 10s max wait measured from the batch's
+  first update — and merges each coalesced burst into a single `StoreUpdate`
+  call, instead of writing once per committed transaction. This cuts
+  persistence latency and version churn under load (Hocuspocus parity). Only
+  servers with a `PersistenceAdapter` configured (`NewServerWithPersistence`
+  or an explicit persistence set) are affected; a plain `NewServer()` has no
+  persistence and is unaffected. Restore the previous strict per-update
+  behaviour with `Server.PersistCoalesceWindow = -1`.
+
+### Added
+
+- **`Server.PersistCoalesceWindow` and `Server.PersistCoalesceMaxWait`**
+  ([#175](https://github.com/reearth/ygo/issues/175)): new `time.Duration`
+  fields to tune or disable persistence coalescing. Zero uses the defaults
+  (2s window, 10s max wait); a negative `PersistCoalesceWindow` (e.g. `-1`)
+  disables coalescing entirely, reverting to strict one-`StoreUpdate`-per-update
+  writes; `PersistCoalesceMaxWait` is clamped to be at least
+  `PersistCoalesceWindow`.
+
 ## [1.35.0] — 2026-07-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Post-v1.0 hardening:
 - **Read-only WebSocket connections** (v1.30.0). New `Server.Authorize func(*http.Request) (ConnectionConfig, bool)` both accepts/rejects a connection and reports per-connection config — currently `ReadOnly`. A read-only peer receives document and awareness broadcasts but its inbound writes (sync step-2/update and awareness) are dropped server-side, while still being able to request state (SyncStep1) and query awareness. The existing bool `AuthFunc` is unchanged; `Authorize` takes precedence when both are set. Matches Hocuspocus's `readOnly` connection flag (#59).
 - **Attribution API** (v1.30.0). `IDSet`/`IDMap`/`ContentMap` + wire codec tracking yjs v14-rc `14.0.0-16` — stamp CRDT content with per-item authorship (`userid`, `ts`, …) and exchange it with JS. Non-goals documented (no storage integration; `diffDocsToDelta` deferred). See [Attribution](#attribution) below.
 - **Subdocument lifecycle** (#63). A `Doc` can embed another `Doc` as a subdocument via `YMap.Set(txn, key, subdoc)`; `GetSubdocs`/`GetSubdocGUIDs`/`OnSubdocs`/`Load` plus `WithAutoLoad`/`WithShouldLoad`/`WithCollectionID` track and drive the add/remove/load lifecycle — the local half of Yjs's subdocuments feature. Also: `New()` now defaults a Doc's `guid` to a random uuidv4 instead of `""` (Yjs parity). Live cross-peer subdoc sync is a separate, tracked follow-up (#142). See [Subdocuments](#subdocuments) below.
+- **Coalesced persistence** (v1.36.0). The websocket server's persistence worker now debounces backing-store writes by default — a 2s window, capped by a 10s max wait — merging bursts into a single `StoreUpdate` instead of one write per update (Hocuspocus parity). This is a behaviour change for servers with a `PersistenceAdapter` configured; set `Server.PersistCoalesceWindow = -1` to restore strict per-update writes (#175).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 
@@ -377,6 +378,8 @@ type PersistenceAdapter interface {
 ```
 
 `LoadDoc` is called once when the first peer connects to a room; the result seeds the in-memory doc. `StoreUpdate` is called on every committed transaction. Writes run on a per-room worker goroutine — slow storage doesn't block peers. Wire an adapter in via `NewServerWithPersistence(adapter)`.
+
+By default (v1.36.0) these writes are coalesced: the worker debounces bursts of updates into a single merged `StoreUpdate` call using a 2s window (reset on each new update) capped by a 10s max wait, matching Hocuspocus's default debounce behaviour. Tune it via `Server.PersistCoalesceWindow` / `Server.PersistCoalesceMaxWait`, or set `PersistCoalesceWindow` to a negative value (e.g. `-1`) to disable coalescing and restore strict one-write-per-update persistence.
 
 For a ready-made durable backend, [`persistence/sqlite`](persistence/sqlite/) provides a pure-Go (CGO-free, `modernc.org/sqlite`) `VersionedPersistence` store with WAL mode, full versioned history, and a crash-safe two-phase prune. Open it with `sqlite.Open("data.db")`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,41 @@
+## v1.36.0
+
+A minor release that changes the default persistence behaviour for the
+websocket server: backing-store writes are now debounce-coalesced (2s window,
+10s max wait) into a single merged `StoreUpdate` per burst, instead of one
+write per committed transaction, cutting persistence latency and version
+churn under load. This only affects servers with a `PersistenceAdapter`
+configured (`NewServerWithPersistence`); plain `NewServer()` is unaffected.
+Set `Server.PersistCoalesceWindow = -1` to opt back into the previous strict
+per-update behaviour.
+
+### Changed
+
+- **Websocket persistence writes are coalesced by default (behaviour
+  change)** ([#175](https://github.com/reearth/ygo/issues/175)): the
+  per-room persistence worker debounces writes and merges each burst into a
+  single `StoreUpdate` call rather than writing once per update
+  (Hocuspocus parity). Only servers with a `PersistenceAdapter` configured
+  are affected.
+
+### Added
+
+- **`Server.PersistCoalesceWindow` and `Server.PersistCoalesceMaxWait`**
+  ([#175](https://github.com/reearth/ygo/issues/175)): tune or disable
+  persistence coalescing. Defaults are 2s and 10s; a negative
+  `PersistCoalesceWindow` (e.g. `-1`) disables coalescing and restores strict
+  per-update writes.
+
+## Install
+
+```
+go get github.com/reearth/ygo@v1.36.0
+```
+
+See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+
+---
+
 ## v1.35.0
 
 A minor release hardening the websocket broadcast path against slow peers. It

--- a/persistence/adapter_test.go
+++ b/persistence/adapter_test.go
@@ -50,6 +50,10 @@ func TestLegacyAdapter_LoadDoc_StoreUpdate(t *testing.T) {
 func TestLegacyAdapter_PluggedIntoServer(t *testing.T) {
 	store := persistence.NewMemoryPersistence()
 	srv := ygws.NewServerWithPersistence(persistence.NewLegacyAdapter(store))
+	// Disable persistence coalescing (default-on as of v1.36.0, #175) so the
+	// seeded edit is persisted immediately rather than after the debounce
+	// window — this test exercises the shim + reload path, not write timing.
+	srv.PersistCoalesceWindow = -1
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 

--- a/provider/websocket/coalesce.go
+++ b/provider/websocket/coalesce.go
@@ -1,0 +1,51 @@
+package websocket
+
+import "time"
+
+// wsTimer is the minimal timer surface the persistence worker needs. Backed by
+// *time.Timer in production; a fake in tests fires channels deterministically.
+type wsTimer interface {
+	ch() <-chan time.Time
+	stop()
+}
+
+// wsClock creates wsTimers. Server.clock is nil in production and resolves to
+// realClock{}; tests inject a fake for deterministic debounce behaviour.
+type wsClock interface {
+	newTimer(d time.Duration) wsTimer
+}
+
+type realClock struct{}
+
+func (realClock) newTimer(d time.Duration) wsTimer { return &realTimer{t: time.NewTimer(d)} }
+
+type realTimer struct{ t *time.Timer }
+
+func (r *realTimer) ch() <-chan time.Time { return r.t.C }
+func (r *realTimer) stop()                { r.t.Stop() }
+
+const (
+	defaultCoalesceWindow  = 2 * time.Second
+	defaultCoalesceMaxWait = 10 * time.Second
+)
+
+// resolveCoalesceConfig turns the raw Server fields into effective values.
+// window<0 disables coalescing (strict per-update). window==0 uses the default.
+// maxWait==0 uses the default and is clamped to be at least the window.
+func resolveCoalesceConfig(window, maxWait time.Duration) (enabled bool, win, max time.Duration) {
+	if window < 0 {
+		return false, 0, 0
+	}
+	win = window
+	if win == 0 {
+		win = defaultCoalesceWindow
+	}
+	max = maxWait
+	if max == 0 {
+		max = defaultCoalesceMaxWait
+	}
+	if max < win {
+		max = win
+	}
+	return true, win, max
+}

--- a/provider/websocket/coalesce.go
+++ b/provider/websocket/coalesce.go
@@ -32,7 +32,7 @@ const (
 // resolveCoalesceConfig turns the raw Server fields into effective values.
 // window<0 disables coalescing (strict per-update). window==0 uses the default.
 // maxWait==0 uses the default and is clamped to be at least the window.
-func resolveCoalesceConfig(window, maxWait time.Duration) (enabled bool, win, max time.Duration) {
+func resolveCoalesceConfig(window, maxWait time.Duration) (enabled bool, win, maxW time.Duration) {
 	if window < 0 {
 		return false, 0, 0
 	}
@@ -40,12 +40,12 @@ func resolveCoalesceConfig(window, maxWait time.Duration) (enabled bool, win, ma
 	if win == 0 {
 		win = defaultCoalesceWindow
 	}
-	max = maxWait
-	if max == 0 {
-		max = defaultCoalesceMaxWait
+	maxW = maxWait
+	if maxW == 0 {
+		maxW = defaultCoalesceMaxWait
 	}
-	if max < win {
-		max = win
+	if maxW < win {
+		maxW = win
 	}
-	return true, win, max
+	return true, win, maxW
 }

--- a/provider/websocket/coalesce_test.go
+++ b/provider/websocket/coalesce_test.go
@@ -18,6 +18,7 @@ func TestResolveCoalesceConfig(t *testing.T) {
 		{"custom window default wait", 500 * time.Millisecond, 0, true, 500 * time.Millisecond, 10 * time.Second},
 		{"custom both", time.Second, 3 * time.Second, true, time.Second, 3 * time.Second},
 		{"maxwait clamped up to window", 5 * time.Second, time.Second, true, 5 * time.Second, 5 * time.Second},
+		{"negative maxwait clamped up to window", time.Second, -5 * time.Second, true, time.Second, time.Second},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/provider/websocket/coalesce_test.go
+++ b/provider/websocket/coalesce_test.go
@@ -1,0 +1,31 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveCoalesceConfig(t *testing.T) {
+	cases := []struct {
+		name         string
+		window, wait time.Duration
+		wantEnabled  bool
+		wantWin      time.Duration
+		wantMax      time.Duration
+	}{
+		{"defaults", 0, 0, true, 2 * time.Second, 10 * time.Second},
+		{"disabled negative window", -1, 0, false, 0, 0},
+		{"custom window default wait", 500 * time.Millisecond, 0, true, 500 * time.Millisecond, 10 * time.Second},
+		{"custom both", time.Second, 3 * time.Second, true, time.Second, 3 * time.Second},
+		{"maxwait clamped up to window", 5 * time.Second, time.Second, true, 5 * time.Second, 5 * time.Second},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enabled, win, max := resolveCoalesceConfig(c.window, c.wait)
+			if enabled != c.wantEnabled || win != c.wantWin || max != c.wantMax {
+				t.Fatalf("resolveCoalesceConfig(%v,%v) = (%v,%v,%v), want (%v,%v,%v)",
+					c.window, c.wait, enabled, win, max, c.wantEnabled, c.wantWin, c.wantMax)
+			}
+		})
+	}
+}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -182,6 +182,9 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				// flush can race with shutdown cancelling ctx, and niling an
 				// unpersisted batch would lose it. Timers are cleared regardless;
 				// a retained batch re-flushes on the next update or at exit.
+				// A batch retained here has no self-driven retry timer in steady
+				// state; it is re-flushed at the stop/shutdown exit case below
+				// with a background context.
 				if flush(ctx, batch) {
 					batch = nil
 				}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -53,14 +54,15 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 		}()
 
 		// store issues one backing-store write for a single update using the
-		// given ctx. Panics are contained; errors logged (no retry).
-		store := func(ctx context.Context, update []byte) {
+		// given ctx and returns whether it failed. Panics are contained and
+		// reported as a non-nil error; errors are logged (no retry).
+		store := func(ctx context.Context, update []byte) (err error) {
 			defer func() {
 				if rv := recover(); rv != nil {
 					log.Printf("ygo/websocket: StoreUpdate panic for room %q: %v", name, rv)
+					err = fmt.Errorf("StoreUpdate panic for room %q: %v", name, rv)
 				}
 			}()
-			var err error
 			if pac, ok := s.persistence.(PersistenceAdapterContext); ok {
 				err = pac.StoreUpdateContext(ctx, name, update)
 			} else {
@@ -69,27 +71,35 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			if err != nil {
 				log.Printf("ygo/websocket: StoreUpdate for room %q: %v", name, err)
 			}
+			return err
 		}
 
 		// flush merges batch into one update and stores it. On merge failure it
-		// stores each update individually so a bad merge never drops data.
-		flush := func(ctx context.Context, batch [][]byte) {
+		// stores each update individually so a bad merge never drops data. It
+		// returns true only if the batch is fully persisted and therefore safe to
+		// discard; a false result (e.g. ctx cancelled at shutdown, or a transient
+		// store error) means the caller must RETAIN the batch so it can be
+		// re-flushed — otherwise a batch could be lost if a timer flush races with
+		// shutdown cancelling the worker ctx.
+		flush := func(ctx context.Context, batch [][]byte) bool {
 			if len(batch) == 0 {
-				return
+				return true
 			}
 			if len(batch) == 1 {
-				store(ctx, batch[0])
-				return
+				return store(ctx, batch[0]) == nil
 			}
 			merged, err := mergeFn(batch...)
 			if err != nil {
 				log.Printf("ygo/websocket: merge of %d updates for room %q failed (%v); storing individually", len(batch), name, err)
+				ok := true
 				for _, u := range batch {
-					store(ctx, u)
+					if store(ctx, u) != nil {
+						ok = false
+					}
 				}
-				return
+				return ok
 			}
-			store(ctx, merged)
+			return store(ctx, merged) == nil
 		}
 
 		// Strict per-update path (coalescing disabled): unchanged behaviour.
@@ -168,12 +178,18 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 					windowT = clock.newTimer(window)
 				}
 			case <-windowC:
-				flush(ctx, batch)
-				batch = nil
+				// Retain the batch if the flush did not fully persist: a timer
+				// flush can race with shutdown cancelling ctx, and niling an
+				// unpersisted batch would lose it. Timers are cleared regardless;
+				// a retained batch re-flushes on the next update or at exit.
+				if flush(ctx, batch) {
+					batch = nil
+				}
 				clearTimers()
 			case <-maxC:
-				flush(ctx, batch)
-				batch = nil
+				if flush(ctx, batch) {
+					batch = nil
+				}
 				clearTimers()
 			case <-r.persistStop:
 				drainBuffered()

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -24,8 +24,11 @@ import (
 //
 // If s.persistence implements PersistenceAdapterContext, store calls are made
 // via StoreUpdateContext with a ctx that is cancelled when shutdown or stop
-// fires — EXCEPT the final stop/shutdown flush, which uses context.Background()
-// so the last batched write is not aborted by the very signal that triggers it.
+// fires. On the coalescing path the final stop/shutdown flush is the exception:
+// it uses context.Background() so the last batched write is not aborted by the
+// very signal that triggers it. On the disabled (per-update) path the final
+// drain uses the cancellable ctx — matching pre-v1.36 behaviour — so a
+// context-aware adapter may still see cancellation during that drain.
 // Otherwise falls back to StoreUpdate (existing behaviour).
 func (s *Server) startPersistenceWorker(r *room, name string) {
 	clock := s.clock
@@ -197,10 +200,12 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			case <-r.persistStop:
 				drainBuffered()
 				flush(context.Background(), batch) // non-cancelled: survive shutdown
+				clearTimers()                      // release any pending timers before exit
 				return
 			case <-s.shutdownCh:
 				drainBuffered()
 				flush(context.Background(), batch)
+				clearTimers() // release any pending timers before exit
 				return
 			}
 		}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -108,7 +108,7 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				for {
 					select {
 					case update := <-r.persistCh:
-						store(ctx, update)
+						_ = store(ctx, update)
 					default:
 						return
 					}
@@ -117,7 +117,7 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			for {
 				select {
 				case update := <-r.persistCh:
-					store(ctx, update)
+					_ = store(ctx, update)
 				case <-r.persistStop:
 					drain()
 					return

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -3,6 +3,9 @@ package websocket
 import (
 	"context"
 	"log"
+	"time"
+
+	"github.com/reearth/ygo/crdt"
 )
 
 // startPersistenceWorker spawns the goroutine that drains r.persistCh and
@@ -13,17 +16,34 @@ import (
 // draining any buffered updates before returning so that no committed
 // transaction is silently lost.
 //
+// When coalescing is enabled (see resolveCoalesceConfig / Server.PersistCoalesceWindow),
+// bursts of updates are debounced into a single merged write: each new update
+// restarts the window timer, and a per-batch maxWait timer bounds staleness.
+// When disabled (window < 0), each update is stored individually.
+//
 // If s.persistence implements PersistenceAdapterContext, store calls are made
 // via StoreUpdateContext with a ctx that is cancelled when shutdown or stop
-// fires. Otherwise falls back to StoreUpdate (existing behaviour).
+// fires — EXCEPT the final stop/shutdown flush, which uses context.Background()
+// so the last batched write is not aborted by the very signal that triggers it.
+// Otherwise falls back to StoreUpdate (existing behaviour).
 func (s *Server) startPersistenceWorker(r *room, name string) {
+	clock := s.clock
+	if clock == nil {
+		clock = realClock{}
+	}
+	mergeFn := s.mergeFn
+	if mergeFn == nil {
+		mergeFn = crdt.MergeUpdatesV1
+	}
+	enabled, window, maxWait := resolveCoalesceConfig(s.PersistCoalesceWindow, s.PersistCoalesceMaxWait)
+
 	go func() {
 		defer close(r.persistDone)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// Cancel the persistence-adapter ctx when shutdown or stop fires.
+		// Cancel the adapter ctx when shutdown or stop fires.
 		go func() {
 			select {
 			case <-s.shutdownCh:
@@ -32,7 +52,9 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			cancel()
 		}()
 
-		store := func(update []byte) {
+		// store issues one backing-store write for a single update using the
+		// given ctx. Panics are contained; errors logged (no retry).
+		store := func(ctx context.Context, update []byte) {
 			defer func() {
 				if rv := recover(); rv != nil {
 					log.Printf("ygo/websocket: StoreUpdate panic for room %q: %v", name, rv)
@@ -48,30 +70,119 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				log.Printf("ygo/websocket: StoreUpdate for room %q: %v", name, err)
 			}
 		}
+
+		// flush merges batch into one update and stores it. On merge failure it
+		// stores each update individually so a bad merge never drops data.
+		flush := func(ctx context.Context, batch [][]byte) {
+			if len(batch) == 0 {
+				return
+			}
+			if len(batch) == 1 {
+				store(ctx, batch[0])
+				return
+			}
+			merged, err := mergeFn(batch...)
+			if err != nil {
+				log.Printf("ygo/websocket: merge of %d updates for room %q failed (%v); storing individually", len(batch), name, err)
+				for _, u := range batch {
+					store(ctx, u)
+				}
+				return
+			}
+			store(ctx, merged)
+		}
+
+		// Strict per-update path (coalescing disabled): unchanged behaviour.
+		if !enabled {
+			drain := func() {
+				for {
+					select {
+					case update := <-r.persistCh:
+						store(ctx, update)
+					default:
+						return
+					}
+				}
+			}
+			for {
+				select {
+				case update := <-r.persistCh:
+					store(ctx, update)
+				case <-r.persistStop:
+					drain()
+					return
+				case <-s.shutdownCh:
+					drain()
+					return
+				}
+			}
+		}
+
+		// Coalescing path.
+		var batch [][]byte
+		var windowT, maxT wsTimer
+
+		clearTimers := func() {
+			if windowT != nil {
+				windowT.stop()
+				windowT = nil
+			}
+			if maxT != nil {
+				maxT.stop()
+				maxT = nil
+			}
+		}
+		// drainBuffered pulls everything currently queued into batch without
+		// blocking. Used on stop/shutdown before the final flush.
+		drainBuffered := func() {
+			for {
+				select {
+				case update := <-r.persistCh:
+					batch = append(batch, update)
+				default:
+					return
+				}
+			}
+		}
+
 		for {
+			var windowC, maxC <-chan time.Time
+			if windowT != nil {
+				windowC = windowT.ch()
+			}
+			if maxT != nil {
+				maxC = maxT.ch()
+			}
 			select {
 			case update := <-r.persistCh:
-				store(update)
+				batch = append(batch, update)
+				if windowT == nil {
+					// First update of a new batch: arm both timers.
+					windowT = clock.newTimer(window)
+					maxT = clock.newTimer(maxWait)
+				} else {
+					// Debounce: restart the window timer; leave maxWait (it is
+					// measured from the batch's first update). Create-new avoids
+					// any Reset/drain hazard.
+					windowT.stop()
+					windowT = clock.newTimer(window)
+				}
+			case <-windowC:
+				flush(ctx, batch)
+				batch = nil
+				clearTimers()
+			case <-maxC:
+				flush(ctx, batch)
+				batch = nil
+				clearTimers()
 			case <-r.persistStop:
-				// Drain buffered updates before exiting.
-				for {
-					select {
-					case update := <-r.persistCh:
-						store(update)
-					default:
-						return
-					}
-				}
+				drainBuffered()
+				flush(context.Background(), batch) // non-cancelled: survive shutdown
+				return
 			case <-s.shutdownCh:
-				// Server is shutting down; drain any remaining buffered updates.
-				for {
-					select {
-					case update := <-r.persistCh:
-						store(update)
-					default:
-						return
-					}
-				}
+				drainBuffered()
+				flush(context.Background(), batch)
+				return
 			}
 		}
 	}()

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/reearth/ygo/crdt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
 )
 
 // --- fake clock -----------------------------------------------------------

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -209,6 +209,79 @@ func TestPersistCoalesce_ShutdownFlushesWithLiveCtx(t *testing.T) {
 	assert.NoError(t, a.ctxErrs[0], "shutdown flush must use a non-cancelled context")
 }
 
+// failFirstAdapter fails the FIRST StoreUpdateContext call and succeeds on every
+// call after, recording each attempted update. Models a transient store failure
+// (or the ctx-cancelled-at-shutdown case) so the worker's retain-and-reflush path
+// can be exercised deterministically.
+type failFirstAdapter struct {
+	mu     sync.Mutex
+	calls  [][]byte
+	failed bool
+}
+
+func (a *failFirstAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+func (a *failFirstAdapter) StoreUpdate(_ string, u []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, append([]byte(nil), u...))
+	return nil
+}
+func (a *failFirstAdapter) StoreUpdateContext(_ context.Context, _ string, u []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, append([]byte(nil), u...))
+	if !a.failed {
+		a.failed = true
+		return errors.New("transient store failure")
+	}
+	return nil
+}
+func (a *failFirstAdapter) count() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.calls)
+}
+
+// A flush that does not fully persist (transient error, or ctx cancelled by a
+// shutdown that races the timer) must RETAIN the batch so it is re-flushed — not
+// silently dropped. Guards the shutdown-handoff durability fix.
+func TestPersistCoalesce_RetainsBatchOnFailedFlush(t *testing.T) {
+	a := &failFirstAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		applyEdit(r, "r", 0)
+	}
+	var last *fakeTimer
+	for i := 0; i < n; i++ {
+		last = fc.nextTimerOfDur(t, 50*time.Millisecond)
+	}
+	last.fire() // window flush attempts one merged store — which fails.
+
+	// Observing the first (failing) store call proves the timer flush ran; the
+	// batch must have been retained (flush returned false), not niled.
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond,
+		"first flush should attempt exactly one merged store (which fails)")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+
+	// Shutdown re-flushes the retained batch with a live (background) ctx: a
+	// SECOND store call. If the batch had been dropped, count would stay at 1.
+	require.Equal(t, 2, a.count(), "retained batch must be re-flushed on shutdown (no data loss)")
+
+	// The re-flushed update decodes to the full n-char state — nothing lost.
+	a.mu.Lock()
+	reflushed := a.calls[len(a.calls)-1]
+	a.mu.Unlock()
+	got := crdt.New()
+	require.NoError(t, crdt.ApplyUpdateV1(got, reflushed, nil))
+	assert.Equal(t, n, got.GetText("t").Len())
+}
+
 // Merge failure falls back to storing each update individually (no loss).
 func TestPersistCoalesce_MergeFailureFallsBack(t *testing.T) {
 	a := &recordAdapter{}

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -1,0 +1,233 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fake clock -----------------------------------------------------------
+
+type fakeTimer struct {
+	c   chan time.Time
+	dur time.Duration
+}
+
+func (t *fakeTimer) ch() <-chan time.Time { return t.c }
+func (t *fakeTimer) stop()                {}
+func (t *fakeTimer) fire()                { t.c <- time.Time{} }
+
+type fakeClock struct {
+	created chan *fakeTimer // buffered; one send per newTimer call
+
+	mu      sync.Mutex
+	pending []*fakeTimer // non-matching timers set aside by nextTimerOfDur
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{created: make(chan *fakeTimer, 256)} }
+
+func (f *fakeClock) newTimer(d time.Duration) wsTimer {
+	t := &fakeTimer{c: make(chan time.Time, 1), dur: d}
+	f.created <- t
+	return t
+}
+
+// nextTimerOfDur returns the next-created timer of duration d. Receiving a timer
+// from created proves the worker processed the update that armed it
+// (happens-before), so the batch state is known. Timers of other durations seen
+// along the way are set aside (not discarded) so an interleaved, singly-armed
+// timer — e.g. the maxWait timer among a run of window timers — can still be
+// retrieved by a later call.
+func (f *fakeClock) nextTimerOfDur(t *testing.T, d time.Duration) *fakeTimer {
+	t.Helper()
+	// Reuse a matching timer set aside by an earlier call first.
+	f.mu.Lock()
+	for i, ft := range f.pending {
+		if ft.dur == d {
+			f.pending = append(f.pending[:i], f.pending[i+1:]...)
+			f.mu.Unlock()
+			return ft
+		}
+	}
+	f.mu.Unlock()
+	for {
+		select {
+		case ft := <-f.created:
+			if ft.dur == d {
+				return ft
+			}
+			f.mu.Lock()
+			f.pending = append(f.pending, ft)
+			f.mu.Unlock()
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for timer of duration %v", d)
+			return nil
+		}
+	}
+}
+
+// --- recording adapter ----------------------------------------------------
+
+type recordAdapter struct {
+	mu      sync.Mutex
+	stores  [][]byte
+	ctxErrs []error // ctx.Err() observed at each StoreUpdateContext call
+}
+
+func (a *recordAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+func (a *recordAdapter) StoreUpdate(_ string, u []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stores = append(a.stores, append([]byte(nil), u...))
+	a.ctxErrs = append(a.ctxErrs, nil)
+	return nil
+}
+func (a *recordAdapter) StoreUpdateContext(ctx context.Context, _ string, u []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stores = append(a.stores, append([]byte(nil), u...))
+	a.ctxErrs = append(a.ctxErrs, ctx.Err())
+	return nil
+}
+func (a *recordAdapter) count() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.stores)
+}
+
+// applyEdit commits one transaction to the room doc, producing exactly one
+// OnUpdate → one entry on persistCh. Text handle resolved OUTSIDE Transact
+// (GetText inside Transact deadlocks).
+func applyEdit(r *room, s string, at int) {
+	txt := r.doc.GetText("t")
+	r.doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, at, s, nil) })
+}
+
+func newCoalesceServer(a PersistenceAdapter, fc *fakeClock, window, maxWait time.Duration) *Server {
+	s := NewServerWithPersistence(a)
+	s.clock = fc
+	s.PersistCoalesceWindow = window
+	s.PersistCoalesceMaxWait = maxWait
+	return s
+}
+
+// Burst of N edits within one window collapses to a single merged store whose
+// state equals the sequential apply.
+func TestPersistCoalesce_BurstMergesToOneStore(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		applyEdit(r, "x", 0)
+	}
+	// Each edit arms one window timer (create or recreate). Receiving the n-th
+	// proves all n updates were batched. Fire it to flush.
+	var last *fakeTimer
+	for i := 0; i < n; i++ {
+		last = fc.nextTimerOfDur(t, 50*time.Millisecond)
+	}
+	last.fire()
+
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond,
+		"burst should produce exactly one store")
+
+	// Merged store must decode to the same 5 inserted chars.
+	got := crdt.New()
+	require.NoError(t, crdt.ApplyUpdateV1(got, a.stores[0], nil))
+	assert.Equal(t, n, got.GetText("t").Len())
+}
+
+// Disabled (window < 0) preserves strict per-update behaviour: no timers, one
+// store per edit.
+func TestPersistCoalesce_DisabledIsPerUpdate(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, -1, 0)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		applyEdit(r, "y", 0)
+	}
+	assert.Eventually(t, func() bool { return a.count() == 3 }, time.Second, 5*time.Millisecond,
+		"disabled coalescing should store once per update")
+	assert.Empty(t, fc.created, "disabled path must not create timers")
+}
+
+// maxWait flushes a batch even while the window keeps being reset.
+func TestPersistCoalesce_MaxWaitFlushes(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 4
+	for i := 0; i < n; i++ {
+		applyEdit(r, "z", 0)
+	}
+	for i := 0; i < n; i++ {
+		fc.nextTimerOfDur(t, 50*time.Millisecond) // drain window arms (do not fire)
+	}
+	maxT := fc.nextTimerOfDur(t, 500*time.Millisecond)
+	maxT.fire()
+
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond,
+		"maxWait should flush the whole batch once")
+}
+
+// Shutdown mid-batch flushes with a NON-cancelled ctx (guards the critical fix).
+func TestPersistCoalesce_ShutdownFlushesWithLiveCtx(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		applyEdit(r, "w", 0)
+	}
+	for i := 0; i < n; i++ {
+		fc.nextTimerOfDur(t, 50*time.Millisecond) // ensure all batched, don't fire
+	}
+	require.NoError(t, s.Shutdown(context.Background()))
+
+	require.Equal(t, 1, a.count(), "shutdown should flush the pending batch exactly once")
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	assert.NoError(t, a.ctxErrs[0], "shutdown flush must use a non-cancelled context")
+}
+
+// Merge failure falls back to storing each update individually (no loss).
+func TestPersistCoalesce_MergeFailureFallsBack(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	s.mergeFn = func(...[]byte) ([]byte, error) { return nil, errors.New("boom") }
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		applyEdit(r, "q", 0)
+	}
+	var last *fakeTimer
+	for i := 0; i < n; i++ {
+		last = fc.nextTimerOfDur(t, 50*time.Millisecond)
+	}
+	last.fire()
+
+	assert.Eventually(t, func() bool { return a.count() == n }, time.Second, 5*time.Millisecond,
+		"merge failure should fall back to individual stores")
+}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -478,9 +478,12 @@ type Server struct {
 	// flushed, measured from the batch's first update (Hocuspocus maxDebounce).
 	// Under sustained editing the debounce window keeps resetting, so flushes
 	// occur every PersistCoalesceMaxWait and durable state can lag live state by
-	// up to this duration. 0 uses the default (10s); the effective value is
-	// clamped to be at least PersistCoalesceWindow. Ignored when coalescing is
-	// disabled.
+	// up to this duration. 0 uses the default (10s). The effective value is
+	// clamped to be at least the effective PersistCoalesceWindow, so any value
+	// below the window — including a negative one — resolves to the window
+	// rather than the 10s default (a negative maxWait is NOT a disable switch;
+	// only a negative PersistCoalesceWindow disables coalescing). Ignored when
+	// coalescing is disabled.
 	PersistCoalesceMaxWait time.Duration
 
 	// clock creates timers for the persistence worker. nil in production

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -466,6 +466,12 @@ type Server struct {
 	// Only affects servers with a PersistenceAdapter configured. Like the other
 	// config fields, set it before serving; it is read without synchronisation
 	// and must not be mutated while the server is handling connections.
+	//
+	// When disabled (<0), the strict per-update path — like the pre-v1.36
+	// behaviour — uses the cancellable worker context for its shutdown drain,
+	// so a context-respecting adapter may abort the final buffered writes on
+	// shutdown; the default coalescing path flushes the final batch with a
+	// background context and is more durable at shutdown.
 	PersistCoalesceWindow time.Duration
 
 	// PersistCoalesceMaxWait bounds how long a buffered update waits before it is

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -149,6 +149,10 @@ const defaultPeerWriteQueueSize = 512
 // room state across server restarts. It is called on every committed update so
 // implementations should be efficient (e.g. append-only log rather than full
 // re-encode on every write).
+//
+// By default the server coalesces bursts of updates and calls StoreUpdate once
+// per debounced batch (a single merged V1 update) rather than once per
+// transaction; see Server.PersistCoalesceWindow.
 type PersistenceAdapter interface {
 	// LoadDoc returns the full binary V1 update representing stored state for
 	// the room, or (nil, nil) if no state exists yet.
@@ -449,6 +453,37 @@ type Server struct {
 	// synchronisation and must not be mutated while the server is handling
 	// connections.
 	SlowPeerPolicy SlowPeerPolicy
+
+	// PersistCoalesceWindow controls debounced coalescing of persistence
+	// writes. Buffered updates are merged into a single StoreUpdate rather than
+	// written one-per-update. The window is a debounce: each new update resets
+	// it; see PersistCoalesceMaxWait for the hard ceiling.
+	//
+	//   0  — default (2s): coalescing ON (matches Hocuspocus).
+	//   <0 — disabled: strict one StoreUpdate per update (pre-v1.36 behaviour).
+	//   >0 — debounce window of this duration.
+	//
+	// Only affects servers with a PersistenceAdapter configured. Like the other
+	// config fields, set it before serving; it is read without synchronisation
+	// and must not be mutated while the server is handling connections.
+	PersistCoalesceWindow time.Duration
+
+	// PersistCoalesceMaxWait bounds how long a buffered update waits before it is
+	// flushed, measured from the batch's first update (Hocuspocus maxDebounce).
+	// Under sustained editing the debounce window keeps resetting, so flushes
+	// occur every PersistCoalesceMaxWait and durable state can lag live state by
+	// up to this duration. 0 uses the default (10s); the effective value is
+	// clamped to be at least PersistCoalesceWindow. Ignored when coalescing is
+	// disabled.
+	PersistCoalesceMaxWait time.Duration
+
+	// clock creates timers for the persistence worker. nil in production
+	// (resolves to realClock). Tests inject a fake for deterministic debounce.
+	clock wsClock
+
+	// mergeFn merges a batch of V1 updates. nil in production (resolves to
+	// crdt.MergeUpdatesV1). Tests inject a failing merge to exercise fallback.
+	mergeFn func(...[]byte) ([]byte, error)
 
 	// MaxPendingItems caps the per-document pending-items queue depth. The
 	// queue holds items whose dependencies have not yet arrived, waiting for

--- a/provider/websocket/server_test.go
+++ b/provider/websocket/server_test.go
@@ -706,6 +706,10 @@ func (a *captureCtxAdapter) StoreUpdateContext(ctx context.Context, room string,
 func TestServer_PersistenceAdapterContext_PreferredOverLegacy(t *testing.T) {
 	a := &captureCtxAdapter{}
 	s := ygws.NewServerWithPersistence(a)
+	// This test asserts the ctx-aware adapter variant is preferred over the
+	// legacy one for a single write; disable coalescing so the store happens
+	// per-update (coalescing is exercised separately in persistence_coalesce_test.go).
+	s.PersistCoalesceWindow = -1
 	defer s.Shutdown(context.Background())
 
 	// Trigger a persistence write by calling Apply.
@@ -746,6 +750,9 @@ func (a *legacyAdapter) StoreUpdate(room string, update []byte) error {
 func TestServer_LegacyPersistenceAdapter_StillWorks(t *testing.T) {
 	a := &legacyAdapter{}
 	s := ygws.NewServerWithPersistence(a)
+	// Disable coalescing so the legacy StoreUpdate fires per-update within the
+	// sleep window; coalescing is exercised in persistence_coalesce_test.go.
+	s.PersistCoalesceWindow = -1
 	defer s.Shutdown(context.Background())
 
 	err := s.Apply(context.Background(), "room2", func(doc *crdt.Doc, transact func(func(*crdt.Transaction))) {


### PR DESCRIPTION
## Summary

Fixes #175. The websocket persistence worker previously wrote **one backing-store update per yjs update** during normal operation, causing high persistence latency and version churn under active editing (observed in reearth-flow on GCS-backed `VersionedPersistence`).

This PR makes the worker **debounce-coalesce** writes: bursts of updates are merged into a single `crdt.MergeUpdatesV1` call and handed to the adapter as one `StoreUpdate`, collapsing the write and version count.

## Design (verified against reference implementations)

Compared how yjs (y-websocket + y-leveldb), yrs (yrs-kvstore), and Hocuspocus handle this. y-leveldb/yrs use *append + periodic compaction* — which doesn't map to ygo, since the adapter owns storage semantics and ygo can't compact on its behalf. **Hocuspocus** is structurally identical to ygo's server (owns the persistence worker, writes to an arbitrary backing store) and debounces persistence by default (2s window / 10s maxDebounce). We follow Hocuspocus.

## Behaviour change

Coalescing is **on by default** (Hocuspocus parity): a 2s debounce window capped by a 10s max wait. This affects **only** servers with a `PersistenceAdapter` configured (`NewServerWithPersistence` / explicit set); a plain `NewServer()` is unaffected. Set `Server.PersistCoalesceWindow = -1` to restore strict one-write-per-update.

## API

- `Server.PersistCoalesceWindow time.Duration` — `0` → 2s default (on); `<0` → disabled; `>0` → custom debounce window (resets per update).
- `Server.PersistCoalesceMaxWait time.Duration` — `0` → 10s default; hard ceiling from the batch's first update; clamped ≥ window.

## Durability

- Stop/shutdown flushes the pending batch with `context.Background()` (never the cancellable worker ctx), so a context-respecting adapter reliably receives the final batched write.
- A shutdown/timer cancelled-ctx race (a timer flush racing `Shutdown`'s ctx-cancel could drop a batch) is closed by retaining the batch on a failed flush and re-flushing at the exit case.
- Merge order = arrival order; merged state is byte-equivalent to sequential apply. On merge failure, the batch is stored individually so no committed transaction is dropped.
- Disabled path (`window < 0`) preserves the exact prior per-update behaviour.

## Tests

New deterministic tests (fake-clock timer seam, no wall-clock sleeps): burst→one merged store, disabled→per-update, maxWait flush, shutdown flush uses a non-cancelled ctx, merge-failure fallback, and retain-and-reflush on a failed flush. Full `provider/websocket` package passes with `-race`; `go build ./...`, `go vet`, and gofmt all clean.

## Release

Targets **v1.36.0** (minor — new exported fields, no API break). CHANGELOG / RELEASE_NOTES / README updated in-branch with the behaviour-change callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
