### PR TITLE
feat: awareness OnUpdate/Meta (#105) + Hocuspocus in-band auth (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only, not `OnChange` — use `OnUpdate` for heartbeat/liveness signals.
   `Heartbeat()` now fires `OnUpdate` (previously fired no observers). A
   reactivated (removed→returning) client is now classified `Updated` rather than
-  `Added`, matching Yjs/yrs.
+  `Added`, matching Yjs/yrs. The in-repo `provider/websocket` cluster relay now
+  subscribes to awareness via `OnUpdate` (not `OnChange`) so that cross-node
+  liveness (heartbeats) keeps propagating to other nodes; other `OnChange`
+  consumers, such as the mobile UI presence observer, intentionally remain
+  content-only.
 
 ## [1.37.0] — 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.0] — 2026-07-24
+
+### Added
+
+- **Awareness `OnUpdate` event + `Meta(clientID)` accessor**
+  ([#105](https://github.com/reearth/ygo/issues/105)): `OnUpdate` fires on every
+  applied awareness entry including heartbeats, distinct from the content-only
+  `OnChange`; `Meta(clientID)` returns the per-client `{Clock, LastUpdated}`,
+  retained for tombstones to match Yjs `y-protocols`/yrs.
+- **Hocuspocus in-band token auth + docName framing**
+  ([#104](https://github.com/reearth/ygo/issues/104)): opt-in
+  `Server.HocuspocusFraming` reads/writes docName-prefixed frames for real
+  `@hocuspocus/provider` interop; new `Server.OnTokenAuth` hook handles the
+  in-band Auth message (tag 2), replying `Authenticated`/`PermissionDenied` and
+  closing denied connections with WebSocket code `4401`. Complements (does not
+  replace) `AuthFunc`/`Authorize`; `OnTokenAuth` is a handshake reply and
+  optional read-only downgrade, not a document-confidentiality gate.
+
+### Changed
+
+- **Awareness `OnChange` no longer fires on content-identical re-emits**
+  ([#105](https://github.com/reearth/ygo/issues/105)): a remote heartbeat via
+  `ApplyUpdate` and a local same-content `SetLocalState` now fire `OnUpdate`
+  only, not `OnChange` — use `OnUpdate` for heartbeat/liveness signals.
+  `Heartbeat()` now fires `OnUpdate` (previously fired no observers). A
+  reactivated (removed→returning) client is now classified `Updated` rather than
+  `Added`, matching Yjs/yrs.
+
 ## [1.37.0] — 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.37.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.38.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+## v1.38.0
+
+A minor, additive release adding two independent features. On the awareness
+layer, a new `OnUpdate` event channel fires on every applied entry (including
+heartbeats) alongside the content-only `OnChange`, plus a `Meta(clientID)`
+accessor — matching Yjs `y-protocols`/yrs semantics. On the websocket provider,
+opt-in Hocuspocus docName framing and an `OnTokenAuth` hook bring in-band token
+authentication for the `@hocuspocus/provider` client ecosystem. No breaking
+API changes, though `OnChange` is tightened (see Changed).
+
+### Added
+
+- **Awareness `OnUpdate` + `Meta(clientID)`**
+  ([#105](https://github.com/reearth/ygo/issues/105)): `OnUpdate` fires on every
+  applied awareness entry including heartbeats, distinct from the content-only
+  `OnChange`. `Meta(clientID)` returns per-client `{Clock, LastUpdated}`,
+  retained for tombstones to match the reference implementations.
+- **Hocuspocus in-band token auth + docName framing**
+  ([#104](https://github.com/reearth/ygo/issues/104)): opt-in
+  `Server.HocuspocusFraming` reads/writes docName-prefixed frames for real
+  `@hocuspocus/provider` interop; `Server.OnTokenAuth` validates the tag-2 Auth
+  token and replies `Authenticated`/`PermissionDenied`, closing denied
+  connections with WebSocket code `4401`. Composes with `AuthFunc`/`Authorize`;
+  it is a handshake reply + optional read-only downgrade, not a
+  document-confidentiality gate (use the HTTP-boundary auth for that).
+
+### Changed
+
+- **`OnChange` no longer fires on content-identical re-emits**
+  ([#105](https://github.com/reearth/ygo/issues/105)): remote heartbeats (via
+  `ApplyUpdate`) and local same-content `SetLocalState` now fire `OnUpdate`
+  only. `Heartbeat()` now fires `OnUpdate` (previously silent). A reactivated
+  client is classified `Updated` rather than `Added`, matching Yjs/yrs.
+
 ## v1.37.0
 
 A minor release hardening the websocket server's coalesced persistence path.

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -96,10 +96,27 @@ type ChangeEvent struct {
 	Origin  any
 }
 
+// UpdateEvent is delivered to OnUpdate observers on every applied awareness
+// entry, including same-content heartbeat re-emits at a bumped clock. Same
+// shape as ChangeEvent; a distinct type prevents accidentally crossing the two
+// callback kinds.
+type UpdateEvent struct {
+	Added   []uint64
+	Updated []uint64
+	Removed []uint64
+	Origin  any
+}
+
 // observer wraps a callback with an active flag so it can be unsubscribed
 // without shifting the slice.
 type observer struct {
 	fn     func(ChangeEvent)
+	active bool
+}
+
+// updateObserver wraps an OnUpdate callback with an active flag.
+type updateObserver struct {
+	fn     func(UpdateEvent)
 	active bool
 }
 
@@ -110,11 +127,12 @@ type Awareness struct {
 	// states stores all known clients including those with nil State (removed).
 	// Clients with nil State have been removed but their clock is retained so
 	// removal messages can be properly encoded with an up-to-date clock.
-	states     map[uint64]ClientState
-	meta       map[uint64]time.Time // last update time, for expiry (only active clients)
-	clock      uint64               // local client's clock
-	observers  []*observer
-	stopExpiry func() // set by StartAutoExpiry; stopped by Destroy
+	states          map[uint64]ClientState
+	meta            map[uint64]time.Time // last update time, for expiry (only active clients)
+	clock           uint64               // local client's clock
+	observers       []*observer
+	updateObservers []*updateObserver
+	stopExpiry      func() // set by StartAutoExpiry; stopped by Destroy
 	// wireBytes tracks the JSON byte length of the last ApplyUpdate-accepted
 	// state per client. Used to enforce maxBytes (issue #48 vector B). Only
 	// entries that arrived via ApplyUpdate are counted; SetLocalState is
@@ -342,6 +360,44 @@ func (a *Awareness) copyObservers() []func(ChangeEvent) {
 
 // fireObservers calls each observer function in turn.
 func fireObservers(fns []func(ChangeEvent), evt ChangeEvent) {
+	for _, fn := range fns {
+		fn(evt)
+	}
+}
+
+// OnUpdate registers a callback invoked on every applied awareness entry,
+// including heartbeats (where OnChange does not fire). Returns an unsubscribe
+// function. Observers are not cleared by Destroy (matches OnChange).
+func (a *Awareness) OnUpdate(fn func(UpdateEvent)) func() {
+	if fn == nil {
+		return func() {}
+	}
+	obs := &updateObserver{fn: fn, active: true}
+	a.mu.Lock()
+	a.updateObservers = append(a.updateObservers, obs)
+	a.mu.Unlock()
+
+	return func() {
+		a.mu.Lock()
+		obs.active = false
+		a.mu.Unlock()
+	}
+}
+
+// copyUpdateObservers returns a snapshot of active OnUpdate callbacks.
+// Must be called while holding a.mu (read or write).
+func (a *Awareness) copyUpdateObservers() []func(UpdateEvent) {
+	fns := make([]func(UpdateEvent), 0, len(a.updateObservers))
+	for _, o := range a.updateObservers {
+		if o.active {
+			fns = append(fns, o.fn)
+		}
+	}
+	return fns
+}
+
+// fireUpdateObservers calls each OnUpdate callback in turn.
+func fireUpdateObservers(fns []func(UpdateEvent), evt UpdateEvent) {
 	for _, fn := range fns {
 		fn(evt)
 	}
@@ -580,11 +636,12 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 	}
 
 	obs := a.copyObservers()
+	updObs := a.copyUpdateObservers()
 	a.mu.Unlock()
 
 	if len(added) > 0 || len(updated) > 0 || len(removed) > 0 {
-		evt := ChangeEvent{Added: added, Updated: updated, Removed: removed, Origin: origin}
-		fireObservers(obs, evt)
+		fireObservers(obs, ChangeEvent{Added: added, Updated: updated, Removed: removed, Origin: origin})
+		fireUpdateObservers(updObs, UpdateEvent{Added: added, Updated: updated, Removed: removed, Origin: origin})
 	}
 
 	return nil

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -1,10 +1,12 @@
 package awareness
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"math"
+	"reflect"
 	"sync"
 	"time"
 
@@ -144,7 +146,11 @@ type Awareness struct {
 	// entries that arrived via ApplyUpdate are counted; SetLocalState is
 	// excluded because the local client's state is set by trusted embedder
 	// code, not adversarial wire input.
-	wireBytes   map[uint64]int
+	wireBytes map[uint64]int
+	// priorJSON stores the last ApplyUpdate-accepted non-null wire bytes per
+	// client, for the OnChange content-change fast-path (bytes.Equal). Same
+	// lifecycle as wireBytes: written on non-null accept, deleted on tombstone.
+	priorJSON   map[uint64][]byte
 	activeBytes int64 // sum of wireBytes values
 	maxBytes    int64 // 0 = unlimited (default; backward compatible)
 	maxClients  int   // 0 = unlimited (default; backward compatible)
@@ -163,6 +169,7 @@ func New(clientID uint64) *Awareness {
 		states:    make(map[uint64]ClientState),
 		meta:      make(map[uint64]time.Time),
 		wireBytes: make(map[uint64]int),
+		priorJSON: make(map[uint64][]byte),
 		removedAt: make(map[uint64]time.Time),
 	}
 }
@@ -520,7 +527,7 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 	}
 
 	a.mu.Lock()
-	var added, updated, removed []uint64
+	var added, updated, changedUpdated, removed []uint64
 
 	for _, e := range entries {
 		current, exists := a.states[e.clientID]
@@ -642,7 +649,19 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 			if wasActive {
 				removed = append(removed, e.clientID)
 			}
+			delete(a.priorJSON, e.clientID)
 		} else {
+			// Content-change detection (pre-update values: oldSize, current.State,
+			// priorJSON[e.clientID] are all read before the overwrites below).
+			changed := true
+			if oldSize == newSize {
+				if prev, ok := a.priorJSON[e.clientID]; ok && bytes.Equal(prev, e.jsonBytes) {
+					changed = false
+				} else if current.State != nil && reflect.DeepEqual(current.State, state) {
+					changed = false
+				}
+			}
+
 			a.states[e.clientID] = ClientState{
 				Clock: e.clock,
 				State: state,
@@ -654,8 +673,13 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 			// Update byte accounting: replace the old size with the new size.
 			a.activeBytes += int64(newSize - oldSize)
 			a.wireBytes[e.clientID] = newSize
-			if wasActive {
+			a.priorJSON[e.clientID] = append([]byte(nil), e.jsonBytes...)
+
+			if exists {
 				updated = append(updated, e.clientID)
+				if changed {
+					changedUpdated = append(changedUpdated, e.clientID)
+				}
 			} else {
 				added = append(added, e.clientID)
 			}
@@ -666,8 +690,10 @@ func (a *Awareness) ApplyUpdate(update []byte, origin any) error {
 	updObs := a.copyUpdateObservers()
 	a.mu.Unlock()
 
+	if len(added) > 0 || len(changedUpdated) > 0 || len(removed) > 0 {
+		fireObservers(obs, ChangeEvent{Added: added, Updated: changedUpdated, Removed: removed, Origin: origin})
+	}
 	if len(added) > 0 || len(updated) > 0 || len(removed) > 0 {
-		fireObservers(obs, ChangeEvent{Added: added, Updated: updated, Removed: removed, Origin: origin})
 		fireUpdateObservers(updObs, UpdateEvent{Added: added, Updated: updated, Removed: removed, Origin: origin})
 	}
 

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -236,7 +236,7 @@ func (a *Awareness) SetLocalState(state map[string]any) {
 	if a.clock < math.MaxUint64 {
 		a.clock++
 	}
-	var added, updated, removed []uint64
+	var added, updated, changedUpdated, removed []uint64
 
 	prev, exists := a.states[a.clientID]
 	// "exists and active" means prev.State != nil
@@ -250,21 +250,27 @@ func (a *Awareness) SetLocalState(state map[string]any) {
 			removed = []uint64{a.clientID}
 		}
 	} else {
-		a.states[a.clientID] = ClientState{Clock: a.clock, State: state}
-		a.meta[a.clientID] = time.Now()
 		if wasActive {
 			updated = []uint64{a.clientID}
+			if !reflect.DeepEqual(prev.State, state) {
+				changedUpdated = []uint64{a.clientID}
+			}
 		} else {
 			added = []uint64{a.clientID}
 		}
+		a.states[a.clientID] = ClientState{Clock: a.clock, State: state}
+		a.meta[a.clientID] = time.Now()
 	}
 
 	obs := a.copyObservers()
+	updObs := a.copyUpdateObservers()
 	a.mu.Unlock()
 
+	if len(added) > 0 || len(changedUpdated) > 0 || len(removed) > 0 {
+		fireObservers(obs, ChangeEvent{Added: added, Updated: changedUpdated, Removed: removed})
+	}
 	if len(added) > 0 || len(updated) > 0 || len(removed) > 0 {
-		evt := ChangeEvent{Added: added, Updated: updated, Removed: removed}
-		fireObservers(obs, evt)
+		fireUpdateObservers(updObs, UpdateEvent{Added: added, Updated: updated, Removed: removed})
 	}
 }
 
@@ -278,8 +284,9 @@ func (a *Awareness) SetLocalState(state map[string]any) {
 // haven't. Matches Yjs JS's constructor interval which re-emits local
 // state every outdatedTimeout/2.
 //
-// Observers are NOT fired — the state itself didn't change, only the
-// clock advanced. Peers will pick up the new clock via EncodeUpdate.
+// OnUpdate observers ARE fired (the clock advanced); OnChange observers are
+// not (the state content is unchanged). Matches Yjs, whose interval re-emits
+// local state via setLocalState and emits `update` but not `change`.
 //
 // Added in v1.11.0 (#73 vector C5).
 func (a *Awareness) Heartbeat() {
@@ -297,7 +304,11 @@ func (a *Awareness) Heartbeat() {
 	}
 	a.states[a.clientID] = ClientState{Clock: a.clock, State: cs.State}
 	a.meta[a.clientID] = time.Now()
+	updObs := a.copyUpdateObservers()
 	a.mu.Unlock()
+
+	// Content unchanged (only the clock advanced) -> OnUpdate only, never OnChange.
+	fireUpdateObservers(updObs, UpdateEvent{Updated: []uint64{a.clientID}})
 }
 
 // SetLocalStateContext is the context-aware variant of SetLocalState.
@@ -362,7 +373,9 @@ func (a *Awareness) Meta(clientID uint64) (ClientMeta, bool) {
 	return m, true
 }
 
-// OnChange registers a callback invoked whenever any state changes.
+// OnChange registers a callback invoked whenever client state content
+// changes (added, removed, or content-differing update). For an event on
+// every applied entry including heartbeats, use OnUpdate.
 // Returns an unsubscribe function.
 func (a *Awareness) OnChange(fn func(ChangeEvent)) func() {
 	if fn == nil {
@@ -814,11 +827,12 @@ func (a *Awareness) RemoveExpired(timeout time.Duration) {
 		}
 	}
 	obs := a.copyObservers()
+	updObs := a.copyUpdateObservers()
 	a.mu.Unlock()
 
 	if len(removed) > 0 {
-		evt := ChangeEvent{Removed: removed}
-		fireObservers(obs, evt)
+		fireObservers(obs, ChangeEvent{Removed: removed})
+		fireUpdateObservers(updObs, UpdateEvent{Removed: removed})
 	}
 }
 

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -88,6 +88,12 @@ type ClientState struct {
 	State map[string]any // nil means the client was removed
 }
 
+// ClientMeta is the per-client metadata returned by Meta.
+type ClientMeta struct {
+	Clock       uint64
+	LastUpdated time.Time
+}
+
 // ChangeEvent is delivered to observers when states change.
 type ChangeEvent struct {
 	Added   []uint64 // client IDs newly seen
@@ -326,6 +332,27 @@ func (a *Awareness) GetStates() map[uint64]ClientState {
 		}
 	}
 	return out
+}
+
+// Meta returns the clock and last-updated time for a known client, including
+// remote tombstones (Yjs/yrs retain meta for removed clients). LastUpdated is
+// the last-applied time for an active client, or the tombstone time for a
+// remote tombstone; a local tombstone (our own leaving state) has a valid
+// Clock with a zero LastUpdated. Returns ok=false only for never-seen clients.
+func (a *Awareness) Meta(clientID uint64) (ClientMeta, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	cs, ok := a.states[clientID]
+	if !ok {
+		return ClientMeta{}, false
+	}
+	m := ClientMeta{Clock: cs.Clock}
+	if t, active := a.meta[clientID]; active {
+		m.LastUpdated = t
+	} else if t, tomb := a.removedAt[clientID]; tomb {
+		m.LastUpdated = t
+	}
+	return m, true
 }
 
 // OnChange registers a callback invoked whenever any state changes.

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -941,3 +941,19 @@ func TestUnit_Meta_ActiveAndTombstone(t *testing.T) {
 	require.Greater(t, m2.Clock, m.Clock)
 	require.False(t, m2.LastUpdated.IsZero())
 }
+
+func TestUnit_Meta_LocalTombstone(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"k": "v"})
+	m, ok := a.Meta(1)
+	require.True(t, ok)
+	require.False(t, m.LastUpdated.IsZero())
+
+	// Local client leaves: its own tombstone keeps a valid clock but no
+	// meta/removedAt entry, so LastUpdated is zero (documented behavior).
+	a.SetLocalState(nil)
+	m2, ok := a.Meta(1)
+	require.True(t, ok, "local tombstone still known")
+	require.Greater(t, m2.Clock, m.Clock)
+	require.True(t, m2.LastUpdated.IsZero(), "local tombstone has zero LastUpdated")
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -916,3 +916,28 @@ func TestUnit_OnUpdate_FiresOnApply(t *testing.T) {
 	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
 	require.Len(t, got, 1, "no events after unsubscribe")
 }
+
+func TestUnit_Meta_ActiveAndTombstone(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+
+	// unknown client
+	_, ok := a.Meta(99)
+	require.False(t, ok)
+
+	// active client
+	b.SetLocalState(map[string]any{"k": "v"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	m, ok := a.Meta(99)
+	require.True(t, ok)
+	require.Greater(t, m.Clock, uint64(0))
+	require.False(t, m.LastUpdated.IsZero())
+
+	// tombstone (remote removal): Meta still returns clock + a timestamp
+	b.SetLocalState(nil)
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	m2, ok := a.Meta(99)
+	require.True(t, ok, "tombstone still known (Yjs/yrs parity)")
+	require.Greater(t, m2.Clock, m.Clock)
+	require.False(t, m2.LastUpdated.IsZero())
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -957,3 +957,54 @@ func TestUnit_Meta_LocalTombstone(t *testing.T) {
 	require.Greater(t, m2.Clock, m.Clock)
 	require.True(t, m2.LastUpdated.IsZero(), "local tombstone has zero LastUpdated")
 }
+
+func TestUnit_Heartbeat_OnUpdateNotOnChange(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+	b.SetLocalState(map[string]any{"name": "x"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	var chg, upd int
+	a.OnChange(func(awareness.ChangeEvent) { chg++ })
+	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
+
+	// remote heartbeat: same content, bumped clock
+	b.Heartbeat()
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	require.Equal(t, 0, chg, "OnChange must NOT fire on a content-identical heartbeat")
+	require.Equal(t, 1, upd, "OnUpdate must fire on the heartbeat")
+}
+
+func TestUnit_ContentChange_FiresBoth(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+	b.SetLocalState(map[string]any{"name": "x"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	var chg, upd int
+	a.OnChange(func(awareness.ChangeEvent) { chg++ })
+	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
+
+	b.SetLocalState(map[string]any{"name": "y"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	require.Equal(t, 1, chg)
+	require.Equal(t, 1, upd)
+}
+
+func TestUnit_ReactivatedTombstone_ClassifiedUpdated(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+	b.SetLocalState(map[string]any{"n": 1})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	b.SetLocalState(nil) // remove -> tombstone on a
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	var ev awareness.UpdateEvent
+	a.OnUpdate(func(e awareness.UpdateEvent) { ev = e })
+	b.SetLocalState(map[string]any{"n": 2}) // reactivate
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	require.Equal(t, []uint64{99}, ev.Updated, "reactivated tombstone is 'updated' (Yjs/yrs parity)")
+	require.Empty(t, ev.Added)
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -1008,3 +1008,39 @@ func TestUnit_ReactivatedTombstone_ClassifiedUpdated(t *testing.T) {
 	require.Equal(t, []uint64{99}, ev.Updated, "reactivated tombstone is 'updated' (Yjs/yrs parity)")
 	require.Empty(t, ev.Added)
 }
+
+func TestUnit_LocalHeartbeat_FiresOnUpdateNotOnChange(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"name": "me"})
+	var chg, upd int
+	a.OnChange(func(awareness.ChangeEvent) { chg++ })
+	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
+
+	a.Heartbeat()
+	require.Equal(t, 0, chg, "local heartbeat: OnChange must not fire")
+	require.Equal(t, 1, upd, "local heartbeat: OnUpdate must fire")
+}
+
+func TestUnit_SetLocalState_SameContent_OnUpdateOnly(t *testing.T) {
+	a := awareness.New(1)
+	a.SetLocalState(map[string]any{"name": "me"})
+	var chg, upd int
+	a.OnChange(func(awareness.ChangeEvent) { chg++ })
+	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
+
+	a.SetLocalState(map[string]any{"name": "me"}) // identical content
+	require.Equal(t, 0, chg, "identical local re-set: OnChange must not fire (Yjs parity)")
+	require.Equal(t, 1, upd)
+}
+
+func TestUnit_RemoveExpired_FiresOnUpdate(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+	b.SetLocalState(map[string]any{"k": "v"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+
+	var upd int
+	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
+	a.RemoveExpired(0) // everything older than 0 => expire client 99
+	require.Equal(t, 1, upd)
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -899,3 +899,20 @@ func TestUnit_Awareness_C5_Heartbeat_PreservesMonotonicity_AcrossMixedUpdates(t 
 			i, clocks[i], clocks[i-1])
 	}
 }
+
+func TestUnit_OnUpdate_FiresOnApply(t *testing.T) {
+	a := awareness.New(1)
+	b := awareness.New(99)
+	b.SetLocalState(map[string]any{"name": "x"})
+
+	var got []awareness.UpdateEvent
+	unsub := a.OnUpdate(func(e awareness.UpdateEvent) { got = append(got, e) })
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	require.Len(t, got, 1)
+	require.Equal(t, []uint64{99}, got[0].Added)
+
+	unsub()
+	b.SetLocalState(map[string]any{"name": "y"})
+	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
+	require.Len(t, got, 1, "no events after unsubscribe")
+}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -930,7 +930,7 @@ func TestUnit_Meta_ActiveAndTombstone(t *testing.T) {
 	require.NoError(t, a.ApplyUpdate(b.EncodeUpdate(nil), nil))
 	m, ok := a.Meta(99)
 	require.True(t, ok)
-	require.Greater(t, m.Clock, uint64(0))
+	require.Positive(t, m.Clock)
 	require.False(t, m.LastUpdated.IsZero())
 
 	// tombstone (remote removal): Meta still returns clock + a timestamp

--- a/provider/websocket/cluster.go
+++ b/provider/websocket/cluster.go
@@ -49,7 +49,7 @@ var _ cluster.Sink = (*Server)(nil)
 // cancelled when Server.Shutdown is called. If relay.Start returns an error the
 // server is left UNATTACHED (s.relay stays nil) and the call may be retried —
 // it does not latch a partial attach. Rooms that become resident after attach
-// are wired automatically (doc.OnUpdate + awareness.OnChange → a bounded
+// are wired automatically (doc.OnUpdate + awareness.OnUpdate → a bounded
 // outbound queue drained by a worker → Publish); the echo guard drops changes
 // whose origin is the relay sentinel.
 //
@@ -108,10 +108,16 @@ func (s *Server) relayWorker(ctx context.Context, out <-chan relayOutbound) {
 	}
 }
 
-// registerRelayObservers wires doc.OnUpdate and awareness.OnChange for a room so
-// local (non-sentinel-origin) changes are published to the relay. Must be called
-// with s.rmu.Lock held (from getOrCreateRoomLocked). The unsubscribe functions
-// are stored on the room and invoked by teardownRelayRoom.
+// registerRelayObservers wires doc.OnUpdate and awareness.OnUpdate for a room so
+// local (non-sentinel-origin) changes are published to the relay. The awareness
+// side deliberately subscribes via OnUpdate rather than OnChange: OnUpdate fires
+// for every applied entry, including content-identical heartbeat re-emits, so a
+// heartbeat still gets relayed cross-node. Using OnChange here would drop
+// heartbeats from the relay (OnChange only fires on content changes), leaving a
+// remote node's view of this client's liveness stale and causing it to falsely
+// expire a still-alive client. Must be called with s.rmu.Lock held (from
+// getOrCreateRoomLocked). The unsubscribe functions are stored on the room and
+// invoked by teardownRelayRoom.
 func (s *Server) registerRelayObservers(r *room, name string) {
 	sentinel := s.relaySentinel
 
@@ -129,7 +135,7 @@ func (s *Server) registerRelayObservers(r *room, name string) {
 		})
 	})
 
-	unsubAw := r.awareness.OnChange(func(ev awareness.ChangeEvent) {
+	unsubAw := r.awareness.OnUpdate(func(ev awareness.UpdateEvent) {
 		if ev.Origin == sentinel {
 			return // echo guard
 		}
@@ -165,7 +171,7 @@ func (s *Server) enqueueRelayOutbound(name string, out cluster.Outbound) {
 }
 
 // changedAwarenessIDs returns the union of added/updated/removed client IDs.
-func changedAwarenessIDs(ev awareness.ChangeEvent) []uint64 {
+func changedAwarenessIDs(ev awareness.UpdateEvent) []uint64 {
 	ids := make([]uint64, 0, len(ev.Added)+len(ev.Updated)+len(ev.Removed))
 	ids = append(ids, ev.Added...)
 	ids = append(ids, ev.Updated...)
@@ -195,8 +201,8 @@ func (s *Server) teardownRelayRoom(r *room, name string) {
 // sentinel origin (so the local doc.OnUpdate observer does NOT re-publish them)
 // and rebroadcast to local peers via BroadcastUpdate. KindAwareness updates are
 // merged into the room's awareness with the sentinel origin; the awareness
-// fan-out to peers is driven by the awareness OnChange path the server already
-// runs for local peers — but inbound merges fire OnChange with the sentinel
+// fan-out to peers is driven by the awareness OnUpdate path the server already
+// runs for local peers — but inbound merges fire OnUpdate with the sentinel
 // origin, which the relay observer drops, so we additionally fan the awareness
 // update out to local peers here.
 //
@@ -240,7 +246,7 @@ func (s *Server) Inject(ctx context.Context, in cluster.Inbound) error {
 		if err := rm.awareness.ApplyUpdate(in.Data, s.relaySentinel); err != nil {
 			return err
 		}
-		// Fan the awareness update out to local peers (the OnChange-driven relay
+		// Fan the awareness update out to local peers (the OnUpdate-driven relay
 		// observer dropped it as a sentinel echo, so peers won't otherwise see it).
 		s.broadcastAwarenessToPeers(rm, in.Data)
 		return nil

--- a/provider/websocket/cluster_reentrancy_internal_test.go
+++ b/provider/websocket/cluster_reentrancy_internal_test.go
@@ -4,9 +4,11 @@ package websocket
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/reearth/ygo/awareness"
 	"github.com/reearth/ygo/cluster"
 	"github.com/reearth/ygo/crdt"
 )
@@ -160,5 +162,142 @@ func TestGetOrCreateRoom_RoomActivatedFiresOnceOffLockAfterPublish(t *testing.T)
 	}
 	if !relay.publishedAtCallback[0] {
 		t.Fatal("RoomActivated fired before the room was published into s.rooms (#133)")
+	}
+}
+
+// captureRelay records every Publish call so a test can inspect the outbound
+// events the relay observers produced. Unlike reentrantActivationRelay it does
+// not drive any Inject re-entrancy; it is a plain capture sink.
+type captureRelay struct {
+	mu   sync.Mutex
+	outs []cluster.Outbound
+}
+
+func (r *captureRelay) Publish(_ context.Context, out cluster.Outbound) error {
+	r.mu.Lock()
+	r.outs = append(r.outs, out)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *captureRelay) Start(context.Context, cluster.Sink) error { return nil }
+func (r *captureRelay) RoomActivated(string)                      {}
+func (r *captureRelay) RoomDeactivated(string)                    {}
+func (r *captureRelay) Close() error                              { return nil }
+
+// awarenessEvents returns a snapshot of the captured KindAwareness events.
+func (r *captureRelay) awarenessEvents() []cluster.Outbound {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]cluster.Outbound, 0, len(r.outs))
+	for _, ob := range r.outs {
+		if ob.Kind == cluster.KindAwareness {
+			out = append(out, ob)
+		}
+	}
+	return out
+}
+
+// waitForAwarenessEvents polls until at least n KindAwareness events have been
+// captured, or fails the test after a timeout. The relay worker drains the
+// outbound queue on its own goroutine (enqueueRelayOutbound is non-blocking),
+// so Publish is asynchronous with respect to the ApplyUpdate call that
+// triggers it.
+func waitForAwarenessEvents(t *testing.T, r *captureRelay, n int) []cluster.Outbound {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if evs := r.awarenessEvents(); len(evs) >= n {
+			return evs
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d KindAwareness relay events, got %d", n, len(r.awarenessEvents()))
+	return nil
+}
+
+// TestRegisterRelayObservers_HeartbeatPropagatesToRelay is the regression test
+// for the #105/#175 review finding: registerRelayObservers used to subscribe
+// the awareness side via OnChange, which does NOT fire for a content-identical
+// heartbeat re-emit (only the clock advances). In a cluster deployment this
+// silently dropped heartbeats from cross-node relay, so a remote node's cached
+// awareness meta went stale and could falsely expire a still-alive client. The
+// fix subscribes via OnUpdate instead, which fires on every applied entry
+// including heartbeats. This test proves a heartbeat now reaches the relay.
+func TestRegisterRelayObservers_HeartbeatPropagatesToRelay(t *testing.T) {
+	relay := &captureRelay{}
+	s := NewServer()
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	rm, err := s.getOrCreateRoom(context.Background(), "room")
+	if err != nil {
+		t.Fatalf("getOrCreateRoom: %v", err)
+	}
+
+	// Establish an active remote awareness client (id 55) in the room's
+	// awareness, as if a peer on another node had announced itself. Applying
+	// with a non-sentinel origin makes it look like a locally-originated
+	// change from the relay observer's point of view, so it is eligible for
+	// relay (matching how a locally-connected peer's awareness update arrives
+	// at the room's awareness via peer.go).
+	const remoteID = uint64(55)
+	remoteAw := awareness.New(remoteID)
+	remoteAw.SetLocalState(map[string]any{"cursor": 1})
+	initialUpdate := remoteAw.EncodeUpdate([]uint64{remoteID})
+	if err := rm.awareness.ApplyUpdate(initialUpdate, "peer-origin"); err != nil {
+		t.Fatalf("ApplyUpdate (initial): %v", err)
+	}
+
+	// The initial (content-changing) update must have relayed — sanity check
+	// that the relay path is wired at all before we test the heartbeat case.
+	waitForAwarenessEvents(t, relay, 1)
+
+	// Now apply a HEARTBEAT from that same client: a content-identical
+	// re-emit at a bumped clock. Heartbeat() only bumps remoteAw's own clock
+	// (it does not touch the room's awareness), so EncodeUpdate(nil) after it
+	// carries the same state JSON at a higher clock — exactly what a remote
+	// node's periodic liveness re-emit looks like on the wire.
+	remoteAw.Heartbeat()
+	heartbeatUpdate := remoteAw.EncodeUpdate(nil)
+	if err := rm.awareness.ApplyUpdate(heartbeatUpdate, "peer-origin"); err != nil {
+		t.Fatalf("ApplyUpdate (heartbeat): %v", err)
+	}
+
+	// Before the fix, this second event would never arrive: OnChange does not
+	// fire for a content-identical, clock-only-bumped update, so the relay
+	// observer built on OnChange never saw the heartbeat.
+	evs := waitForAwarenessEvents(t, relay, 2)
+	if len(evs) != 2 {
+		t.Fatalf("got %d KindAwareness relay events after heartbeat, want exactly 2 (initial + heartbeat)", len(evs))
+	}
+}
+
+// TestRegisterRelayObservers_SentinelEchoStillDropped is a narrow companion
+// check: the echo guard on the OnUpdate-based awareness relay subscription
+// must still drop updates that arrive with the relay's own sentinel origin,
+// exactly as it did on the OnChange-based subscription before this fix.
+func TestRegisterRelayObservers_SentinelEchoStillDropped(t *testing.T) {
+	relay := &captureRelay{}
+	s := NewServer()
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	// Inject (as the relay itself would) using the server's sentinel origin.
+	// Inject auto-creates the room.
+	if err := s.Inject(context.Background(), cluster.Inbound{
+		Room: "room", Kind: cluster.KindAwareness, Data: awarenessUpdateFor(77),
+	}); err != nil {
+		t.Fatalf("Inject: %v", err)
+	}
+
+	// Give the relay worker a moment to have processed anything that
+	// might have been enqueued, then assert nothing was published: the inbound
+	// merge used the sentinel origin, so the echo guard must have dropped it.
+	time.Sleep(50 * time.Millisecond)
+	if evs := relay.awarenessEvents(); len(evs) != 0 {
+		t.Fatalf("sentinel-origin inbound merge must not be re-published to the relay; got %d events", len(evs))
 	}
 }

--- a/provider/websocket/doc.go
+++ b/provider/websocket/doc.go
@@ -17,6 +17,27 @@
 //
 // See the Example* functions for canonical usage patterns.
 //
+// # Hocuspocus interop
+//
+// ygo's y-websocket message dispatcher additionally understands the
+// Hocuspocus protocol extensions (tags 4-10: SyncReply, Stateless,
+// BroadcastStateless, Close, SyncStatus, Ping, Pong) on the same wire
+// framing, and an in-band Auth (tag 2) sub-protocol used by
+// @hocuspocus/provider to authenticate after the WebSocket upgrade.
+//
+// Set Server.OnTokenAuth to validate the token carried in an Auth message:
+// a nil error accepts the connection (replying Authenticated with a
+// "read-write" or "readonly" scope, per the returned ConnectionConfig); a
+// non-nil error replies PermissionDenied and closes the connection with the
+// Hocuspocus 4401 code. When OnTokenAuth is nil (the default), Auth (tag 2)
+// frames are ignored — the legacy y-websocket behavior, preserved for
+// backward compatibility with clients that never send them.
+//
+// Set Server.HocuspocusFraming to true to additionally read and write the
+// Hocuspocus docName-prefixed wire framing (VarString(docName) + frame),
+// enabling real interop with an unmodified @hocuspocus/provider client.
+// Leave it false (the default) for native y-websocket clients.
+//
 // # Stability
 //
 // ygo follows semantic versioning. The v1.x public API is considered

--- a/provider/websocket/hocuspocus_auth_internal_test.go
+++ b/provider/websocket/hocuspocus_auth_internal_test.go
@@ -8,6 +8,7 @@ package websocket
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -115,4 +116,57 @@ func TestInbandAuth_Authenticated_ReadWrite(t *testing.T) {
 
 	require.Equal(t, room, gotRoom)
 	require.Equal(t, "secret-token", gotToken)
+}
+
+// TestInbandAuth_PermissionDenied_Then4401 verifies the G1 fix (#104): a
+// PermissionDenied (tag msgAuth, sub authTypePermissionDenied) data frame must
+// be observed by the client BEFORE the connection closes, and the close must
+// carry the Hocuspocus 4401 (wsCodeUnauthorized) code. Both the data frame and
+// the close are funneled through the single per-peer writer goroutine via
+// enqueueClose's nil-sentinel, so ordering is guaranteed even though the tag-2
+// auth handler runs on the read-loop goroutine.
+func TestInbandAuth_PermissionDenied_Then4401(t *testing.T) {
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		return ConnectionConfig{}, fmt.Errorf("bad token")
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("nope")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	// Read frames until the connection closes; we must observe the
+	// PermissionDenied data frame before the close error.
+	sawDenied := false
+	var closeErr error
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			closeErr = err
+			break
+		}
+		dec := encoding.NewDecoder(data)
+		_, _ = dec.ReadVarString() // docName
+		if tag, _ := dec.ReadVarUint(); tag == msgAuth {
+			if sub, _ := dec.ReadVarUint(); sub == authTypePermissionDenied {
+				sawDenied = true
+			}
+		}
+	}
+	require.True(t, sawDenied, "PermissionDenied must arrive before close")
+	require.True(t, gws.IsCloseError(closeErr, wsCodeUnauthorized),
+		"connection must close with 4401, got %v", closeErr)
 }

--- a/provider/websocket/hocuspocus_auth_internal_test.go
+++ b/provider/websocket/hocuspocus_auth_internal_test.go
@@ -1,0 +1,63 @@
+// Package websocket - internal test for Hocuspocus docName framing (#104).
+//
+// This lives in the internal (package websocket) test set, rather than in
+// hocuspocus_test.go (package websocket_test), because the external test
+// package cannot see unexported identifiers such as peer.hocuspocusFraming
+// or the dial/readOne helpers used to build this test's local equivalents.
+package websocket
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/encoding"
+)
+
+// dialRoomInternal opens a WebSocket connection to the test server at
+// "/"+room, mirroring wsURL/dial in server_test.go (package websocket_test)
+// which cannot be reused here because it lives in a different package.
+func dialRoomInternal(t *testing.T, ts *httptest.Server, room string) *gws.Conn {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/" + room
+	conn, _, err := gws.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// TestHocuspocusFraming_RoundTrip verifies that with HocuspocusFraming
+// enabled, every server->client frame is prefixed with VarString(roomName)
+// as Hocuspocus's own wire protocol requires (#104).
+func TestHocuspocusFraming_RoundTrip(t *testing.T) {
+	// NewServer (not a bare &Server{}) so rooms/upgrader/shutdownCh are
+	// initialized — ServeHTTP writes into s.rooms and Shutdown closes
+	// s.shutdownCh, both nil on the zero value.
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "doc-room"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	// First server->client frame must be docName-prefixed.
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := c.ReadMessage()
+	require.NoError(t, err)
+	_ = c.SetReadDeadline(time.Time{})
+
+	dec := encoding.NewDecoder(data)
+	name, err := dec.ReadVarString()
+	require.NoError(t, err)
+	require.Equal(t, room, name, "server frames are docName-prefixed")
+	_, err = dec.ReadVarUint() // a valid message tag follows
+	require.NoError(t, err)
+}

--- a/provider/websocket/hocuspocus_auth_internal_test.go
+++ b/provider/websocket/hocuspocus_auth_internal_test.go
@@ -61,3 +61,58 @@ func TestHocuspocusFraming_RoundTrip(t *testing.T) {
 	_, err = dec.ReadVarUint() // a valid message tag follows
 	require.NoError(t, err)
 }
+
+// TestInbandAuth_Authenticated_ReadWrite verifies the success path of the
+// Hocuspocus in-band Auth (tag 2) sub-protocol: a Server.OnTokenAuth hook that
+// accepts the token results in an Authenticated (sub-type 2) reply carrying
+// the "read-write" scope, and the hook receives the correct room + token
+// (#104).
+func TestInbandAuth_Authenticated_ReadWrite(t *testing.T) {
+	var gotRoom, gotToken string
+	// NewServer (not a bare &Server{}) so rooms/upgrader/shutdownCh are
+	// initialized — ServeHTTP writes into s.rooms and Shutdown closes
+	// s.shutdownCh, both nil on the zero value.
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		gotRoom, gotToken = room, token
+		return ConnectionConfig{ReadOnly: false}, nil
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	// Send Auth: VarString(docName) VarUint(2) VarUint(0=Token) VarString(token)
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("secret-token")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	// Expect an Authenticated reply somewhere in the incoming frames.
+	require.Eventually(t, func() bool {
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			return false
+		}
+		dec := encoding.NewDecoder(data)
+		_, _ = dec.ReadVarString() // docName
+		tag, _ := dec.ReadVarUint()
+		if tag != msgAuth {
+			return false
+		}
+		sub, _ := dec.ReadVarUint()
+		scope, _ := dec.ReadVarString()
+		return sub == authTypeAuthenticated && scope == "read-write"
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Equal(t, room, gotRoom)
+	require.Equal(t, "secret-token", gotToken)
+}

--- a/provider/websocket/hocuspocus_auth_internal_test.go
+++ b/provider/websocket/hocuspocus_auth_internal_test.go
@@ -171,6 +171,59 @@ func TestInbandAuth_PermissionDenied_Then4401(t *testing.T) {
 		"connection must close with 4401, got %v", closeErr)
 }
 
+// TestInbandAuth_LongErrorReason_StillCloses4401 guards the fix for the WS
+// control-frame 125-byte cap: an OnTokenAuth error longer than the close-frame
+// payload limit must NOT drop the 4401 close. The full error text still rides
+// in the PermissionDenied data frame; the close frame uses the short constant
+// reason, so the client always sees the 4401 code.
+func TestInbandAuth_LongErrorReason_StillCloses4401(t *testing.T) {
+	longReason := strings.Repeat("x", 300) // >123 bytes: would overflow a close frame
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		return ConnectionConfig{}, fmt.Errorf("%s", longReason)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("nope")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	sawFullReason := false
+	var closeErr error
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			closeErr = err
+			break
+		}
+		dec := encoding.NewDecoder(data)
+		_, _ = dec.ReadVarString() // docName
+		if tag, _ := dec.ReadVarUint(); tag == msgAuth {
+			if sub, _ := dec.ReadVarUint(); sub == authTypePermissionDenied {
+				reason, _ := dec.ReadVarString()
+				if reason == longReason {
+					sawFullReason = true
+				}
+			}
+		}
+	}
+	require.True(t, sawFullReason, "full error text must survive in the PermissionDenied data frame")
+	require.True(t, gws.IsCloseError(closeErr, wsCodeUnauthorized),
+		"4401 close must still be delivered despite a long hook error, got %v", closeErr)
+}
+
 // TestInbandAuth_NilHook_Ignored verifies backward compatibility (#104): when
 // Server.OnTokenAuth is nil, an inbound Auth (tag 2) frame is silently
 // ignored — no reply, no close — and the connection keeps working normally,

--- a/provider/websocket/hocuspocus_auth_internal_test.go
+++ b/provider/websocket/hocuspocus_auth_internal_test.go
@@ -170,3 +170,169 @@ func TestInbandAuth_PermissionDenied_Then4401(t *testing.T) {
 	require.True(t, gws.IsCloseError(closeErr, wsCodeUnauthorized),
 		"connection must close with 4401, got %v", closeErr)
 }
+
+// TestInbandAuth_NilHook_Ignored verifies backward compatibility (#104): when
+// Server.OnTokenAuth is nil, an inbound Auth (tag 2) frame is silently
+// ignored — no reply, no close — and the connection keeps working normally,
+// matching the legacy y-websocket behavior where tag 2 has no handler at all.
+func TestInbandAuth_NilHook_Ignored(t *testing.T) {
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	// OnTokenAuth intentionally left nil.
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("whatever")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	// Connection must stay open (no auth reply, no close): a follow-up
+	// QueryAwareness still gets answered.
+	q := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgQueryAwareness)
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, q))
+
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := c.ReadMessage()
+	require.NoError(t, err, "connection stays open with nil OnTokenAuth")
+}
+
+// TestInbandAuth_ReadonlyScope verifies that an OnTokenAuth hook returning
+// ConnectionConfig{ReadOnly: true} results in an Authenticated (sub-type 2)
+// reply carrying the "readonly" scope string (#104).
+func TestInbandAuth_ReadonlyScope(t *testing.T) {
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		return ConnectionConfig{ReadOnly: true}, nil
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("t")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	require.Eventually(t, func() bool {
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			return false
+		}
+		dec := encoding.NewDecoder(data)
+		_, _ = dec.ReadVarString() // docName
+		if tag, _ := dec.ReadVarUint(); tag != msgAuth {
+			return false
+		}
+		sub, _ := dec.ReadVarUint()
+		scope, _ := dec.ReadVarString()
+		return sub == authTypeAuthenticated && scope == "readonly"
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+// TestInbandAuth_HookPanic_Denied verifies that a panicking OnTokenAuth hook
+// is converted into a denial by safeTokenAuth's recover, rather than
+// crashing the read-loop goroutine: the connection must be closed (a
+// PermissionDenied frame followed by a close, or at minimum a read error),
+// never left silently open or the process taken down (#104 Task 7 review).
+func TestInbandAuth_HookPanic_Denied(t *testing.T) {
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		panic("boom")
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeToken)
+		enc.WriteVarString("nope")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	// Read frames until the connection closes; a panicking hook must never
+	// leave the connection silently open. A PermissionDenied data frame may
+	// or may not be observed depending on timing, but a close must follow.
+	var closeErr error
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, _, err := c.ReadMessage()
+		if err != nil {
+			closeErr = err
+			break
+		}
+	}
+	require.Error(t, closeErr, "connection must close after a panicking OnTokenAuth hook")
+	require.True(t, gws.IsCloseError(closeErr, wsCodeUnauthorized),
+		"connection must close with 4401 after a panicking hook, got %v", closeErr)
+}
+
+// TestInbandAuth_WrongSubType_Ignored verifies that an Auth frame carrying a
+// sub-type other than Token(0) — e.g. Authenticated(2), a server->client-only
+// sub-type — is ignored by the server: no reply, no close, and the
+// connection keeps working (#104 Task 7 review).
+func TestInbandAuth_WrongSubType_Ignored(t *testing.T) {
+	srv := NewServer()
+	srv.HocuspocusFraming = true
+	srv.OnTokenAuth = func(room, token string) (ConnectionConfig, error) {
+		return ConnectionConfig{ReadOnly: false}, nil
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	room := "r1"
+	c := dialRoomInternal(t, ts, room)
+	defer c.Close()
+
+	frame := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(authTypeAuthenticated) // wrong sub-type: not Token(0)
+		enc.WriteVarString("irrelevant")
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, frame))
+
+	// Connection must stay open: a follow-up QueryAwareness still gets
+	// answered, and it must not be an Auth reply.
+	q := encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarString(room)
+		enc.WriteVarUint(msgQueryAwareness)
+	})
+	require.NoError(t, c.WriteMessage(gws.BinaryMessage, q))
+
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := c.ReadMessage()
+	require.NoError(t, err, "connection stays open after a non-Token Auth sub-type")
+	dec := encoding.NewDecoder(data)
+	_, _ = dec.ReadVarString() // docName
+	tag, _ := dec.ReadVarUint()
+	require.NotEqual(t, msgAuth, tag, "wrong sub-type Auth frame must not produce an Auth reply")
+}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -115,8 +116,7 @@ func (p *peer) handleMessage(data []byte) {
 		p.broadcastAwareness(awBytes)
 
 	case msgAuth:
-		// Auth messages (type 2) are defined by y-websocket but not used by
-		// this server. Silently ignore.
+		p.handleAuth(dec)
 
 	case msgQueryAwareness:
 		p.sendAwareness(p.room.awareness.EncodeUpdate(nil))
@@ -212,6 +212,68 @@ func (p *peer) handleMessage(data []byte) {
 		// just keeps the dispatcher from dropping the frame.
 	}
 }
+
+// handleAuth processes a Hocuspocus in-band Auth (tag 2) sub-message. No-op
+// when Server.OnTokenAuth is nil (backward compatible with the legacy
+// silent-ignore behavior).
+func (p *peer) handleAuth(dec *encoding.Decoder) {
+	hook := p.server.OnTokenAuth
+	if hook == nil {
+		return
+	}
+	subType, err := dec.ReadVarUint()
+	if err != nil || subType != authTypeToken {
+		return // only client Token(0) sub-messages are actionable
+	}
+	token, err := dec.ReadVarString()
+	if err != nil {
+		p.server.log().Debug("discarded malformed auth token frame", "room", p.roomName, "err", err)
+		return
+	}
+
+	cfg, authErr := p.safeTokenAuth(hook, token)
+	if authErr != nil {
+		p.write(encodeAuthMessage(authTypePermissionDenied, authErr.Error()))
+		p.enqueueClose(wsCodeUnauthorized, authErr.Error())
+		return
+	}
+
+	p.readOnly = cfg.ReadOnly // safe: only read on this read-loop goroutine
+	scope := "read-write"
+	if cfg.ReadOnly {
+		scope = "readonly"
+	}
+	p.write(encodeAuthMessage(authTypeAuthenticated, scope))
+}
+
+// safeTokenAuth calls the hook, converting a panic into a denial.
+func (p *peer) safeTokenAuth(hook func(string, string) (ConnectionConfig, error), token string) (cfg ConnectionConfig, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.server.log().Warn("OnTokenAuth panicked; denying", "room", p.roomName, "panic", r)
+			cfg = ConnectionConfig{}
+			err = fmt.Errorf("authentication error")
+		}
+	}()
+	return hook(p.roomName, token)
+}
+
+// encodeAuthMessage builds a tag-2 auth reply: VarUint(msgAuth) VarUint(sub)
+// VarString(s). docName framing (if enabled) is applied later in writeToConn.
+func encodeAuthMessage(subType uint64, s string) []byte {
+	return encoding.EncodeBytes(func(enc *encoding.Encoder) {
+		enc.WriteVarUint(msgAuth)
+		enc.WriteVarUint(subType)
+		enc.WriteVarString(s)
+	})
+}
+
+// enqueueClose is fully implemented in Task 8 (graceful queued close with
+// WS close code + reason). This is a TEMPORARY stub for Task 7 so the
+// success path compiles and is testable; it ignores code/reason and just
+// force-closes the underlying connection. DO NOT extend this — Task 8
+// replaces it wholesale.
+func (p *peer) enqueueClose(code int, reason string) { _ = code; _ = reason; _ = p.conn.Close() }
 
 // trackAwarenessClients records which awareness clientIDs this peer owns
 // so they can be removed when the peer disconnects.

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -30,9 +30,10 @@ type peer struct {
 	// needsResync is set (under wmu) when a broadcast is dropped because writeCh
 	// was full under SlowPeerResync. runWriter clears it and sends a full-state
 	// resync once the queue drains, so the peer converges without a reconnect.
-	needsResync bool
-	limiter     *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
-	readOnly    bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
+	needsResync       bool
+	limiter           *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
+	readOnly          bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
+	hocuspocusFraming bool          // #104: docName-prefixed framing for this connection
 
 	// disconnectOnce ensures the full teardown sequence in handleDisconnect
 	// runs exactly once, regardless of how many callers race (e.g. broadcast's

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -275,6 +275,16 @@ func encodeAuthMessage(subType uint64, s string) []byte {
 // on the writer goroutine, preserving ordering (a preceding PermissionDenied
 // data frame is flushed first) and the single-writer invariant. A nil sentinel
 // on writeCh signals runWriter to close.
+//
+// Callers MUST invoke enqueueClose only from the peer's own read-loop
+// goroutine (the same goroutine that runs the deferred handleDisconnect).
+// Unlike write()/broadcast(), which hold wmu across both the closed-check and
+// the writeCh send, enqueueClose releases wmu before the send below: its
+// full-queue fallback calls sendCloseFrame(), which re-locks wmu, and
+// sync.Mutex is not reentrant, so holding wmu across the send would deadlock
+// on that path. Because handleDisconnect (the sole close(p.writeCh) site)
+// runs sequentially after enqueueClose's caller on the same goroutine, this
+// send can never race the channel close today.
 func (p *peer) enqueueClose(code int, reason string) {
 	p.wmu.Lock()
 	if p.closed {
@@ -285,12 +295,22 @@ func (p *peer) enqueueClose(code int, reason string) {
 	p.closeReason = reason
 	p.wmu.Unlock()
 
-	select {
-	case p.writeCh <- nil:
-	default:
-		// Queue full: best-effort direct close (ordering already at risk).
-		p.sendCloseFrame()
-	}
+	func() {
+		defer func() {
+			if recover() != nil {
+				// writeCh already closed by handleDisconnect (a future
+				// cross-goroutine misuse) — close directly instead of
+				// panicking.
+				p.sendCloseFrame()
+			}
+		}()
+		select {
+		case p.writeCh <- nil:
+		default:
+			// Queue full: best-effort direct close (ordering already at risk).
+			p.sendCloseFrame()
+		}
+	}()
 }
 
 // sendCloseFrame writes the queued WS close control frame then closes the

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -32,6 +32,8 @@ type peer struct {
 	// was full under SlowPeerResync. runWriter clears it and sends a full-state
 	// resync once the queue drains, so the peer converges without a reconnect.
 	needsResync       bool
+	closeCode         int           // #104: WS close code queued via enqueueClose (0 = none)
+	closeReason       string        // #104: WS close reason accompanying closeCode
 	limiter           *rate.Limiter // per-peer inbound-message rate limiter; nil = unlimited (#51)
 	readOnly          bool          // #59: drop this peer's inbound writes (sync step-2/update + awareness)
 	hocuspocusFraming bool          // #104: docName-prefixed framing for this connection
@@ -268,12 +270,43 @@ func encodeAuthMessage(subType uint64, s string) []byte {
 	})
 }
 
-// enqueueClose is fully implemented in Task 8 (graceful queued close with
-// WS close code + reason). This is a TEMPORARY stub for Task 7 so the
-// success path compiles and is testable; it ignores code/reason and just
-// force-closes the underlying connection. DO NOT extend this — Task 8
-// replaces it wholesale.
-func (p *peer) enqueueClose(code int, reason string) { _ = code; _ = reason; _ = p.conn.Close() }
+// enqueueClose queues a WS close (with an application close code) AFTER any
+// frames already in writeCh. The close control frame is emitted by runWriter
+// on the writer goroutine, preserving ordering (a preceding PermissionDenied
+// data frame is flushed first) and the single-writer invariant. A nil sentinel
+// on writeCh signals runWriter to close.
+func (p *peer) enqueueClose(code int, reason string) {
+	p.wmu.Lock()
+	if p.closed {
+		p.wmu.Unlock()
+		return
+	}
+	p.closeCode = code
+	p.closeReason = reason
+	p.wmu.Unlock()
+
+	select {
+	case p.writeCh <- nil:
+	default:
+		// Queue full: best-effort direct close (ordering already at risk).
+		p.sendCloseFrame()
+	}
+}
+
+// sendCloseFrame writes the queued WS close control frame then closes the
+// connection. Called only from the writer goroutine (via runWriter) or the
+// enqueueClose full-queue fallback.
+func (p *peer) sendCloseFrame() {
+	p.wmu.Lock()
+	code, reason := p.closeCode, p.closeReason
+	p.wmu.Unlock()
+	if code != 0 {
+		_ = p.conn.WriteControl(gws.CloseMessage,
+			gws.FormatCloseMessage(code, reason),
+			time.Now().Add(writeTimeout))
+	}
+	_ = p.conn.Close()
+}
 
 // trackAwarenessClients records which awareness clientIDs this peer owns
 // so they can be removed when the peer disconnects.
@@ -586,6 +619,12 @@ func (p *peer) write(data []byte) {
 func (p *peer) runWriter() {
 	defer close(p.writerDone)
 	for data := range p.writeCh {
+		if data == nil {
+			// close-directive sentinel (#104 G1): flush is done; emit the WS
+			// close control frame on this goroutine, then stop.
+			p.sendCloseFrame()
+			return
+		}
 		if !p.writeToConn(data) {
 			return
 		}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -46,6 +46,18 @@ type peer struct {
 // handleMessage decodes the outer message type and dispatches accordingly.
 func (p *peer) handleMessage(data []byte) {
 	dec := encoding.NewDecoder(data)
+	if p.hocuspocusFraming {
+		docName, err := dec.ReadVarString()
+		if err != nil {
+			p.server.log().Debug("discarded malformed hocuspocus frame: unreadable docName",
+				"room", p.roomName, "err", err)
+			return
+		}
+		if docName != p.roomName {
+			p.server.log().Debug("hocuspocus frame docName mismatch (processing anyway)",
+				"room", p.roomName, "docName", docName)
+		}
+	}
 	outerType, err := dec.ReadVarUint()
 	if err != nil {
 		// Debug, not Warn: the rate is attacker-controlled, so a noisier level
@@ -542,6 +554,12 @@ func (p *peer) writeToConn(data []byte) bool {
 	p.wmu.Unlock()
 	if closed {
 		return false
+	}
+	if p.hocuspocusFraming {
+		data = encoding.EncodeBytes(func(enc *encoding.Encoder) {
+			enc.WriteVarString(p.roomName)
+			enc.WriteRaw(data)
+		})
 	}
 	if err := p.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
 		p.server.log().Debug("set write deadline failed", "err", err)

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -236,7 +236,10 @@ func (p *peer) handleAuth(dec *encoding.Decoder) {
 	cfg, authErr := p.safeTokenAuth(hook, token)
 	if authErr != nil {
 		p.write(encodeAuthMessage(authTypePermissionDenied, authErr.Error()))
-		p.enqueueClose(wsCodeUnauthorized, authErr.Error())
+		// Full error text goes in the PermissionDenied data frame above; the
+		// WS close frame uses a short constant reason because control frames
+		// cap the payload at 125 bytes (a long reason would drop the close).
+		p.enqueueClose(wsCodeUnauthorized, wsReasonUnauthorized)
 		return
 	}
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -84,6 +84,14 @@ const (
 
 	// wsCodeUnauthorized is Hocuspocus's WS close code for failed auth.
 	wsCodeUnauthorized = 4401
+
+	// wsReasonUnauthorized is the WS close-frame reason for a denied
+	// connection. It is a short constant because a WS close control frame's
+	// payload is capped at 125 bytes (2-byte code + reason); a long
+	// hook-supplied error would overflow it and drop the close frame, so the
+	// full error text is carried only in the PermissionDenied data frame.
+	// Matches Hocuspocus's CloseEvents.Unauthorized.reason.
+	wsReasonUnauthorized = "Unauthorized"
 )
 
 // maxWSMessageBytes is the maximum size of a single WebSocket frame accepted

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -369,6 +369,19 @@ type Server struct {
 	// to the embedding application.
 	OnStateless StatelessHook
 
+	// OnTokenAuth, if non-nil, validates the token from a Hocuspocus in-band
+	// Auth message (tag 2). A nil error accepts the connection and replies
+	// Authenticated (scope from the returned ConnectionConfig.ReadOnly); a
+	// non-nil error replies PermissionDenied(err) and closes with WS 4401.
+	// When nil, tag-2 frames are silently ignored (unchanged legacy behavior).
+	//
+	// OnTokenAuth complements the HTTP-boundary AuthFunc/Authorize; it does not
+	// replace them. IMPORTANT: it is NOT a document-confidentiality gate — the
+	// initial sync is served before any PermissionDenied, so deployments that
+	// must withhold document contents from unauthenticated clients must reject
+	// them at the boundary via AuthFunc/Authorize.
+	OnTokenAuth func(room, token string) (ConnectionConfig, error)
+
 	// OnLoadDocument, if non-nil, is called once per room immediately
 	// after the document has been bootstrapped from the PersistenceAdapter
 	// (or freshly constructed when no adapter is configured) but before

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -76,6 +76,16 @@ const (
 	msgPong               = uint64(10) // liveness reply to a server-sent Ping; no-op
 )
 
+// Hocuspocus in-band Auth (tag 2) sub-protocol types (see #104).
+const (
+	authTypeToken            = uint64(0)
+	authTypePermissionDenied = uint64(1)
+	authTypeAuthenticated    = uint64(2)
+
+	// wsCodeUnauthorized is Hocuspocus's WS close code for failed auth.
+	wsCodeUnauthorized = 4401
+)
+
 // maxWSMessageBytes is the maximum size of a single WebSocket frame accepted
 // by the server. Frames larger than this are rejected before being buffered,
 // preventing OOM from a single crafted large message.
@@ -293,6 +303,15 @@ type Server struct {
 	// AuthFunc grants read-write access. To grant read-only access, use Authorize
 	// instead — when Authorize is set it takes precedence and AuthFunc is ignored.
 	AuthFunc func(r *http.Request) bool
+
+	// HocuspocusFraming, when true, makes this server read and write the
+	// Hocuspocus docName-prefixed framing: every frame is
+	// VarString(docName) + <y-websocket frame>. Enables real @hocuspocus/provider
+	// interop. One room per connection is still enforced (no multi-document
+	// multiplexing); the inbound docName is read and used only for logging.
+	// Leave false (default) for native y-websocket clients — the two framings
+	// cannot be auto-detected on one endpoint.
+	HocuspocusFraming bool
 
 	// Authorize, if non-nil, is the richer alternative to AuthFunc: it both
 	// accepts/rejects the connection (second return value; false → 401) and
@@ -955,16 +974,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ws.SetReadLimit(s.maxMessageBytes())
 
 	p := &peer{
-		conn:       ws,
-		room:       rm,
-		roomName:   name,
-		server:     s,
-		done:       make(chan struct{}),
-		clientIDs:  make(map[uint64]struct{}),
-		writeCh:    make(chan []byte, s.peerWriteQueueSize()),
-		writerDone: make(chan struct{}),
-		limiter:    s.newPeerLimiter(),
-		readOnly:   readOnly,
+		conn:              ws,
+		room:              rm,
+		roomName:          name,
+		server:            s,
+		done:              make(chan struct{}),
+		clientIDs:         make(map[uint64]struct{}),
+		writeCh:           make(chan []byte, s.peerWriteQueueSize()),
+		writerDone:        make(chan struct{}),
+		limiter:           s.newPeerLimiter(),
+		readOnly:          readOnly,
+		hocuspocusFraming: s.HocuspocusFraming,
 	}
 
 	// Verify the room is still in the server map before adding the peer.


### PR DESCRIPTION
## Summary

Two independent, additive enhancements shipped together, targeting **v1.38.0**.

### #105 — awareness `OnUpdate` event + `Meta(clientID)` accessor
- New `OnUpdate(func(UpdateEvent)) func()` fires on **every** applied awareness entry, including same-content heartbeat re-emits — distinct from the now content-only `OnChange`.
- New `Meta(clientID) (ClientMeta, bool)` returns per-client `{Clock, LastUpdated}`, retained for tombstones (matches Yjs `y-protocols`/yrs).
- Semantics matched line-for-line against Yjs and yrs: two-event model (`change` = content-only, `update` = all); reactivated (removed→returning) clients classified `Updated` not `Added`; `Meta` retained for removed clients.

### #104 — Hocuspocus in-band token auth + docName framing
- Opt-in `Server.HocuspocusFraming` reads/writes docName-prefixed frames (stripped inbound, prepended outbound at the single write choke-point) for real `@hocuspocus/provider` interop. One room per connection (no multi-doc multiplexing).
- New `Server.OnTokenAuth func(room, token string) (ConnectionConfig, error)` handles the in-band Auth message (tag 2): `Authenticated` (with `readonly`/`read-write` scope) on success, `PermissionDenied` + an **ordered** WebSocket `4401` close on failure (the close is funneled through the writer goroutine so the `PermissionDenied` frame always flushes first and the single-writer invariant holds).
- Composes with `AuthFunc`/`Authorize`; `OnTokenAuth == nil` keeps tag-2 silently ignored (backward compatible).

## Behavioral changes (documented in CHANGELOG)
- `OnChange` no longer fires on content-identical re-emits (remote heartbeats via `ApplyUpdate`, local same-content `SetLocalState`) — use `OnUpdate` for liveness/presence. `Heartbeat()` now fires `OnUpdate` (was silent).
- The in-repo cluster relay now subscribes via `OnUpdate` so cross-node awareness liveness (heartbeats) keeps propagating; the mobile observer intentionally stays content-only.

## Security note
`OnTokenAuth` is a handshake reply + optional read-only downgrade, **not** a document-confidentiality gate: the initial sync is served before any `PermissionDenied`. Deployments needing confidentiality must reject at the HTTP-upgrade boundary via `AuthFunc`/`Authorize`. Documented on the `OnTokenAuth` godoc.

## Testing
- Awareness: OnUpdate-vs-OnChange heartbeat distinction, content-change fires both, self-state re-emit = update-only, `Meta` active/remote-tombstone/local-tombstone, reactivation classification, `ApplyUpdate` benchmarks re-checked.
- Websocket: docName framing round-trip, Authenticated (read-write + readonly scope), `PermissionDenied` **before** `4401` (ordering), nil-hook backward-compat, hook-panic denial, wrong-subType ignored, docName mismatch lenient, native framing unaffected.
- Verified green: `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go test -race ./awareness/... ./provider/websocket/...`, no `go.mod`/`go.sum` drift.

## Notes
- Branch is merged up to current `main` (includes v1.37.0 persistence work). The #104 close/flush paths were reviewed to coexist correctly with v1.37.0's flush-before-evict teardown (disjoint channels, ordering preserved).

Closes #104
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
