### PR TITLE
fix(websocket): durable-before-evict persistence + compaction support (#175 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.37.0] — 2026-07-23
+
+### Fixed
+
+- **Lost edits on quick refresh with coalesced persistence**: the websocket
+  server evicted a room from its in-memory map before the pending coalesced
+  batch was flushed, so a fast reconnect could reload stale state from the
+  backing store and miss the just-made edit. The room-teardown paths
+  (`handleDisconnect`, `CloseRoom`) now flush the batch durably — and await it —
+  while the room is still discoverable, then re-check and evict; a peer that
+  reconnects during the flush reuses the live in-memory document. Follow-up to
+  the v1.36.0 coalescing work ([#175](https://github.com/reearth/ygo/issues/175)).
+
+### Added
+
+- **`CompactableAdapter`** (optional `PersistenceAdapter` extension) and
+  **`Server.CompactEvery`** ([#175](https://github.com/reearth/ygo/issues/175)):
+  the server calls `Compact(ctx, room)` on room unload, and — when
+  `CompactEvery > 0` — after every N persistence flushes, letting an adapter
+  bound stored-version growth. `persistence.LegacyAdapter` implements it (new
+  `KeepVersions` field) by forwarding to the existing
+  `VersionedPersistence.Compact`.
+
 ## [1.36.0] — 2026-07-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.36.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.37.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 
@@ -71,6 +71,7 @@ Post-v1.0 hardening:
 - **Attribution API** (v1.30.0). `IDSet`/`IDMap`/`ContentMap` + wire codec tracking yjs v14-rc `14.0.0-16` — stamp CRDT content with per-item authorship (`userid`, `ts`, …) and exchange it with JS. Non-goals documented (no storage integration; `diffDocsToDelta` deferred). See [Attribution](#attribution) below.
 - **Subdocument lifecycle** (#63). A `Doc` can embed another `Doc` as a subdocument via `YMap.Set(txn, key, subdoc)`; `GetSubdocs`/`GetSubdocGUIDs`/`OnSubdocs`/`Load` plus `WithAutoLoad`/`WithShouldLoad`/`WithCollectionID` track and drive the add/remove/load lifecycle — the local half of Yjs's subdocuments feature. Also: `New()` now defaults a Doc's `guid` to a random uuidv4 instead of `""` (Yjs parity). Live cross-peer subdoc sync is a separate, tracked follow-up (#142). See [Subdocuments](#subdocuments) below.
 - **Coalesced persistence** (v1.36.0). The websocket server's persistence worker now debounces backing-store writes by default — a 2s window, capped by a 10s max wait — merging bursts into a single `StoreUpdate` instead of one write per update (Hocuspocus parity). This is a behaviour change for servers with a `PersistenceAdapter` configured; set `Server.PersistCoalesceWindow = -1` to restore strict per-update writes (#175).
+- **Persistence durability + compaction** (v1.37.0). The room-teardown paths now flush a pending coalesced batch durably before evicting the room, closing a gap where a fast reconnect could reload stale state and miss the just-made edit. Adapters can also bound stored-version growth by implementing `CompactableAdapter`, driven by `Server.CompactEvery` (`persistence.LegacyAdapter` supports this via its new `KeepVersions` field) (#175).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 
@@ -380,6 +381,8 @@ type PersistenceAdapter interface {
 `LoadDoc` is called once when the first peer connects to a room; the result seeds the in-memory doc. `StoreUpdate` is called on every committed transaction. Writes run on a per-room worker goroutine — slow storage doesn't block peers. Wire an adapter in via `NewServerWithPersistence(adapter)`.
 
 By default (v1.36.0) these writes are coalesced: the worker debounces bursts of updates into a single merged `StoreUpdate` call using a 2s window (reset on each new update) capped by a 10s max wait, matching Hocuspocus's default debounce behaviour. Tune it via `Server.PersistCoalesceWindow` / `Server.PersistCoalesceMaxWait`, or set `PersistCoalesceWindow` to a negative value (e.g. `-1`) to disable coalescing and restore strict one-write-per-update persistence.
+
+A room's pending coalesced batch is flushed durably before the room unloads (v1.37.0), so a peer that reconnects during a quick refresh reuses the live document instead of racing a stale reload from the backing store. Adapters that also want to bound stored-version growth can implement `CompactableAdapter` (`Compact(ctx, room) error`); the server invokes it on room unload and, when `Server.CompactEvery > 0`, after every N persistence flushes. `persistence.LegacyAdapter` implements this via its `KeepVersions` field.
 
 For a ready-made durable backend, [`persistence/sqlite`](persistence/sqlite/) provides a pure-Go (CGO-free, `modernc.org/sqlite`) `VersionedPersistence` store with WAL mode, full versioned history, and a crash-safe two-phase prune. Open it with `sqlite.Open("data.db")`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+## v1.37.0
+
+A minor release hardening the websocket server's coalesced persistence path.
+It closes a durability gap where a room could be evicted before its pending
+batch was flushed, and gives adapters an optional way to bound stored-version
+growth. No breaking changes; the default behaviour of servers without a
+`CompactableAdapter` is unchanged.
+
+### Fixed
+
+- **Lost edits on quick refresh with coalesced persistence**
+  ([#175](https://github.com/reearth/ygo/issues/175)): the room-teardown paths
+  (`handleDisconnect`, `CloseRoom`) now flush the pending coalesced batch
+  durably — and await it — while the room is still discoverable, then re-check
+  and evict. A peer that reconnects during the flush reuses the live
+  in-memory document instead of reloading stale state from the backing store.
+
+### Added
+
+- **`CompactableAdapter` and `Server.CompactEvery`**
+  ([#175](https://github.com/reearth/ygo/issues/175)): an optional
+  `PersistenceAdapter` extension the server calls on room unload, and — when
+  `CompactEvery > 0` — after every N persistence flushes, letting an adapter
+  bound stored-version growth. `persistence.LegacyAdapter` implements it via a
+  new `KeepVersions` field, forwarding to the existing
+  `VersionedPersistence.Compact`.
+
+## Install
+
+```
+go get github.com/reearth/ygo@v1.37.0
+```
+
+See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+
+---
+
 ## v1.36.0
 
 A minor release that changes the default persistence behaviour for the

--- a/persistence/adapter.go
+++ b/persistence/adapter.go
@@ -20,6 +20,13 @@ import "context"
 type LegacyAdapter struct {
 	store VersionedPersistence
 	ctx   context.Context
+
+	// KeepVersions bounds retained history when the websocket server asks the
+	// adapter to compact (see the provider's CompactableAdapter / CompactEvery).
+	// 0 (default) keeps all history — Compact becomes a cheap no-op. Set > 0 to
+	// trim to the newest KeepVersions updates on each compaction. Adapter-side
+	// retention policy; set before serving.
+	KeepVersions int
 }
 
 // NewLegacyAdapter wraps store. The provider's LoadDoc/StoreUpdate are
@@ -62,6 +69,14 @@ func (a *LegacyAdapter) StoreUpdate(room string, update []byte) error {
 // in-flight writes on shutdown.
 func (a *LegacyAdapter) StoreUpdateContext(ctx context.Context, room string, update []byte) error {
 	_, err := a.store.AppendUpdate(ctx, room, update)
+	return err
+}
+
+// Compact satisfies the provider's optional CompactableAdapter interface. It
+// forwards to the wrapped VersionedPersistence.Compact with the configured
+// KeepVersions retention (0 = keep all). The deleted count is dropped.
+func (a *LegacyAdapter) Compact(ctx context.Context, room string) error {
+	_, err := a.store.Compact(ctx, room, a.KeepVersions)
 	return err
 }
 

--- a/persistence/adapter_test.go
+++ b/persistence/adapter_test.go
@@ -115,7 +115,8 @@ func TestLegacyAdapter_CompactKeepZeroIsNoop(t *testing.T) {
 	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
 	require.NoError(t, ad.StoreUpdate("room", crdt.EncodeStateAsUpdateV1(doc, nil)))
 	require.NoError(t, ad.Compact(context.Background(), "room")) // keep=0 → keep all, no error
-	metas, _ := store.ListVersions(context.Background(), "room")
+	metas, err := store.ListVersions(context.Background(), "room")
+	require.NoError(t, err)
 	assert.Len(t, metas, 1)
 }
 

--- a/persistence/adapter_test.go
+++ b/persistence/adapter_test.go
@@ -81,6 +81,44 @@ func TestLegacyAdapter_PluggedIntoServer(t *testing.T) {
 	assert.Equal(t, "persisted", docB.GetText("t").ToString())
 }
 
+func TestLegacyAdapter_CompactForwardsWithKeep(t *testing.T) {
+	store := persistence.NewMemoryPersistence()
+	ad := persistence.NewLegacyAdapter(store)
+	ad.KeepVersions = 2
+
+	// Append 5 versions.
+	for i := 0; i < 5; i++ {
+		doc := crdt.New(crdt.WithClientID(crdt.ClientID(i + 1)))
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+		require.NoError(t, ad.StoreUpdate("room", crdt.EncodeStateAsUpdateV1(doc, nil)))
+	}
+
+	// Compact via the shim → must forward to store.Compact(room, 2).
+	require.NoError(t, ad.Compact(context.Background(), "room"))
+
+	metas, err := store.ListVersions(context.Background(), "room")
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(metas), 2, "history should be trimmed to KeepVersions")
+
+	// State is preserved (materialised head still loads).
+	head, err := ad.LoadDoc("room")
+	require.NoError(t, err)
+	assert.NotEmpty(t, head)
+}
+
+func TestLegacyAdapter_CompactKeepZeroIsNoop(t *testing.T) {
+	store := persistence.NewMemoryPersistence()
+	ad := persistence.NewLegacyAdapter(store) // KeepVersions defaults to 0
+	doc := crdt.New(crdt.WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+	require.NoError(t, ad.StoreUpdate("room", crdt.EncodeStateAsUpdateV1(doc, nil)))
+	require.NoError(t, ad.Compact(context.Background(), "room")) // keep=0 → keep all, no error
+	metas, _ := store.ListVersions(context.Background(), "room")
+	assert.Len(t, metas, 1)
+}
+
 // ── minimal WS test helpers (self-contained; persistence_test package) ──
 
 func dialWS(t *testing.T, ts *httptest.Server, room string) *gws.Conn {

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -486,6 +486,24 @@ func (s *Server) CloseRoom(name string, force bool) error {
 		<-d
 	}
 
+	// FLUSH-BEFORE-EVICT (#175 follow-up). Make the pending coalesced batch
+	// durable while rm is still in s.rooms — before re-acquiring s.rmu to
+	// delete it — so a concurrent GetDoc / reconnect reads up-to-date state
+	// rather than a stale store. Uses the flushReq path (worker stays alive,
+	// room discoverable) instead of relying on close(persistStop)'s exit-flush.
+	// Guard against a worker that already exited: a last-peer handleDisconnect
+	// forced above may have already evicted the room and closed persistStop, in
+	// which case the persistDone branch is taken and the flush is a harmless
+	// no-op. No lock is held across the send/ack.
+	if rm.flushReq != nil {
+		ack := make(chan struct{})
+		select {
+		case rm.flushReq <- ack:
+			<-ack
+		case <-rm.persistDone:
+		}
+	}
+
 	// Re-acquire locks to delete the room. Compare pointer identity so we
 	// don't delete a REPLACEMENT room that was created at the same key:
 	//   - handleDisconnect may have already deleted the original.

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -494,12 +494,21 @@ func (s *Server) CloseRoom(name string, force bool) error {
 	// Guard against a worker that already exited: a last-peer handleDisconnect
 	// forced above may have already evicted the room and closed persistStop, in
 	// which case the persistDone branch is taken and the flush is a harmless
-	// no-op. No lock is held across the send/ack.
+	// no-op. No lock is held across the send/ack; the ack is buffered (cap 1) so
+	// the worker never blocks reporting the result.
+	//
+	// Unlike handleDisconnect, CloseRoom is a FORCED admin removal: it proceeds to
+	// evict regardless of flush success. The close(persistStop) below drives the
+	// worker's exit-flush as the retry, so a false result here is not fatal — we
+	// only log it (best effort) and do not abort.
 	if rm.flushReq != nil {
-		ack := make(chan struct{})
+		ack := make(chan bool, 1)
 		select {
 		case rm.flushReq <- ack:
-			<-ack
+			if !<-ack {
+				s.log().Warn("CloseRoom flush did not fully persist; relying on exit-flush retry",
+					"room", name)
+			}
 		case <-rm.persistDone:
 		}
 	}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -290,25 +290,41 @@ func (p *peer) handleDisconnect() {
 		// exit-flush, but a reconnect can beat that; the flushReq path is what
 		// guarantees durability-while-discoverable. Guard against a worker that
 		// already exited (e.g. CloseRoom raced us) via the persistDone branch.
-		// CRITICAL: no lock (rmu / rm.mu) may be held across the send/ack.
+		//
+		// The ack is a real durability barrier: flushOK is true only if the batch
+		// was actually persisted. On failure we ABORT eviction below — keeping the
+		// room + worker alive so the retained batch is retried on the next teardown
+		// / Shutdown, and a reconnect meanwhile finds the warm in-memory doc rather
+		// than reloading a stale store (which would silently lose the edit).
+		// CRITICAL: no lock (rmu / rm.mu) may be held across the send/ack; the ack
+		// is buffered (cap 1) so the worker never blocks reporting the result.
+		flushOK := true
 		if empty && rm.flushReq != nil {
-			ack := make(chan struct{})
+			ack := make(chan bool, 1)
 			select {
 			case rm.flushReq <- ack:
-				<-ack
+				flushOK = <-ack
 			case <-rm.persistDone:
-				// worker already gone — nothing to flush
+				// Worker already gone (raced by CloseRoom/shutdown); its exit-flush
+				// handled durability best-effort. Leave flushOK true so eviction can
+				// still finish tearing down this defunct room.
 			}
 		}
 
-		// Re-check emptiness under the locks and evict only if still empty: a
-		// peer may have reconnected during the (possibly slow) flush above.
+		// Re-check emptiness under the locks and evict only if still empty AND the
+		// flush persisted: a peer may have reconnected during the (possibly slow)
+		// flush above, or the flush may have failed. evict gates both the
+		// persistStop close and the persistDone wait so they stay consistent —
+		// when we abort (flush failed) the worker stays alive and we must NOT wait
+		// on persistDone (it would block forever).
 		stillEmpty := false
+		evict := false
 		if empty {
 			p.server.rmu.Lock()
 			rm.mu.Lock()
 			stillEmpty = len(rm.peers) == 0
-			if stillEmpty {
+			evict = stillEmpty && flushOK
+			if evict {
 				if current, stillIn := p.server.rooms[p.roomName]; stillIn && current == rm {
 					delete(p.server.rooms, p.roomName)
 					roomEvicted = true
@@ -326,10 +342,11 @@ func (p *peer) handleDisconnect() {
 			p.server.rmu.Unlock()
 
 			// Wait for the persistence goroutine to drain and exit before the
-			// room reference becomes garbage. Only wait when we actually closed
-			// persistStop (stillEmpty): otherwise the worker is still running
-			// (a peer rejoined) and this would block forever.
-			if stillEmpty && rm.persistDone != nil {
+			// room reference becomes garbage. Only wait when we actually evicted
+			// (closed persistStop, or found it already closed by CloseRoom):
+			// otherwise the worker is still running (a peer rejoined, or we aborted
+			// on flush failure) and this would block forever.
+			if evict && rm.persistDone != nil {
 				<-rm.persistDone
 			}
 		}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -262,30 +262,11 @@ func (p *peer) handleDisconnect() {
 		rm.mu.Lock()
 		delete(rm.peers, p)
 		empty := len(rm.peers) == 0
-		// roomEvicted distinguishes "we were the path that removed rm from
-		// s.rooms" from "rm was already gone (CloseRoom won the race)".
-		// Only the evicting path fires OnUnloadDocument — without this
-		// guard a concurrent CloseRoom + last-peer-disconnect double-fires
-		// the hook on the same room name. (#93 self-review B1.)
-		roomEvicted := false
-		if empty {
-			if current, stillIn := p.server.rooms[p.roomName]; stillIn && current == rm {
-				delete(p.server.rooms, p.roomName)
-				roomEvicted = true
-			}
-			if rm.persistStop != nil {
-				select {
-				case <-rm.persistStop:
-					// already closed by CloseRoom
-				default:
-					close(rm.persistStop)
-				}
-			}
-		}
 		rm.mu.Unlock()
 		p.server.rmu.Unlock()
 
-		// Release semaphore slots now that the peer has left.
+		// Release semaphore slots now that the peer has left. These run
+		// regardless of the eviction decision below.
 		if rm.peerSem != nil {
 			rm.peerSem.Release(1)
 		}
@@ -293,10 +274,64 @@ func (p *peer) handleDisconnect() {
 			sem.Release(1)
 		}
 
-		// Wait for the persistence goroutine to drain buffered writes before the
-		// room reference becomes garbage. This runs outside the locks above.
-		if empty && rm.persistDone != nil {
-			<-rm.persistDone
+		// roomEvicted distinguishes "we were the path that removed rm from
+		// s.rooms" from "rm was already gone (CloseRoom won the race)".
+		// Only the evicting path fires OnUnloadDocument — without this
+		// guard a concurrent CloseRoom + last-peer-disconnect double-fires
+		// the hook on the same room name. (#93 self-review B1.)
+		roomEvicted := false
+
+		// FLUSH-BEFORE-EVICT (#175 follow-up). When the room is now empty, make
+		// the pending coalesced batch durable BEFORE evicting the room from
+		// s.rooms — while the worker is still alive and the room is still
+		// discoverable. A quick reconnect then either finds this warm room or
+		// reads an up-to-date store, never a stale one. We must NOT close
+		// persistStop for this flush: closing it triggers the worker's own
+		// exit-flush, but a reconnect can beat that; the flushReq path is what
+		// guarantees durability-while-discoverable. Guard against a worker that
+		// already exited (e.g. CloseRoom raced us) via the persistDone branch.
+		// CRITICAL: no lock (rmu / rm.mu) may be held across the send/ack.
+		if empty && rm.flushReq != nil {
+			ack := make(chan struct{})
+			select {
+			case rm.flushReq <- ack:
+				<-ack
+			case <-rm.persistDone:
+				// worker already gone — nothing to flush
+			}
+		}
+
+		// Re-check emptiness under the locks and evict only if still empty: a
+		// peer may have reconnected during the (possibly slow) flush above.
+		stillEmpty := false
+		if empty {
+			p.server.rmu.Lock()
+			rm.mu.Lock()
+			stillEmpty = len(rm.peers) == 0
+			if stillEmpty {
+				if current, stillIn := p.server.rooms[p.roomName]; stillIn && current == rm {
+					delete(p.server.rooms, p.roomName)
+					roomEvicted = true
+				}
+				if rm.persistStop != nil {
+					select {
+					case <-rm.persistStop:
+						// already closed by CloseRoom
+					default:
+						close(rm.persistStop)
+					}
+				}
+			}
+			rm.mu.Unlock()
+			p.server.rmu.Unlock()
+
+			// Wait for the persistence goroutine to drain and exit before the
+			// room reference becomes garbage. Only wait when we actually closed
+			// persistStop (stillEmpty): otherwise the worker is still running
+			// (a peer rejoined) and this would block forever.
+			if stillEmpty && rm.persistDone != nil {
+				<-rm.persistDone
+			}
 		}
 
 		// #60 — Fire lifecycle hooks AFTER locks released and persistence

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -143,13 +143,18 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 
 		// Strict per-update path (coalescing disabled): unchanged behaviour.
 		if !enabled {
-			drain := func() {
+			// drain stores everything currently buffered and reports whether every
+			// store succeeded, so an on-demand flush can act as a durability barrier.
+			drain := func() bool {
+				ok := true
 				for {
 					select {
 					case update := <-r.persistCh:
-						_ = store(ctx, update)
+						if store(ctx, update) != nil {
+							ok = false
+						}
 					default:
-						return
+						return ok
 					}
 				}
 			}
@@ -158,8 +163,8 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				case update := <-r.persistCh:
 					_ = store(ctx, update)
 				case ack := <-r.flushReq:
-					drain() // store everything currently buffered
-					close(ack)
+					ok := drain() // store everything currently buffered
+					ack <- ok
 				case <-r.persistStop:
 					drain()
 					maybeCompact()
@@ -255,7 +260,10 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				}
 				clearTimers()
 				onFlushed(wrote && ok)
-				close(ack)
+				// Report success so teardown can gate eviction on real durability.
+				// On failure the batch is retained (not niled) for a later retry.
+				// ack is buffered (cap 1) by every caller, so this never blocks.
+				ack <- ok
 			case <-r.persistStop:
 				drainBuffered()
 				flush(context.Background(), batch) // non-cancelled: survive shutdown

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -230,28 +230,31 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				// state; it is re-flushed at the stop/shutdown exit case below
 				// with a background context.
 				wrote := len(batch) > 0
-				if flush(ctx, batch) {
+				ok := flush(ctx, batch)
+				if ok {
 					batch = nil
 				}
 				clearTimers()
-				onFlushed(wrote)
+				onFlushed(wrote && ok)
 			case <-maxC:
 				wrote := len(batch) > 0
-				if flush(ctx, batch) {
+				ok := flush(ctx, batch)
+				if ok {
 					batch = nil
 				}
 				clearTimers()
-				onFlushed(wrote)
+				onFlushed(wrote && ok)
 			case ack := <-r.flushReq:
 				// The just-arrived edit may still be in persistCh, not yet in
 				// batch — drain first so an on-demand flush never misses it.
 				drainBuffered()
 				wrote := len(batch) > 0
-				if flush(context.Background(), batch) {
+				ok := flush(context.Background(), batch)
+				if ok {
 					batch = nil
 				}
 				clearTimers()
-				onFlushed(wrote)
+				onFlushed(wrote && ok)
 				close(ack)
 			case <-r.persistStop:
 				drainBuffered()

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -153,6 +153,9 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				select {
 				case update := <-r.persistCh:
 					_ = store(ctx, update)
+				case ack := <-r.flushReq:
+					drain() // store everything currently buffered
+					close(ack)
 				case <-r.persistStop:
 					drain()
 					maybeCompact()
@@ -235,6 +238,17 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				}
 				clearTimers()
 				onFlushed(wrote)
+			case ack := <-r.flushReq:
+				// The just-arrived edit may still be in persistCh, not yet in
+				// batch — drain first so an on-demand flush never misses it.
+				drainBuffered()
+				wrote := len(batch) > 0
+				if flush(context.Background(), batch) {
+					batch = nil
+				}
+				clearTimers()
+				onFlushed(wrote)
+				close(ack)
 			case <-r.persistStop:
 				drainBuffered()
 				flush(context.Background(), batch) // non-cancelled: survive shutdown

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -56,6 +56,38 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			cancel()
 		}()
 
+		compactor, _ := s.persistence.(CompactableAdapter)
+		compactEvery := s.CompactEvery
+		flushCount := 0
+
+		// maybeCompact calls the adapter's Compact (if any) with a background
+		// ctx, contained by recover; errors/panics are logged, never fatal.
+		maybeCompact := func() {
+			if compactor == nil {
+				return
+			}
+			defer func() {
+				if rv := recover(); rv != nil {
+					log.Printf("ygo/websocket: Compact panic for room %q: %v", name, rv)
+				}
+			}()
+			if err := compactor.Compact(context.Background(), name); err != nil {
+				log.Printf("ygo/websocket: Compact for room %q: %v", name, err)
+			}
+		}
+
+		// onFlushed records a non-empty flush and triggers count-based compaction.
+		onFlushed := func(wrote bool) {
+			if !wrote || compactEvery <= 0 || compactor == nil {
+				return
+			}
+			flushCount++
+			if flushCount >= compactEvery {
+				flushCount = 0
+				maybeCompact()
+			}
+		}
+
 		// store issues one backing-store write for a single update using the
 		// given ctx and returns whether it failed. Panics are contained and
 		// reported as a non-nil error; errors are logged (no retry).
@@ -123,9 +155,11 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 					_ = store(ctx, update)
 				case <-r.persistStop:
 					drain()
+					maybeCompact()
 					return
 				case <-s.shutdownCh:
 					drain()
+					maybeCompact()
 					return
 				}
 			}
@@ -188,24 +222,30 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				// A batch retained here has no self-driven retry timer in steady
 				// state; it is re-flushed at the stop/shutdown exit case below
 				// with a background context.
+				wrote := len(batch) > 0
 				if flush(ctx, batch) {
 					batch = nil
 				}
 				clearTimers()
+				onFlushed(wrote)
 			case <-maxC:
+				wrote := len(batch) > 0
 				if flush(ctx, batch) {
 					batch = nil
 				}
 				clearTimers()
+				onFlushed(wrote)
 			case <-r.persistStop:
 				drainBuffered()
 				flush(context.Background(), batch) // non-cancelled: survive shutdown
 				clearTimers()                      // release any pending timers before exit
+				maybeCompact()
 				return
 			case <-s.shutdownCh:
 				drainBuffered()
 				flush(context.Background(), batch)
 				clearTimers() // release any pending timers before exit
+				maybeCompact()
 				return
 			}
 		}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -30,6 +30,10 @@ import (
 // drain uses the cancellable ctx — matching pre-v1.36 behaviour — so a
 // context-aware adapter may still see cancellation during that drain.
 // Otherwise falls back to StoreUpdate (existing behaviour).
+//
+// When s.persistence also implements CompactableAdapter, Compact is invoked
+// on room unload (including server shutdown) and, when s.CompactEvery > 0,
+// after every N persistence flushes on the coalescing path.
 func (s *Server) startPersistenceWorker(r *room, name string) {
 	clock := s.clock
 	if clock == nil {

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -365,6 +365,61 @@ func TestPersistCompact_NonCompactableAdapterSafe(t *testing.T) {
 	require.NoError(t, s.Shutdown(context.Background())) // must not panic
 }
 
+// flushRoom sends a flush request and waits for the ack (test helper mirroring
+// what teardown will do).
+func flushRoom(t *testing.T, r *room) {
+	t.Helper()
+	ack := make(chan struct{})
+	select {
+	case r.flushReq <- ack:
+		select {
+		case <-ack:
+		case <-time.After(2 * time.Second):
+			t.Fatal("flush ack timed out")
+		}
+	case <-r.persistDone:
+		// worker already gone
+	case <-time.After(2 * time.Second):
+		t.Fatal("flushReq send timed out")
+	}
+}
+
+// A pending batch (window timer NOT fired) is made durable by flushReq.
+func TestPersistFlushReq_MakesPendingBatchDurable(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		applyEdit(r, "x", 0)
+	}
+	for i := 0; i < n; i++ {
+		fc.nextTimerOfDur(t, 50*time.Millisecond) // ensure all batched, do NOT fire
+	}
+	flushRoom(t, r) // force durable flush without firing the timer
+
+	require.Equal(t, 1, a.count(), "flushReq should flush the pending batch exactly once")
+	got := crdt.New()
+	require.NoError(t, crdt.ApplyUpdateV1(got, a.stores[0], nil))
+	assert.Equal(t, n, got.GetText("t").Len())
+}
+
+// flushReq works on the disabled path too.
+func TestPersistFlushReq_DisabledPath(t *testing.T) {
+	a := &recordAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, -1, 0) // disabled
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+	applyEdit(r, "y", 0)
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond)
+	flushRoom(t, r) // no pending data; must still ack, no deadlock, no extra store
+	assert.Equal(t, 1, a.count())
+}
+
 // Merge failure falls back to storing each update individually (no loss).
 func TestPersistCoalesce_MergeFailureFallsBack(t *testing.T) {
 	a := &recordAdapter{}

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -3,14 +3,20 @@ package websocket
 import (
 	"context"
 	"errors"
+	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gws "github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+	ygsync "github.com/reearth/ygo/sync"
 )
 
 // --- fake clock -----------------------------------------------------------
@@ -441,4 +447,215 @@ func TestPersistCoalesce_MergeFailureFallsBack(t *testing.T) {
 
 	assert.Eventually(t, func() bool { return a.count() == n }, time.Second, 5*time.Millisecond,
 		"merge failure should fall back to individual stores")
+}
+
+// --- flush-before-evict teardown (Task 4 / #175 follow-up) ------------------
+//
+// These tests exercise the real disconnect/reconnect path end-to-end through an
+// httptest server so the teardown reorder in handleDisconnect + CloseRoom is
+// covered against a live worker. They live in the internal package, so the
+// external dial/handshake helpers in server_test.go are not reachable — the
+// minimal local equivalents below dial a gws client, run the sync handshake,
+// and apply received sync frames into a local *crdt.Doc.
+
+// dialWS opens a WebSocket connection to the test server for the given room.
+func dialWS(t *testing.T, ts *httptest.Server, room string) *gws.Conn {
+	t.Helper()
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "/" + room
+	conn, _, err := gws.DefaultDialer.Dial(u, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// drainWS reads the three handshake frames the server always sends on connect
+// (sync step-1, sync step-2, awareness) and applies any sync frames into doc.
+// A fixed read count is used because gorilla's reader is permanently broken by a
+// deadline expiry; the server contract is exactly three frames.
+func drainWS(t *testing.T, conn *gws.Conn, doc *crdt.Doc) {
+	t.Helper()
+	for i := 0; i < 3; i++ {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := conn.ReadMessage()
+		_ = conn.SetReadDeadline(time.Time{})
+		require.NoError(t, err)
+		dec := encoding.NewDecoder(data)
+		outer, err := dec.ReadVarUint()
+		require.NoError(t, err)
+		if outer == msgSync {
+			if _, err := ygsync.ApplySyncMessage(doc, dec.RemainingBytes(), nil); err != nil {
+				t.Fatalf("apply sync frame: %v", err)
+			}
+		}
+	}
+}
+
+// sendV1Update frames a full V1 update as an outer msgSync + inner MsgUpdate
+// (VarBytes-wrapped) and sends it to the server.
+func sendV1Update(t *testing.T, conn *gws.Conn, update []byte) {
+	t.Helper()
+	enc := encoding.NewEncoder()
+	enc.WriteVarUint(msgSync)
+	enc.WriteVarUint(ygsync.MsgUpdate)
+	enc.WriteVarBytes(update)
+	require.NoError(t, conn.WriteMessage(gws.BinaryMessage, enc.Bytes()))
+}
+
+// blockingAdapter blocks StoreUpdate until released, so a flush is in-flight
+// during the reconnect window. close(blocked) signals the first store attempt.
+type blockingAdapter struct {
+	mu      sync.Mutex
+	docs    map[string][]byte
+	release chan struct{}
+	blocked chan struct{}
+	once    sync.Once
+}
+
+func newBlockingAdapter() *blockingAdapter {
+	return &blockingAdapter{docs: map[string][]byte{}, release: make(chan struct{}), blocked: make(chan struct{})}
+}
+
+func (a *blockingAdapter) LoadDoc(room string) ([]byte, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.docs[room], nil
+}
+
+func (a *blockingAdapter) StoreUpdate(room string, update []byte) error {
+	a.once.Do(func() { close(a.blocked) })
+	<-a.release // block until the test releases
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.docs[room]) == 0 {
+		a.docs[room] = append([]byte(nil), update...)
+	} else {
+		merged, err := crdt.MergeUpdatesV1(a.docs[room], update)
+		if err != nil {
+			return err
+		}
+		a.docs[room] = merged
+	}
+	return nil
+}
+
+// A peer edits then disconnects; while the flush is blocked, a reconnect must
+// NOT lose the edit (it finds the still-warm room, or reads a durable store).
+func TestPersistTeardown_NoLossOnQuickRefresh(t *testing.T) {
+	a := newBlockingAdapter()
+	// Real server (real clock) so the disconnect/reconnect path runs end-to-end.
+	s := NewServerWithPersistence(a)
+	s.PersistCoalesceWindow = 5 * time.Second // long window: edit stays in batch
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Peer A edits.
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hello", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	// Disconnect A -> teardown starts flush (blocks in StoreUpdate).
+	_ = connA.Close()
+	<-a.blocked // flush is now in-flight and blocked
+
+	// Reconnect (fresh peer) for the same room while the flush is blocked.
+	go func() { time.Sleep(50 * time.Millisecond); close(a.release) }()
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	drainWS(t, connB, docB)
+
+	assert.Equal(t, "hello", docB.GetText("t").ToString(),
+		"reconnect must see the edit — no loss on quick refresh")
+}
+
+// A peer rejoining during the flush keeps the room alive (no reload, no unload
+// hook). Uses the blocking adapter to hold the flush open across the rejoin.
+func TestPersistTeardown_RejoinDuringFlushKeepsRoom(t *testing.T) {
+	a := newBlockingAdapter()
+	s := NewServerWithPersistence(a)
+	s.PersistCoalesceWindow = 5 * time.Second
+	var unloaded int32
+	s.OnUnloadDocument = func(_ context.Context, _ string) {
+		atomic.AddInt32(&unloaded, 1)
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hi", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-a.blocked
+	// Rejoin while flush blocked, then release.
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	go func() { time.Sleep(50 * time.Millisecond); close(a.release) }()
+	drainWS(t, connB, docB)
+
+	assert.Equal(t, "hi", docB.GetText("t").ToString())
+	assert.Equal(t, int32(0), atomic.LoadInt32(&unloaded), "room must not unload when a peer rejoined")
+}
+
+// discoverabilityProbeAdapter records, at the moment StoreUpdate runs, whether
+// the room is still present in the server map (discoverable via GetDoc). It
+// implements only StoreUpdate (not the Context variant) so the worker calls
+// this method directly. GetDoc takes s.rmu.RLock; the flush send/ack in the
+// teardown paths never holds rmu, so no deadlock.
+type discoverabilityProbeAdapter struct {
+	mu          sync.Mutex
+	s           *Server
+	room        string
+	stores      [][]byte
+	liveAtStore bool
+}
+
+func (a *discoverabilityProbeAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+func (a *discoverabilityProbeAdapter) StoreUpdate(_ string, u []byte) error {
+	live := a.s != nil && a.s.GetDoc(a.room) != nil
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if live {
+		a.liveAtStore = true
+	}
+	a.stores = append(a.stores, append([]byte(nil), u...))
+	return nil
+}
+
+// CloseRoom must flush the pending coalesced batch WHILE the room is still
+// discoverable in s.rooms (via flushReq), not after evicting it. If the flush
+// happened after the delete, a racing reconnect would create a fresh room and
+// read a stale store. We probe the ordering directly: the store must observe
+// the room still present. Also asserts the flushed bytes carry the edit.
+func TestPersistTeardown_CloseRoomFlushesBeforeEvict(t *testing.T) {
+	a := &discoverabilityProbeAdapter{room: "room"}
+	s := NewServerWithPersistence(a)
+	a.s = s
+	s.PersistCoalesceWindow = 5 * time.Second
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Server-side edit via Apply auto-creates a peerless room and batches the
+	// update behind the 5s window (never flushed by a timer within the test).
+	require.NoError(t, s.Apply(context.Background(), "room",
+		func(doc *crdt.Doc, transact func(func(*crdt.Transaction))) {
+			txt := doc.GetText("t")
+			transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "persisted", nil) })
+		}))
+
+	require.NoError(t, s.CloseRoom("room", false))
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	require.NotEmpty(t, a.stores, "CloseRoom must flush the pending batch before evicting")
+	assert.True(t, a.liveAtStore,
+		"the flush must happen while the room is still discoverable (before delete)")
+	got := crdt.New()
+	require.NoError(t, crdt.ApplyUpdateV1(got, a.stores[len(a.stores)-1], nil))
+	assert.Equal(t, "persisted", got.GetText("t").ToString())
 }

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -375,7 +375,7 @@ func TestPersistCompact_NonCompactableAdapterSafe(t *testing.T) {
 // what teardown will do).
 func flushRoom(t *testing.T, r *room) {
 	t.Helper()
-	ack := make(chan struct{})
+	ack := make(chan bool, 1)
 	select {
 	case r.flushReq <- ack:
 		select {
@@ -600,6 +600,88 @@ func TestPersistTeardown_RejoinDuringFlushKeepsRoom(t *testing.T) {
 
 	assert.Equal(t, "hi", docB.GetText("t").ToString())
 	assert.Equal(t, int32(0), atomic.LoadInt32(&unloaded), "room must not unload when a peer rejoined")
+}
+
+// alwaysFailAdapter fails every StoreUpdate, modelling a persistent backing-store
+// outage. LoadDoc returns empty so that IF the room were (wrongly) evicted, a
+// reconnect would reload an empty doc — surfacing the lost edit. Implements only
+// StoreUpdate (not the Context variant) so both worker paths call it directly.
+type alwaysFailAdapter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (a *alwaysFailAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+func (a *alwaysFailAdapter) StoreUpdate(_ string, _ []byte) error {
+	a.mu.Lock()
+	a.calls++
+	a.mu.Unlock()
+	return errors.New("backing store down")
+}
+func (a *alwaysFailAdapter) storeCalls() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+// When the last peer disconnects and the pending flush FAILS, eviction MUST be
+// aborted: the room stays in s.rooms with its worker alive so the retained batch
+// is retried on the next teardown, and a reconnect meanwhile finds the warm
+// in-memory doc rather than reloading a stale (empty) store. The flushReq ack
+// must therefore be a real durability barrier, not a signal that fires
+// regardless of flush success. Asserts OnUnloadDocument did NOT fire and the
+// reconnect still sees the edit. (#175 follow-up, comment 1.)
+func TestPersistTeardown_FlushFailureAbortsEviction(t *testing.T) {
+	a := &alwaysFailAdapter{}
+	s := NewServerWithPersistence(a)
+	s.PersistCoalesceWindow = 5 * time.Second // long window: edit stays batched
+	var unloaded int32
+	s.OnUnloadDocument = func(_ context.Context, _ string) {
+		atomic.AddInt32(&unloaded, 1)
+	}
+	// OnLastPeer fires in BOTH the evict and the flush-failed-abort paths, after
+	// the eviction decision is made and (if evicted) persistDone drained. Use it
+	// to synchronise: once signalled, the teardown has finished deciding, so a
+	// reconnect deterministically observes the post-decision room state — no
+	// sleeps. Non-blocking send so a later 1→0 (connB during Shutdown) can't stall
+	// the hook goroutine.
+	lastPeer := make(chan struct{}, 1)
+	s.OnLastPeer = func(_ context.Context, _ string) {
+		select {
+		case lastPeer <- struct{}{}:
+		default:
+		}
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Peer A edits, then disconnects. The pending batch flush on teardown fails.
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hello", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-lastPeer // teardown reached its eviction decision (and drained if it evicted)
+
+	// The flush must have been attempted (and failed) at least once.
+	assert.GreaterOrEqual(t, a.storeCalls(), 1, "teardown must attempt the flush")
+
+	// Reconnect for the same room. With the fix the warm room survived, so this
+	// finds the live in-memory doc carrying the edit. Without the fix the room was
+	// evicted, a fresh room reloads the empty store, and the edit is lost.
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	drainWS(t, connB, docB)
+
+	assert.Equal(t, "hello", docB.GetText("t").ToString(),
+		"reconnect must see the edit from the warm in-memory doc — flush failure must not evict")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&unloaded),
+		"OnUnloadDocument must NOT fire when the flush failed (room not evicted)")
+
+	require.NoError(t, s.Shutdown(context.Background()))
 }
 
 // discoverabilityProbeAdapter records, at the moment StoreUpdate runs, whether

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -283,6 +283,88 @@ func TestPersistCoalesce_RetainsBatchOnFailedFlush(t *testing.T) {
 	assert.Equal(t, n, got.GetText("t").Len())
 }
 
+// compactAdapter is a recordAdapter that also implements CompactableAdapter.
+type compactAdapter struct {
+	recordAdapter
+	mu       sync.Mutex
+	compacts []string // room per Compact call
+}
+
+func (a *compactAdapter) Compact(_ context.Context, room string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.compacts = append(a.compacts, room)
+	return nil
+}
+func (a *compactAdapter) compactCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.compacts)
+}
+
+// CompactEvery=N → Compact after every N non-empty window flushes.
+func TestPersistCompact_CountTrigger(t *testing.T) {
+	a := &compactAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	s.CompactEvery = 2
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	// 2 separate flushes: edit → window fire → edit → window fire.
+	for i := 0; i < 2; i++ {
+		applyEdit(r, "x", 0)
+		fc.nextTimerOfDur(t, 50*time.Millisecond).fire()
+		// wait for the store from this flush to land
+		want := i + 1
+		assert.Eventually(t, func() bool { return a.count() == want }, time.Second, 5*time.Millisecond)
+	}
+	assert.Eventually(t, func() bool { return a.compactCount() == 1 }, time.Second, 5*time.Millisecond,
+		"Compact should fire once after 2 flushes")
+}
+
+// CompactEvery=0 → no count-based Compact (only on unload).
+func TestPersistCompact_ZeroNoCountTrigger(t *testing.T) {
+	a := &compactAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond) // CompactEvery=0
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+	applyEdit(r, "x", 0)
+	fc.nextTimerOfDur(t, 50*time.Millisecond).fire()
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond)
+	// Give any erroneous compaction a chance, then assert none.
+	assert.Never(t, func() bool { return a.compactCount() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+// On room unload (Shutdown), Compact fires once after the final flush.
+func TestPersistCompact_OnUnload(t *testing.T) {
+	a := &compactAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+	applyEdit(r, "x", 0)
+	fc.nextTimerOfDur(t, 50*time.Millisecond) // batched, do not fire
+	require.NoError(t, s.Shutdown(context.Background()))
+	assert.Equal(t, 1, a.compactCount(), "Compact fires once on unload")
+	assert.GreaterOrEqual(t, a.count(), 1, "batch flushed before compact")
+}
+
+// Adapter without CompactableAdapter → no panic, no calls.
+func TestPersistCompact_NonCompactableAdapterSafe(t *testing.T) {
+	a := &recordAdapter{} // no Compact method
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, 50*time.Millisecond, 500*time.Millisecond)
+	s.CompactEvery = 1
+	r, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+	applyEdit(r, "x", 0)
+	fc.nextTimerOfDur(t, 50*time.Millisecond).fire()
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond)
+	require.NoError(t, s.Shutdown(context.Background())) // must not panic
+}
+
 // Merge failure falls back to storing each update individually (no loss).
 func TestPersistCoalesce_MergeFailureFallsBack(t *testing.T) {
 	a := &recordAdapter{}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -261,9 +261,13 @@ type room struct {
 
 	// flushReq requests an on-demand durable flush of the pending batch without
 	// stopping the worker. The worker drains persistCh, flushes with a
-	// background ctx, and closes the sent ack channel. nil when no
-	// PersistenceAdapter is configured.
-	flushReq chan chan struct{}
+	// background ctx, and reports the result on the sent ack channel: true only
+	// if the batch was fully persisted, false if any store failed (the batch is
+	// then retained for a later retry). The ack is a real durability barrier —
+	// teardown gates eviction on a true result. Callers MUST use a buffered ack
+	// (cap 1) so the worker's send never blocks. nil when no PersistenceAdapter
+	// is configured.
+	flushReq chan chan bool
 
 	// relayUnsub holds the doc.OnUpdate / awareness.OnChange unsubscribe
 	// functions registered when a Relay is attached. nil when no relay. Called
@@ -896,7 +900,7 @@ func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room,
 		r.persistCh = make(chan []byte, 256)
 		r.persistStop = make(chan struct{})
 		r.persistDone = make(chan struct{})
-		r.flushReq = make(chan chan struct{})
+		r.flushReq = make(chan chan bool)
 		s.startPersistenceWorker(r, name)
 		r.doc.OnUpdate(func(update []byte, _ any) {
 			select {

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -195,9 +195,12 @@ type PersistenceAdapterContext interface {
 // error (or panic) is logged and does not abort persistence. Retention policy
 // (how much history to keep) is the adapter's concern.
 //
-// On room unload, Compact runs synchronously in the worker's exit path, so a
-// slow or hanging implementation delays that room's teardown; the only bound
-// on it is the ctx passed to Server.Shutdown by its caller.
+// On room unload, Compact runs synchronously in the worker's exit path.
+// Compact is invoked with context.Background() (it is not cancelled by
+// Server.Shutdown), so a slow or hanging Compact delays that room's teardown
+// and its worker goroutine can outlive Shutdown's return (Shutdown stops
+// waiting when its caller's ctx fires, but the worker keeps running until
+// Compact returns).
 type CompactableAdapter interface {
 	Compact(ctx context.Context, room string) error
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -194,6 +194,10 @@ type PersistenceAdapterContext interface {
 // against concurrent writes to the same room. It is best-effort: a returned
 // error (or panic) is logged and does not abort persistence. Retention policy
 // (how much history to keep) is the adapter's concern.
+//
+// On room unload, Compact runs synchronously in the worker's exit path, so a
+// slow or hanging implementation delays that room's teardown; the only bound
+// on it is the ctx passed to Server.Shutdown by its caller.
 type CompactableAdapter interface {
 	Compact(ctx context.Context, room string) error
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -183,6 +183,21 @@ type PersistenceAdapterContext interface {
 	StoreUpdateContext(ctx context.Context, room string, update []byte) error
 }
 
+// CompactableAdapter is an optional extension to PersistenceAdapter. When the
+// adapter implements it, the server calls Compact to signal a good time to
+// collapse stored updates for a room into a compact form (e.g. merge the update
+// log into a snapshot, prune old versions) — on room unload, and, when
+// Server.CompactEvery > 0, after every N persistence flushes.
+//
+// Compact is invoked from the room's persistence worker goroutine, serialised
+// with StoreUpdate for that room, so implementations need no extra locking
+// against concurrent writes to the same room. It is best-effort: a returned
+// error (or panic) is logged and does not abort persistence. Retention policy
+// (how much history to keep) is the adapter's concern.
+type CompactableAdapter interface {
+	Compact(ctx context.Context, room string) error
+}
+
 // MemoryPersistence is a thread-safe in-memory PersistenceAdapter that merges
 // all updates into a single V1 snapshot per room. It is the default adapter
 // used when no external persistence is configured and is primarily useful in
@@ -485,6 +500,16 @@ type Server struct {
 	// only a negative PersistCoalesceWindow disables coalescing). Ignored when
 	// coalescing is disabled.
 	PersistCoalesceMaxWait time.Duration
+
+	// CompactEvery, when > 0, asks a CompactableAdapter to Compact a room after
+	// every N successful (non-empty) persistence flushes, bounding version
+	// growth for long-lived, always-connected documents. 0 (default) compacts
+	// only on room unload. Ignored when the adapter does not implement
+	// CompactableAdapter, and on the disabled (PersistCoalesceWindow < 0) path
+	// (which has no flush cycle — those deployments get on-unload compaction
+	// only). Like the other config fields, set it before serving; it is read
+	// without synchronisation.
+	CompactEvery int
 
 	// clock creates timers for the persistence worker. nil in production
 	// (resolves to realClock). Tests inject a fake for deterministic debounce.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -252,6 +252,12 @@ type room struct {
 	persistStop chan struct{} // closed to signal goroutine to drain and exit
 	persistDone chan struct{} // closed when persistence goroutine exits
 
+	// flushReq requests an on-demand durable flush of the pending batch without
+	// stopping the worker. The worker drains persistCh, flushes with a
+	// background ctx, and closes the sent ack channel. nil when no
+	// PersistenceAdapter is configured.
+	flushReq chan chan struct{}
+
 	// relayUnsub holds the doc.OnUpdate / awareness.OnChange unsubscribe
 	// functions registered when a Relay is attached. nil when no relay. Called
 	// once when the room is evicted so the relay observers don't leak. Guarded
@@ -883,6 +889,7 @@ func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room,
 		r.persistCh = make(chan []byte, 256)
 		r.persistStop = make(chan struct{})
 		r.persistDone = make(chan struct{})
+		r.flushReq = make(chan chan struct{})
 		s.startPersistenceWorker(r, name)
 		r.doc.OnUpdate(func(update []byte, _ any) {
 			select {


### PR DESCRIPTION
## Summary

Follow-up to #175 (v1.36.0 persistence coalescing). Fixes two production reports from websocket-server users:

1. **Lost edits on quick refresh.** Room teardown removed the room from the in-memory map **before** the pending coalesced batch was flushed, so a fast reconnect created a fresh room and reloaded **stale** state from the backing store — missing the just-made edit. v1.36.0's debounce widened this window from ~ms to seconds.
2. **Aggressive versioning.** The `VersionedPersistence` adapter appends a version per `StoreUpdate`; coalescing cut the rate but nothing bounded total version growth.

Approach validated against Hocuspocus, yrs (yrs-kvstore / y-sweet), y-leveldb, and Deln0r/ygo — all await the flush before dropping a doc from their registry, and all treat version compaction as a backend concern the server merely *triggers*.

## Fixed — durable-before-evict (no lost edits on quick refresh)

`handleDisconnect` and `CloseRoom` now flush the pending batch durably — via a new worker **`flushReq`** signal (worker stays alive), off-lock, **while the room is still in `s.rooms`** — then re-check emptiness and evict. A peer reconnecting during the flush reuses the live in-memory document (no reload). Matches Hocuspocus's `unloadImmediately` model. Not lazy: the flush happens immediately on last-disconnect.

- `flushReq` drains `persistCh` first (the just-arrived edit may not be batched yet) and flushes with `context.Background()`.
- Send is guarded against an already-exited worker (`select` on send vs `<-persistDone`) — no deadlock.
- Lock order (`rmu`→`rm.mu`), exactly-once `close(persistStop)`, the pointer-identity eviction guard, and `OnLastPeer`/`OnUnloadDocument` semantics are all preserved; a rejoin during the flush aborts eviction and keeps hooks balanced.

## Added — compaction support (bounds version growth)

- `CompactableAdapter { Compact(ctx, room) error }` — optional `PersistenceAdapter` extension (runtime type-assert, like `PersistenceAdapterContext`).
- `Server.CompactEvery int` — the worker calls `Compact` on room unload, and (when `> 0`) after every N successful flushes. Serialised in the worker goroutine, `recover`-wrapped, best-effort/non-fatal.
- `persistence.LegacyAdapter` implements it (new `KeepVersions` field) by forwarding to the **existing, already-tested** `VersionedPersistence.Compact` — no new store logic. Retention policy stays adapter-side.

## Tests

New deterministic tests: refresh-loss race (RED→GREEN via a blocking adapter), rejoin-during-flush keeps the room, `CloseRoom` flushes before evict, `flushReq` drain/ack (coalescing + disabled), compaction count-trigger / on-unload / `CompactEvery=0` / non-compactable-adapter-safe, and shim forwarding with `KeepVersions`. Full `provider/websocket` + `persistence` pass under `-race`; the teardown fix also verified under `-race -count=20`. Reviewed task-by-task plus a final whole-branch review (all 6 teardown race scenarios traced clean).

## Release

Targets **v1.37.0** (minor — new optional interface + `Server.CompactEvery` + `LegacyAdapter.KeepVersions`, all additive/zero-value-safe; behavioural durability fix). No breaking API change. CHANGELOG / RELEASE_NOTES / README updated in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
