### PR TITLE
docs: bump README current-release line to v1.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.34.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.36.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Docs-only. The README intro's "current release is **vX.Y.Z**" line had drifted — it still read **v1.34.0** through both the v1.35.0 and v1.36.0 releases. This bumps it to **v1.36.0** so the repo README matches the latest tag.

No module surface change; this can ride along with the next patch/minor release.

### Note on the recurring drift
This hand-maintained line has now lagged across several releases. A follow-up option (not in this PR) is to replace it with a dynamic version badge (e.g. a shields.io Go-module/release badge) so it can't go stale, or to drop the explicit version and point solely at the release list. Happy to do that separately if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
