### PR TITLE
perf: O(1) positional access (search marker) + room-load off global lock + idle residency (#181/#182/#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.39.0] — 2026-07-24
+
+### Performance
+
+- **O(1) amortized positional access for `YText`/`YArray`**
+  ([#181](https://github.com/reearth/ygo/issues/181)): a Yjs-style
+  bidirectional, move-aware search-marker structure replaces the old
+  forward-only position cache behind `YArray.Get`/`Slice`, the shared
+  `deleteRange` used by `YText`/`YArray` deletes, and `YText.Format` /
+  `ApplyDelta`'s positional cursor. Internal only — no public API change.
+  Measured on a 100k-node document: random-position insert ~101× faster
+  (632µs → 6.3µs), reverse (backward-walking) insert ~916× faster
+  (1.15ms → 1.26µs — this was the O(n²) cliff the old forward-only cache hit
+  on backward walks), random `Get` ~114× faster (481µs → 4.2µs).
+
+### Fixed
+
+- **`YText.ApplyDelta` format-bleed into a following insert**
+  ([#181](https://github.com/reearth/ygo/issues/181)): an `insert` op with no
+  `Attributes` of its own no longer inherits formatting from a preceding
+  `{retain, attributes}` op — matching the Yjs/Quill rule that an insert's
+  formatting comes only from its own `Attributes`. This is a behaviour
+  change: code relying on the old bleed-through will see different
+  formatting output. Also fixed: consecutive attribute-less inserts could
+  integrate out of order.
+- **Room load no longer serializes under the global room-map lock**
+  ([#182](https://github.com/reearth/ygo/issues/182)): `LoadDoc` /
+  full-state decode / `OnLoadDocument` previously ran while holding the
+  server's single rooms lock, so one slow or large room load stalled every
+  other room's create/lookup/evict process-wide. Loading now runs off-lock
+  behind a per-room `ready` barrier — concurrent connects to distinct rooms
+  load in parallel — while a reentrant load into a room still loading (e.g.
+  the cluster relay's `Inject`) waits on the same barrier instead of
+  double-loading.
+
+### Added
+
+- **`Server.RoomIdleTimeout` and `Server.MaxResidentRooms`**
+  ([#183](https://github.com/reearth/ygo/issues/183)): `RoomIdleTimeout
+  time.Duration` keeps a room resident in memory for this long after its
+  last peer disconnects — the durable flush-before-evict still runs
+  immediately, but the in-memory doc and worker stay warm so a quick
+  reconnect skips a full `LoadDoc` reload; zero (the default) preserves the
+  previous eager-evict-on-last-peer behaviour. `MaxResidentRooms int` bounds
+  how many idle-resident rooms stay warm at once — once the count exceeds it,
+  a background sweeper evicts the least-recently-idle rooms first; zero is
+  unbounded and only meaningful together with `RoomIdleTimeout > 0`.
+
 ## [1.38.0] — 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ygo is a pure-Go CRDT library that interoperates with Yjs (JavaScript) and yrs (
 - Native iOS/Android embedding via `gomobile` (the `mobile/` subpackage) — no JS runtime, no CGO
 - Snapshots, garbage collection, undo manager, persistence adapters
 
-The current release is **v1.38.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
+The current release is **v1.39.0**. See [CHANGELOG.md](CHANGELOG.md) for the per-release detail and [docs/HISTORY.md](docs/HISTORY.md) for the longer arc.
 
 ## Features
 
@@ -72,6 +72,8 @@ Post-v1.0 hardening:
 - **Subdocument lifecycle** (#63). A `Doc` can embed another `Doc` as a subdocument via `YMap.Set(txn, key, subdoc)`; `GetSubdocs`/`GetSubdocGUIDs`/`OnSubdocs`/`Load` plus `WithAutoLoad`/`WithShouldLoad`/`WithCollectionID` track and drive the add/remove/load lifecycle — the local half of Yjs's subdocuments feature. Also: `New()` now defaults a Doc's `guid` to a random uuidv4 instead of `""` (Yjs parity). Live cross-peer subdoc sync is a separate, tracked follow-up (#142). See [Subdocuments](#subdocuments) below.
 - **Coalesced persistence** (v1.36.0). The websocket server's persistence worker now debounces backing-store writes by default — a 2s window, capped by a 10s max wait — merging bursts into a single `StoreUpdate` instead of one write per update (Hocuspocus parity). This is a behaviour change for servers with a `PersistenceAdapter` configured; set `Server.PersistCoalesceWindow = -1` to restore strict per-update writes (#175).
 - **Persistence durability + compaction** (v1.37.0). The room-teardown paths now flush a pending coalesced batch durably before evicting the room, closing a gap where a fast reconnect could reload stale state and miss the just-made edit. Adapters can also bound stored-version growth by implementing `CompactableAdapter`, driven by `Server.CompactEvery` (`persistence.LegacyAdapter` supports this via its new `KeepVersions` field) (#175).
+- **Positional-access performance** (v1.39.0). `YText`/`YArray` positional operations (`Get`, `Slice`, positional insert/delete, `Format`, `ApplyDelta`) now route through a Yjs-style bidirectional, move-aware search-marker cache instead of the old forward-only position cache — internal only, no public API change. Measured on a 100k-node document: random-position insert ~101× faster, reverse insert ~916× faster (the old cache's O(n²) worst case), random `Get` ~114× faster. Also fixes a `YText.ApplyDelta` bug where an attribute-less `insert` could inherit a preceding retain's `attributes` (Yjs/Quill-aligned fix; behaviour change for callers relying on the old bleed-through) (#181).
+- **Room load off the global lock + idle-room residency** (v1.39.0). Concurrent connects to distinct rooms now load in parallel instead of serializing behind the server's single rooms lock (#182). New `Server.RoomIdleTimeout`/`Server.MaxResidentRooms` let a room stay warm in memory for a bounded time (and bounded count) after its last peer leaves so a quick reconnect reuses the live doc instead of reloading; both default to zero, preserving the previous eager-evict behaviour (#183).
 
 See [CHANGELOG.md](CHANGELOG.md) for the full per-release picture.
 
@@ -384,6 +386,8 @@ By default (v1.36.0) these writes are coalesced: the worker debounces bursts of 
 
 A room's pending coalesced batch is flushed durably before the room unloads (v1.37.0), so a peer that reconnects during a quick refresh reuses the live document instead of racing a stale reload from the backing store. Adapters that also want to bound stored-version growth can implement `CompactableAdapter` (`Compact(ctx, room) error`); the server invokes it on room unload and, when `Server.CompactEvery > 0`, after every N persistence flushes. `persistence.LegacyAdapter` implements this via its `KeepVersions` field.
 
+`Server.RoomIdleTimeout` (v1.39.0) goes a step further: instead of unloading a room the instant its last peer disconnects, it keeps the room resident — the durable flush above still runs immediately, but the worker and in-memory doc stay warm — so a peer that reconnects within the timeout reuses the live doc with no `LoadDoc` at all. `Server.MaxResidentRooms` puts an LRU bound on how many idle rooms stay warm at once. Both default to zero, which is the original eager-evict-on-last-peer behaviour; see [Resource limits](#resource-limits) below for the field details.
+
 For a ready-made durable backend, [`persistence/sqlite`](persistence/sqlite/) provides a pure-Go (CGO-free, `modernc.org/sqlite`) `VersionedPersistence` store with WAL mode, full versioned history, and a crash-safe two-phase prune. Open it with `sqlite.Open("data.db")`.
 
 For backend examples (Postgres, Redis, file-system) and the v1.7.0 context-aware extension that lets adapters abort in-flight writes during `Server.Shutdown`, see [docs/PERSISTENCE.md](docs/PERSISTENCE.md).
@@ -504,6 +508,8 @@ All hard-capped (semaphore-backed for connection counts):
 - `Server.MaxPendingItems` — per-document cap on items parked in the out-of-order pending queue (default 100,000). When the cap is reached, updates that would park additional items return `ErrInvalidUpdate`. Defends against a crafted update full of far-future-clock items that would otherwise grow the queue unboundedly. Same cap is available at the doc level via `crdt.WithMaxPendingItems(n)`.
 - `Server.HandshakeTimeout` — first-read deadline applied after WebSocket upgrade (default 30s). Closes connections that complete the handshake but never send a message (slow-loris defense). Cleared after the first successful read.
 - `Server.MaxAwarenessBytesPerRoom` — cap on the cumulative byte size of awareness state held in one room across all remote clients (default unlimited; suggested production value: 100 MiB). Without this cap, a single peer can claim up to 10,000 clientIDs each holding the 1 MiB per-state maximum. Forwarded to each room's `Awareness` via `awareness.Awareness.SetMaxBytes`.
+- `Server.RoomIdleTimeout` (v1.39.0) — keeps a room resident and warm (durably flushed, in-memory doc intact) for this long after its last peer disconnects, so a quick reconnect skips a full `LoadDoc` reload. Default 0: evict immediately, matching prior releases.
+- `Server.MaxResidentRooms` (v1.39.0) — LRU bound on how many idle-resident rooms stay warm at once when `RoomIdleTimeout > 0`; a background sweeper evicts the least-recently-idle room first once the count is exceeded. Default 0: unbounded.
 
 Each defaults to a sensible value or unlimited where noted.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,67 @@
+## v1.39.0
+
+A minor release focused on performance and websocket-server room lifecycle.
+`YText`/`YArray` positional access (`Get`/`Slice`, positional insert/delete,
+`Format`, `ApplyDelta`) now runs through a Yjs-style bidirectional,
+move-aware search-marker cache instead of the old forward-only position
+cache — a purely internal change, no public API surface moved — cutting
+100k-node positional operations by roughly two orders of magnitude. Along
+the way, a real `YText.ApplyDelta` formatting bug was fixed: an `insert` op
+with no attributes of its own no longer bleeds in a preceding retain's
+formatting (Yjs/Quill-aligned); this is a **behaviour change** for code that
+relied on the old bleed-through. On the websocket server, room load
+(`LoadDoc`/decode/`OnLoadDocument`) no longer runs under the global
+room-map lock, so concurrent connects to distinct rooms load in parallel
+instead of serializing; and new `Server.RoomIdleTimeout` /
+`Server.MaxResidentRooms` fields let a room stay warm in memory for a
+bounded time (and bounded count) after its last peer leaves, so a quick
+reconnect reuses the live doc instead of a full reload. No breaking API
+changes; both new fields default to zero, which preserves prior-release
+behaviour exactly.
+
+### Performance
+
+- **O(1) amortized positional access for `YText`/`YArray`**
+  ([#181](https://github.com/reearth/ygo/issues/181)): a Yjs-style
+  bidirectional, move-aware search-marker structure replaces the old
+  forward-only position cache. Internal only — no public API change.
+  Measured on a 100k-node document: random-position insert ~101× faster
+  (632µs → 6.3µs), reverse insert ~916× faster (1.15ms → 1.26µs), random
+  `Get` ~114× faster (481µs → 4.2µs).
+
+### Fixed
+
+- **`YText.ApplyDelta` format-bleed into a following insert**
+  ([#181](https://github.com/reearth/ygo/issues/181)): an `insert` op with
+  no `Attributes` of its own no longer inherits formatting from a preceding
+  `{retain, attributes}` op, matching the Yjs/Quill rule. Behaviour change —
+  see summary above. Also fixed: consecutive attribute-less inserts could
+  integrate out of order.
+- **Room load no longer serializes under the global room-map lock**
+  ([#182](https://github.com/reearth/ygo/issues/182)): loading now runs
+  off-lock behind a per-room `ready` barrier, so concurrent connects to
+  distinct rooms load in parallel; a reentrant load (e.g. cluster relay
+  `Inject`) waits on the same barrier instead of double-loading.
+
+### Added
+
+- **`Server.RoomIdleTimeout` and `Server.MaxResidentRooms`**
+  ([#183](https://github.com/reearth/ygo/issues/183)): keep a room resident
+  and warm for a bounded time after its last peer leaves (durable flush
+  still happens immediately), with an LRU bound on how many idle rooms stay
+  resident at once. Both default to zero, preserving the previous
+  eager-evict behaviour.
+
+## Install
+
+```
+go get github.com/reearth/ygo@v1.39.0
+```
+
+See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+
+---
+
 ## v1.38.0
 
 A minor, additive release adding two independent features. On the awareness

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -147,24 +147,6 @@ func (t *abstractType) invalidateFirstLiveCache() {
 	t.firstLiveCache = nil
 }
 
-// invalidatePosCache clears all search markers. Must be called whenever an
-// insertion or deletion changes the logical positions of items in this type's
-// linked list but the affected range is not known (remote applies, splits,
-// merges). Retained as a thin shim over clearMarkers so existing call sites
-// keep compiling; Task 3 will refine the exact invalidation semantics.
-func (t *abstractType) invalidatePosCache() {
-	t.clearMarkers()
-}
-
-// invalidatePosCacheFrom drops every marker at or after rendered position pos.
-// Markers before pos still point at items whose rendered start an edit at pos
-// cannot shift, so they remain accurate. Retained as a thin shim over
-// dropMarkersFrom for existing call sites; Task 3 will replace these with
-// precise updateMarkerChanges calls.
-func (t *abstractType) invalidatePosCacheFrom(pos int) {
-	t.dropMarkersFrom(pos)
-}
-
 // leftNeighbourAt returns the item that should be the left neighbour when
 // inserting at logical position index, plus the offset within that item.
 //

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -93,6 +93,25 @@ type abstractType struct {
 	// have never had formatting applied — the dominant cost on head-delete
 	// workloads in plain-text documents. Once true, stays true.
 	hasFormatting bool
+
+	// markers is a small cache of (rendered index → *Item) search markers,
+	// modelled on Yjs's ArraySearchMarker. Capped at maxSearchMarker entries.
+	// As of Task 1 (#181) nothing writes to this slice yet — only the
+	// read-only findMarkerRO consults it, and only when a later task
+	// populates it; the field exists now so the read path and the
+	// force-cold test seam (disableMarkers) can be exercised ahead of the
+	// write-path migration that replaces posCache.
+	markers []searchMarker
+	// markerTimestamp is a monotonically increasing counter later tasks use
+	// to decide which marker to evict/refresh (LRU-by-recency). Unused by
+	// Task 1's read-only lookup.
+	markerTimestamp uint64
+	// disableMarkers is a test-only seam that forces findMarkerRO (and, once
+	// later tasks add a marker-aware write path, the rest of the
+	// marker-based lookups) to fall back to a full linear walk from t.start,
+	// exactly like the marker-free oracle. Used to assert marker-based and
+	// cold-walk results agree.
+	disableMarkers bool
 }
 
 // prelimFlusher is implemented by types that buffer mutations while detached

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -90,6 +90,18 @@ type abstractType struct {
 	// exactly like the marker-free oracle. Used to assert marker-based and
 	// cold-walk results agree.
 	disableMarkers bool
+
+	// hasMoves becomes true the first time a ContentMove item is integrated
+	// into this type (locally via YArray.Move or remotely via an update).
+	// renderedStep (search_marker.go) counts items by their PHYSICAL position
+	// in the linked list and does not yet know how to render a ContentMove's
+	// target at the move's destination, nor to skip an item that moved away
+	// (item.MovedBy != nil) — that move-awareness is explicitly deferred to a
+	// later task. Until then, YArray.Get/Slice gate their marker-based fast
+	// path on !hasMoves so arrays that use Move keep taking the original,
+	// fully move-aware linear walk instead of a marker answer that could
+	// silently disagree with it. Once true, stays true (mirrors hasFormatting).
+	hasMoves bool
 }
 
 // prelimFlusher is implemented by types that buffer mutations while detached

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -1,17 +1,5 @@
 package crdt
 
-// posLRUSize is the number of (index → item) pairs cached per abstractType.
-// 80 entries matches the value used by the Yjs reference implementation and
-// gives O(1) average-case performance for sequential and nearby insertions.
-const posLRUSize = 80
-
-// posCacheEntry maps a logical cumulative character count to the item at that
-// boundary. "index" is the total counted characters up to and including item.
-type posCacheEntry struct {
-	index int
-	item  *Item
-}
-
 // SharedType is the public interface satisfied by every exported CRDT type
 // (YArray, YMap, YText, YXmlFragment, …). It exists so external callers can
 // name the element type of NewUndoManager's scope slice
@@ -60,20 +48,10 @@ type abstractType struct {
 	deepSubIDGen  uint64
 	deepObservers []deepSub
 
-	// posCache is a small circular cache of (cumulativeIndex → *Item) pairs
-	// used by leftNeighbourAt to skip linear scan from t.start on repeat
-	// accesses. posCacheLen tracks how many slots are filled (capped at
-	// posLRUSize). posCacheWr is the next write position; it wraps around once
-	// the cache is full, giving O(1) FIFO eviction instead of the previous
-	// O(posLRUSize) min-scan.
-	posCache    [posLRUSize]posCacheEntry
-	posCacheLen int
-	posCacheWr  int
-
 	// insertHint is set by Insert callers to the logical index of an imminent
-	// local insertion. When non-zero, item.integrate uses partial cache
-	// invalidation (discarding only entries ≥ insertHint) instead of clearing
-	// the entire cache, so that entries before the insertion point survive for
+	// local insertion. When non-zero, item.integrate uses partial marker
+	// invalidation (dropping only markers ≥ insertHint) instead of clearing
+	// all markers, so that markers before the insertion point survive for
 	// subsequent nearby lookups. Zero means "no hint; do a full clear".
 	insertHint int
 
@@ -95,16 +73,16 @@ type abstractType struct {
 	hasFormatting bool
 
 	// markers is a small cache of (rendered index → *Item) search markers,
-	// modelled on Yjs's ArraySearchMarker. Capped at maxSearchMarker entries.
-	// As of Task 1 (#181) nothing writes to this slice yet — only the
-	// read-only findMarkerRO consults it, and only when a later task
-	// populates it; the field exists now so the read path and the
-	// force-cold test seam (disableMarkers) can be exercised ahead of the
-	// write-path migration that replaces posCache.
+	// modelled on Yjs's ArraySearchMarker, replacing the old posCache. Capped
+	// at maxSearchMarker entries. The write path (findMarkerMut, called from
+	// leftNeighbourAt) is the only place that installs/refreshes/evicts
+	// markers; the read-only findMarkerRO merely consults them. Because
+	// mutation happens exclusively under the document write lock, findMarkerRO
+	// stays safe to call under an RLock.
 	markers []searchMarker
-	// markerTimestamp is a monotonically increasing counter later tasks use
-	// to decide which marker to evict/refresh (LRU-by-recency). Unused by
-	// Task 1's read-only lookup.
+	// markerTimestamp is a monotonically increasing counter used to decide
+	// which marker to evict/refresh (LRU-by-recency) in markPosition/
+	// markPositionAt.
 	markerTimestamp uint64
 	// disableMarkers is a test-only seam that forces findMarkerRO (and, once
 	// later tasks add a marker-aware write path, the rest of the
@@ -169,45 +147,22 @@ func (t *abstractType) invalidateFirstLiveCache() {
 	t.firstLiveCache = nil
 }
 
-// invalidatePosCache clears all cached position entries. Must be called
-// whenever an insertion or deletion changes the logical positions of items
-// in this type's linked list.
+// invalidatePosCache clears all search markers. Must be called whenever an
+// insertion or deletion changes the logical positions of items in this type's
+// linked list but the affected range is not known (remote applies, splits,
+// merges). Retained as a thin shim over clearMarkers so existing call sites
+// keep compiling; Task 3 will refine the exact invalidation semantics.
 func (t *abstractType) invalidatePosCache() {
-	t.posCacheLen = 0
-	t.posCacheWr = 0
+	t.clearMarkers()
 }
 
-// invalidatePosCacheFrom removes all cached entries with cumulative index ≥ pos.
-// Entries before pos remain valid and can be reused by the next leftNeighbourAt
-// call near the same location, avoiding a full O(n) rescan from t.start.
+// invalidatePosCacheFrom drops every marker at or after rendered position pos.
+// Markers before pos still point at items whose rendered start an edit at pos
+// cannot shift, so they remain accurate. Retained as a thin shim over
+// dropMarkersFrom for existing call sites; Task 3 will replace these with
+// precise updateMarkerChanges calls.
 func (t *abstractType) invalidatePosCacheFrom(pos int) {
-	n := 0
-	for i := 0; i < t.posCacheLen; i++ {
-		if t.posCache[i].index < pos {
-			t.posCache[n] = t.posCache[i]
-			n++
-		}
-	}
-	t.posCacheLen = n
-	t.posCacheWr = 0 // reset write cursor; the compacted entries sit at [0..n-1]
-}
-
-// storePosCache records the entry (index, item) in the circular cache.
-// When the cache is not yet full entries are appended; once full the oldest
-// entry is overwritten in FIFO order. This gives O(1) insertion cost vs the
-// previous O(posLRUSize) min-scan eviction strategy.
-func (t *abstractType) storePosCache(index int, item *Item) {
-	if t.posCacheLen < posLRUSize {
-		t.posCache[t.posCacheLen] = posCacheEntry{index, item}
-		t.posCacheLen++
-		return
-	}
-	// Cache full: circular overwrite.
-	t.posCache[t.posCacheWr] = posCacheEntry{index, item}
-	t.posCacheWr++
-	if t.posCacheWr >= posLRUSize {
-		t.posCacheWr = 0
-	}
+	t.dropMarkersFrom(pos)
 }
 
 // leftNeighbourAt returns the item that should be the left neighbour when
@@ -218,62 +173,35 @@ func (t *abstractType) storePosCache(index int, item *Item) {
 // caller must split it before inserting.
 // Returns (nil, 0) when index == 0 (insert at the very beginning).
 //
-// The LRU position cache is consulted first so that repeated insertions near
-// the same position avoid re-scanning from t.start.
+// The search-marker cache (findMarkerMut) is consulted first so that repeated
+// insertions near the same position avoid re-scanning from t.start; it also
+// installs/refreshes a marker for the resolved position as a side effect.
 func (t *abstractType) leftNeighbourAt(index int) (*Item, int) {
 	if index == 0 {
 		return nil, 0
 	}
 
-	// Find the cache entry with the largest cumulative index ≤ requested index.
-	// Deleted cached items are skipped (they are no longer at their recorded position).
-	startCounted := 0
-	var startItem *Item // first item to scan from (the Right of the cached boundary item)
-	for i := 0; i < t.posCacheLen; i++ {
-		e := t.posCache[i]
-		if e.index <= index && e.index > startCounted && !e.item.Deleted {
-			startCounted = e.index
-			startItem = e.item
-		}
-	}
-
-	counted := startCounted
-	var lastItem *Item
-	scanFrom := t.start
-	if startItem != nil {
-		// Resume scan from the item right after the cached boundary.
-		lastItem = startItem
-		scanFrom = startItem.Right
-	}
-
-	for item := scanFrom; item != nil; item = item.Right {
-		if !item.Deleted && item.Content.IsCountable() {
-			n := item.Content.Len()
-			newCounted := counted + n
-			// Store this boundary in the cache for future nearby lookups.
-			t.storePosCache(newCounted, item)
-			if newCounted >= index {
-				offset := index - counted
-				if offset == n {
-					// Position is at the very end of item — insert right after it.
-					return item, 0
-				}
-				if offset == 0 {
-					// Position is at the very start of item — insert right after
-					// lastItem (i.e. before this item). The cache can cause counted
-					// to equal index at the start of a scan, producing offset=0 for
-					// the first item encountered; returning that item would tell the
-					// caller to insert after it (too far right).
-					return lastItem, 0
-				}
-				return item, offset
+	item, start := t.findMarkerMut(index)
+	if item == nil {
+		// index > total rendered length: append after the last countable item.
+		var last *Item
+		for it := t.start; it != nil; it = it.Right {
+			if !it.Deleted && it.Content.IsCountable() {
+				last = it
 			}
-			counted = newCounted
-			lastItem = item
 		}
+		return last, 0
 	}
-	// index >= length: insert after the last item (append).
-	return lastItem, 0
+
+	// findMarkerMut (like the cold oracle) always returns an item whose
+	// rendered start is strictly < index, so offset ∈ [1, len]. offset == len
+	// means index is exactly at the item's end → insert right after it;
+	// otherwise the item must be split at offset.
+	offset := index - start
+	if offset >= item.Content.Len() {
+		return item, 0
+	}
+	return item, offset
 }
 
 // observeDeep registers fn to be called after any transaction that modifies

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -165,10 +165,23 @@ func (t *abstractType) leftNeighbourAt(index int) (*Item, int) {
 
 	item, start := t.findMarkerMut(index)
 	if item == nil {
-		// index > total rendered length: append after the last countable item.
+		// index > total rendered length (append / insert-beyond-end): anchor
+		// after the last item that actually RENDERS, using the shared move-aware
+		// renderedStep — NOT the raw `!Deleted && IsCountable` test the old
+		// fallback used, which is move-blind. A winning ContentMove is
+		// non-countable yet renders its target here (so it IS the rendered tail
+		// and the correct physical anchor); a moved-away item is countable but
+		// renders elsewhere (so it must NOT be chosen). Picking the physical
+		// last-countable item instead would make append incoherent with the
+		// move-aware Get/Slice/deleteRange: when an element is moved TO the end,
+		// the ContentMove is the physical tail and the last plain item is not the
+		// rendered tail, so the old walk anchored the new element BEFORE the moved
+		// one (#181/#190). For move-free content renderedStep's countable branch
+		// is exactly `!Deleted && IsCountable`, so this is byte-identical without
+		// moves.
 		var last *Item
 		for it := t.start; it != nil; it = it.Right {
-			if !it.Deleted && it.Content.IsCountable() {
+			if countable, _, _ := t.renderedStep(it); countable {
 				last = it
 			}
 		}
@@ -176,11 +189,19 @@ func (t *abstractType) leftNeighbourAt(index int) (*Item, int) {
 	}
 
 	// findMarkerMut (like the cold oracle) always returns an item whose
-	// rendered start is strictly < index, so offset ∈ [1, len]. offset == len
+	// rendered start is strictly < index, so offset ∈ [1, n]. offset == n
 	// means index is exactly at the item's end → insert right after it;
-	// otherwise the item must be split at offset.
+	// otherwise the item must be split at offset. Use renderedStep's n (not
+	// item.Content.Len()) for the same move-aware notion of "how wide is this
+	// item" that findMarkerMut used to bracket index — keeping Insert's split
+	// point consistent with the position walk. For a winning ContentMove n is
+	// the moved target's width (==1, since Move forces single-element targets
+	// and ContentMove.Len()==1), and for any plain item n==Content.Len(), so
+	// this is a no-op relative to the old check; it only closes a latent gap if
+	// the two notions of width could ever disagree for the returned item.
+	_, n, _ := t.renderedStep(item)
 	offset := index - start
-	if offset >= item.Content.Len() {
+	if offset >= n {
 		return item, 0
 	}
 	return item, offset

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -90,18 +90,6 @@ type abstractType struct {
 	// exactly like the marker-free oracle. Used to assert marker-based and
 	// cold-walk results agree.
 	disableMarkers bool
-
-	// hasMoves becomes true the first time a ContentMove item is integrated
-	// into this type (locally via YArray.Move or remotely via an update).
-	// renderedStep (search_marker.go) counts items by their PHYSICAL position
-	// in the linked list and does not yet know how to render a ContentMove's
-	// target at the move's destination, nor to skip an item that moved away
-	// (item.MovedBy != nil) — that move-awareness is explicitly deferred to a
-	// later task. Until then, YArray.Get/Slice gate their marker-based fast
-	// path on !hasMoves so arrays that use Move keep taking the original,
-	// fully move-aware linear walk instead of a marker answer that could
-	// silently disagree with it. Once true, stays true (mirrors hasFormatting).
-	hasMoves bool
 }
 
 // prelimFlusher is implemented by types that buffer mutations while detached

--- a/crdt/apply_delta_cursor_test.go
+++ b/crdt/apply_delta_cursor_test.go
@@ -1,0 +1,97 @@
+package crdt
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestApplyDelta_ConsecutiveInsertsStayInOrder pins the fix for a cursor bug
+// in the ApplyDelta single-threaded-cursor rewrite (#181, commit 481c949):
+// applyDeltaInsert only advanced pos.left/pos.right past the just-inserted
+// item when that insert carried its own Attributes (i.e. the diff/open-close
+// marker path ran). A plain attribute-less insert left the cursor stale at
+// its PRE-insert position, so the next op (whatever it was) re-anchored at
+// the same left neighbour and could integrate out of order.
+//
+// This was flagged (but deliberately not exercised) by
+// TestApplyDelta_InsertDoesNotInheritPrecedingRetainFormat's doc comment,
+// which sidesteps it with an intervening Retain. This test exercises it
+// directly: two attribute-less inserts back-to-back on an empty document.
+func TestApplyDelta_ConsecutiveInsertsStayInOrder(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) {
+		txt.ApplyDelta(tr, []Delta{
+			{Op: DeltaOpInsert, Insert: "a"},
+			{Op: DeltaOpInsert, Insert: "b"},
+		})
+	})
+
+	if got := txt.ToString(); got != "ab" {
+		t.Fatalf("ToString() = %q, want %q", got, "ab")
+	}
+
+	want := []Delta{{Op: DeltaOpInsert, Insert: "ab"}}
+	if got := txt.ToDelta(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToDelta() = %#v, want %#v", got, want)
+	}
+}
+
+// TestApplyDelta_PlainInsertThenAttributedInsertStaysInOrder covers a plain
+// (attribute-less) insert immediately followed by an insert that DOES carry
+// its own attributes. Before the fix, the cursor left stale by the first
+// insert would cause the second insert to anchor at the same left neighbour
+// as the first, instead of after it.
+func TestApplyDelta_PlainInsertThenAttributedInsertStaysInOrder(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) {
+		txt.ApplyDelta(tr, []Delta{
+			{Op: DeltaOpInsert, Insert: "a"},
+			{Op: DeltaOpInsert, Insert: "b", Attributes: Attributes{"bold": true}},
+		})
+	})
+
+	if got := txt.ToString(); got != "ab" {
+		t.Fatalf("ToString() = %q, want %q", got, "ab")
+	}
+
+	want := []Delta{
+		{Op: DeltaOpInsert, Insert: "a"},
+		{Op: DeltaOpInsert, Insert: "b", Attributes: Attributes{"bold": true}},
+	}
+	if got := txt.ToDelta(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToDelta() = %#v, want %#v", got, want)
+	}
+}
+
+// TestApplyDelta_PlainInsertThenRetainFormatStaysInOrder covers a plain
+// insert immediately followed by a {retain, attributes} op. Before the fix,
+// the retain-with-attributes op (applyFormatAtPos) would resolve its range
+// starting from the stale pos.left/pos.right, formatting the wrong span
+// (potentially re-covering the just-inserted item, or the wrong following
+// content) instead of the content that actually follows the insert.
+func TestApplyDelta_PlainInsertThenRetainFormatStaysInOrder(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) {
+		txt.Insert(tr, 0, "xyz", nil)
+		txt.ApplyDelta(tr, []Delta{
+			{Op: DeltaOpInsert, Insert: "a"},
+			{Op: DeltaOpRetain, Retain: 1, Attributes: Attributes{"bold": true}},
+		})
+	})
+
+	if got := txt.ToString(); got != "axyz" {
+		t.Fatalf("ToString() = %q, want %q", got, "axyz")
+	}
+
+	want := []Delta{
+		{Op: DeltaOpInsert, Insert: "a"},
+		{Op: DeltaOpInsert, Insert: "x", Attributes: Attributes{"bold": true}},
+		{Op: DeltaOpInsert, Insert: "yz"},
+	}
+	if got := txt.ToDelta(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToDelta() = %#v, want %#v", got, want)
+	}
+}

--- a/crdt/bench_test.go
+++ b/crdt/bench_test.go
@@ -2,6 +2,8 @@ package crdt
 
 import (
 	"fmt"
+	"math/rand"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -299,5 +301,378 @@ func BenchmarkConcurrentSamePositionInsert(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Search-marker proving harness (Task 8, #181).
+//
+// Tasks 1-7 replaced the old forward-only posCache with a move-aware,
+// Yjs-style search marker (crdt/search_marker.go). abstractType.disableMarkers
+// is the test seam those tasks added: forcing it true makes every positional
+// lookup fall back to the pre-marker full linear walk from t.start, exactly
+// as it behaved before. Every benchmark below runs the identical workload
+// twice — once with markers live (the "_Markers" variant) and once with
+// disableMarkers forced true (the "_Cold" variant) — so the ns/op columns
+// are a direct, apples-to-apples measurement of the speedup those tasks
+// claim, on the shapes that used to be O(n) per op (random access) or
+// O(n^2) over a growing/shrinking document (many such ops in a row).
+//
+// Base documents are always CONSTRUCTED with markers enabled — disableMarkers
+// is flipped only afterward, immediately before the timed section. This
+// keeps setup cost identical (and cheap) between the two variants; building
+// a large fragmented document with disableMarkers forced from the start
+// would itself be the O(n^2) cold walk the benchmark exists to measure,
+// which would make the 100k builds impractically slow.
+// ---------------------------------------------------------------------------
+
+// buildFragmentedTextDoc builds a YText of exactly target characters by
+// inserting one character at a time at a random position, each in its own
+// transaction. Two things matter about this shape:
+//
+//   - One transaction per character means squashRuns (transaction.go) — which
+//     only merges items created within the SAME transaction — never collapses
+//     them back together, so the linked list stays genuinely fragmented into
+//     target separate Items. That is what makes a cold linear walk from
+//     t.start expensive.
+//   - Every item has length exactly 1, so a later Insert at any position
+//     always lands ON an item boundary (leftNeighbourAt's offset is always
+//     == len) and never INSIDE the middle of a multi-character item. That
+//     matters: a mid-item insert forces splitItem, which itself conservatively
+//     clears every marker (item.go's splitItem doc comment) and does an O(store
+//     size) StructStore.insertItem slice-shift — a cost that has nothing to do
+//     with search markers but would otherwise dominate and mask the very
+//     speedup these benchmarks exist to measure. Single-character items avoid
+//     that confound entirely, isolating the position-lookup cost.
+//
+// Markers are left enabled during this build (the default zero value of
+// disableMarkers), keeping construction fast regardless of which variant
+// calls it.
+func buildFragmentedTextDoc(target int, seed int64) (*Doc, *YText) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("text")
+	rng := rand.New(rand.NewSource(seed))
+	for i := 0; i < target; i++ {
+		pos := rng.Intn(txt.Len() + 1)
+		doc.Transact(func(txn *Transaction) {
+			txt.Insert(txn, pos, "a", nil)
+		})
+	}
+	return doc, txt
+}
+
+// buildFragmentedArrayDoc builds a YArray of exactly target elements
+// (values 0..target-1, each its own Insert call at a random position), the
+// YArray counterpart of buildFragmentedTextDoc above.
+func buildFragmentedArrayDoc(target int, seed int64) (*Doc, *YArray) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("arr")
+	rng := rand.New(rand.NewSource(seed))
+	for i := 0; i < target; i++ {
+		pos := rng.Intn(arr.Len() + 1)
+		doc.Transact(func(txn *Transaction) {
+			arr.Insert(txn, pos, []any{i})
+		})
+	}
+	return doc, arr
+}
+
+// benchInsertRandom measures inserting a single character at a
+// uniformly-random position on every iteration — the classic O(n)-per-op
+// cold case, since a linear walk from t.start must cross, on average, half
+// the document to resolve a random target index.
+func benchInsertRandom(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	doc, txt := buildFragmentedTextDoc(n, int64(n)+1)
+	txt.baseType().disableMarkers = cold
+	rng := rand.New(rand.NewSource(int64(n) + 2))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pos := rng.Intn(txt.Len() + 1)
+		doc.Transact(func(txn *Transaction) {
+			txt.Insert(txn, pos, "x", nil)
+		})
+	}
+}
+
+// benchInsertReverse measures inserting characters at a cursor that walks
+// BACKWARD one position per iteration through a large pre-existing document
+// (decrementing from txt.Len() toward 0, wrapping back to the end when it
+// hits bottom). This is the adversarial case for a forward-only cache: each
+// new target is strictly less than the previous one, so a cache that only
+// ever remembers "the last position, moving forward" is useless here and
+// every op degrades to a full cold walk. The move-aware marker this task
+// benchmarks resolves it in O(1) per step instead, via walkLeftFrom from the
+// marker installed one position to the right on the previous iteration —
+// this is exactly the "move-aware" (bidirectional) property Tasks 1-7 added
+// over the old posCache.
+func benchInsertReverse(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	doc, txt := buildFragmentedTextDoc(n, int64(n)+3)
+	txt.baseType().disableMarkers = cold
+	cursor := txt.Len()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if cursor < 0 {
+			cursor = txt.Len()
+		}
+		pos := cursor
+		doc.Transact(func(txn *Transaction) {
+			txt.Insert(txn, pos, "x", nil)
+		})
+		cursor--
+	}
+}
+
+// benchArrayGetRandom measures YArray.Get at a uniformly-random index on
+// every iteration — the YArray counterpart of benchInsertRandom. Get must be
+// called outside Transact (it takes its own read lock).
+func benchArrayGetRandom(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	doc, arr := buildFragmentedArrayDoc(n, int64(n)+4)
+	_ = doc
+	arr.baseType().disableMarkers = cold
+	rng := rand.New(rand.NewSource(int64(n) + 5))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx := rng.Intn(arr.Len())
+		_ = arr.Get(idx)
+	}
+}
+
+// benchDeleteRangeTail measures deleting a small chunk from just before the
+// end of a large document on every iteration. The tail is the position
+// farthest from t.start, so a cold walk must cross the entire document to
+// reach it every single time.
+func benchDeleteRangeTail(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	const chunk = 3
+	doc, txt := buildFragmentedTextDoc(n, int64(n)+6)
+	txt.baseType().disableMarkers = cold
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l := txt.Len()
+		if l <= chunk {
+			break
+		}
+		pos := l - chunk
+		doc.Transact(func(txn *Transaction) {
+			txt.Delete(txn, pos, chunk)
+		})
+	}
+}
+
+// benchDeleteRangeRandom measures deleting a small chunk at a
+// uniformly-random position on every iteration.
+func benchDeleteRangeRandom(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	const chunk = 3
+	doc, txt := buildFragmentedTextDoc(n, int64(n)+7)
+	txt.baseType().disableMarkers = cold
+	rng := rand.New(rand.NewSource(int64(n) + 8))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l := txt.Len()
+		if l <= chunk {
+			break
+		}
+		pos := rng.Intn(l - chunk)
+		doc.Transact(func(txn *Transaction) {
+			txt.Delete(txn, pos, chunk)
+		})
+	}
+}
+
+// benchApplyDelta measures applying a multi-op (retain/delete/insert) delta
+// — the same shape a rich-text editor emits for a single user edit — to a
+// large document on every iteration. ApplyDelta advances a single running
+// cursor through its ops (search_marker_test.go's Task 4 header comment),
+// so this exercises the marker-accelerated cursor advance across a Retain
+// large enough to force a real positional jump on a big document.
+func benchApplyDelta(b *testing.B, n int, cold bool) {
+	b.ReportAllocs()
+
+	const insertStr = "the quick brown fox jumps"
+	const delChunk = 5
+	doc, txt := buildFragmentedTextDoc(n, int64(n)+9)
+	txt.baseType().disableMarkers = cold
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l := txt.Len()
+		retain := l / 2
+		del := delChunk
+		if retain+del > l {
+			del = 0
+		}
+		delta := []Delta{
+			{Op: DeltaOpRetain, Retain: retain},
+			{Op: DeltaOpDelete, Delete: del},
+			{Op: DeltaOpInsert, Insert: insertStr},
+		}
+		doc.Transact(func(txn *Transaction) {
+			txt.ApplyDelta(txn, delta)
+		})
+	}
+}
+
+func BenchmarkSearchMarker_InsertRandom_1k_Markers(b *testing.B) { benchInsertRandom(b, 1_000, false) }
+func BenchmarkSearchMarker_InsertRandom_1k_Cold(b *testing.B)    { benchInsertRandom(b, 1_000, true) }
+func BenchmarkSearchMarker_InsertRandom_100k_Markers(b *testing.B) {
+	benchInsertRandom(b, 100_000, false)
+}
+func BenchmarkSearchMarker_InsertRandom_100k_Cold(b *testing.B) { benchInsertRandom(b, 100_000, true) }
+
+func BenchmarkSearchMarker_InsertReverse_1k_Markers(b *testing.B) {
+	benchInsertReverse(b, 1_000, false)
+}
+func BenchmarkSearchMarker_InsertReverse_1k_Cold(b *testing.B) { benchInsertReverse(b, 1_000, true) }
+func BenchmarkSearchMarker_InsertReverse_100k_Markers(b *testing.B) {
+	benchInsertReverse(b, 100_000, false)
+}
+func BenchmarkSearchMarker_InsertReverse_100k_Cold(b *testing.B) {
+	benchInsertReverse(b, 100_000, true)
+}
+
+func BenchmarkSearchMarker_ArrayGetRandom_1k_Markers(b *testing.B) {
+	benchArrayGetRandom(b, 1_000, false)
+}
+func BenchmarkSearchMarker_ArrayGetRandom_1k_Cold(b *testing.B) {
+	benchArrayGetRandom(b, 1_000, true)
+}
+func BenchmarkSearchMarker_ArrayGetRandom_100k_Markers(b *testing.B) {
+	benchArrayGetRandom(b, 100_000, false)
+}
+func BenchmarkSearchMarker_ArrayGetRandom_100k_Cold(b *testing.B) {
+	benchArrayGetRandom(b, 100_000, true)
+}
+
+func BenchmarkSearchMarker_DeleteRangeTail_1k_Markers(b *testing.B) {
+	benchDeleteRangeTail(b, 1_000, false)
+}
+func BenchmarkSearchMarker_DeleteRangeTail_1k_Cold(b *testing.B) {
+	benchDeleteRangeTail(b, 1_000, true)
+}
+func BenchmarkSearchMarker_DeleteRangeTail_100k_Markers(b *testing.B) {
+	benchDeleteRangeTail(b, 100_000, false)
+}
+func BenchmarkSearchMarker_DeleteRangeTail_100k_Cold(b *testing.B) {
+	benchDeleteRangeTail(b, 100_000, true)
+}
+
+func BenchmarkSearchMarker_DeleteRangeRandom_1k_Markers(b *testing.B) {
+	benchDeleteRangeRandom(b, 1_000, false)
+}
+func BenchmarkSearchMarker_DeleteRangeRandom_1k_Cold(b *testing.B) {
+	benchDeleteRangeRandom(b, 1_000, true)
+}
+func BenchmarkSearchMarker_DeleteRangeRandom_100k_Markers(b *testing.B) {
+	benchDeleteRangeRandom(b, 100_000, false)
+}
+func BenchmarkSearchMarker_DeleteRangeRandom_100k_Cold(b *testing.B) {
+	benchDeleteRangeRandom(b, 100_000, true)
+}
+
+func BenchmarkSearchMarker_ApplyDelta_1k_Markers(b *testing.B) { benchApplyDelta(b, 1_000, false) }
+func BenchmarkSearchMarker_ApplyDelta_1k_Cold(b *testing.B)    { benchApplyDelta(b, 1_000, true) }
+func BenchmarkSearchMarker_ApplyDelta_100k_Markers(b *testing.B) {
+	benchApplyDelta(b, 100_000, false)
+}
+func BenchmarkSearchMarker_ApplyDelta_100k_Cold(b *testing.B) { benchApplyDelta(b, 100_000, true) }
+
+// ---------------------------------------------------------------------------
+// Light correctness re-assertion for the helpers above.
+//
+// search_marker_test.go already carries heavy, dedicated fuzz-style coverage
+// proving markers agree with the cold oracle across inserts, deletes, Get,
+// Slice, and ApplyDelta. The two tests below are deliberately light — they
+// exist only to guard the NEW builder/workload helpers in this file (which
+// are not exercised anywhere else) against a silent divergence, so a benchmark
+// showing "markers are faster" is never quietly measuring two paths that
+// disagree.
+// ---------------------------------------------------------------------------
+
+// TestBenchSearchMarker_TextHelpersMatchCold runs the exact insert-random,
+// insert-reverse, delete-range, and ApplyDelta sequences the benchmarks above
+// use — once with markers enabled, once with disableMarkers forced — and
+// asserts the resulting document text is byte-identical either way.
+func TestBenchSearchMarker_TextHelpersMatchCold(t *testing.T) {
+	const n = 2000
+	run := func(cold bool) string {
+		doc, txt := buildFragmentedTextDoc(n, 99)
+		txt.baseType().disableMarkers = cold
+
+		rng := rand.New(rand.NewSource(100))
+		for i := 0; i < 200; i++ {
+			pos := rng.Intn(txt.Len() + 1)
+			doc.Transact(func(txn *Transaction) { txt.Insert(txn, pos, "x", nil) })
+		}
+
+		cursor := txt.Len()
+		for i := 0; i < 200; i++ {
+			if cursor < 0 {
+				cursor = txt.Len()
+			}
+			pos := cursor
+			doc.Transact(func(txn *Transaction) { txt.Insert(txn, pos, "y", nil) })
+			cursor--
+		}
+
+		for i := 0; i < 50; i++ {
+			l := txt.Len()
+			if l <= 5 {
+				break
+			}
+			pos := rng.Intn(l - 5)
+			doc.Transact(func(txn *Transaction) { txt.Delete(txn, pos, 5) })
+		}
+
+		l := txt.Len()
+		retain := l / 2
+		doc.Transact(func(txn *Transaction) {
+			txt.ApplyDelta(txn, []Delta{
+				{Op: DeltaOpRetain, Retain: retain},
+				{Op: DeltaOpDelete, Delete: 5},
+				{Op: DeltaOpInsert, Insert: "zzz"},
+			})
+		})
+		return txt.ToString()
+	}
+
+	got, want := run(false), run(true)
+	if got != want {
+		t.Fatalf("marker/cold divergence: len(got)=%d len(want)=%d", len(got), len(want))
+	}
+}
+
+// TestBenchSearchMarker_ArrayGetHelperMatchesCold is the YArray.Get
+// counterpart of the text test above.
+func TestBenchSearchMarker_ArrayGetHelperMatchesCold(t *testing.T) {
+	const n = 2000
+	idxs := []int{0, 1, 999, 1000, 1999}
+	run := func(cold bool) []any {
+		doc, arr := buildFragmentedArrayDoc(n, 101)
+		_ = doc
+		arr.baseType().disableMarkers = cold
+		out := make([]any, 0, len(idxs))
+		for _, idx := range idxs {
+			out = append(out, arr.Get(idx))
+		}
+		return out
+	}
+
+	got, want := run(false), run(true)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("marker/cold divergence:\n got  %v\n want %v", got, want)
 	}
 }

--- a/crdt/cache_invalidation_test.go
+++ b/crdt/cache_invalidation_test.go
@@ -35,15 +35,15 @@ func TestFirstLiveCache_StaleAfterInsertAfterTombstone(t *testing.T) {
 		"Delete after insert-past-tombstone must use the live head, not a stale firstLiveCache")
 }
 
-// TestPosCache_StaleAfterRemoteDeleteOnlyApply is #70 residual class 2 — a
+// TestSearchMarker_StaleAfterRemoteDeleteOnlyApply is #70 residual class 2 — a
 // pre-existing bug independent of the YText fix.
 //
 // transactInternal hardcodes txn.Local=true even for ApplyUpdate, so
-// item.delete's posCache-clearing branch (`if !txn.Local`) is dead during
-// remote applies, and applyToPartial never invalidates posCache. A remote
-// update that only tombstones an item leaves posCache stale, so the next local
-// positioned insert resolves the wrong neighbour.
-func TestPosCache_StaleAfterRemoteDeleteOnlyApply(t *testing.T) {
+// item.delete's marker-clearing branch (`if !txn.Local`) is dead during
+// remote applies, and applyToPartial never invalidates the search-marker
+// cache. A remote update that only tombstones an item leaves stale markers
+// behind, so the next local positioned insert resolves the wrong neighbour.
+func TestSearchMarker_StaleAfterRemoteDeleteOnlyApply(t *testing.T) {
 	docA := New(WithClientID(1))
 	arrA := docA.GetArray("a")
 	docA.Transact(func(txn *Transaction) {
@@ -56,11 +56,11 @@ func TestPosCache_StaleAfterRemoteDeleteOnlyApply(t *testing.T) {
 	require.NoError(t, ApplyUpdateV1(docB, EncodeStateAsUpdateV1(docA, nil), nil))
 	arrB := docB.GetArray("a")
 
-	// Populate docB's posCache with a positioned insert near the end, so live
-	// items AFTER the soon-deleted "B" (namely C@3, D@4) get cached. -> [A B C D X E]
+	// Populate docB's search markers with a positioned insert near the end, so
+	// live items AFTER the soon-deleted "B" (namely C@3, D@4) get cached. -> [A B C D X E]
 	docB.Transact(func(txn *Transaction) { arrB.Insert(txn, 4, []any{"X"}) })
 
-	// docA deletes "B"; ship ONLY that delete to docB. The cached C/D entries
+	// docA deletes "B"; ship ONLY that delete to docB. The cached C/D markers
 	// stay LIVE but their cumulative index is now off by one.
 	var delUpdate []byte
 	docA.OnUpdate(func(u []byte, _ any) { delUpdate = u })
@@ -73,7 +73,7 @@ func TestPosCache_StaleAfterRemoteDeleteOnlyApply(t *testing.T) {
 	got, err := arrB.ToJSON()
 	require.NoError(t, err)
 	require.JSONEq(t, `["A","C","D","Y","X","E"]`, string(got),
-		"positioned insert after a remote delete-only apply must not use a stale posCache")
+		"positioned insert after a remote delete-only apply must not use a stale search marker")
 }
 
 func mustText(t *testing.T, d *Doc, name string) string {

--- a/crdt/coverage_test.go
+++ b/crdt/coverage_test.go
@@ -1497,22 +1497,23 @@ func TestUnit_SearchMarker_LargeDocEndAppend(t *testing.T) {
 	assert.Equal(t, total+1, txtDst.Len())
 }
 
-// ── invalidatePosCacheFrom: keeps lower-index entries ────────────────────────
+// ── search-marker position lookup after partial invalidation ────────────────
 
-func TestUnit_InvalidatePosCacheFrom_KeepsLowerEntries(t *testing.T) {
+func TestUnit_SearchMarker_PartialInvalidation_KeepsLowerMarkers(t *testing.T) {
 	// Build two separate ContentString items so leftNeighbourAt stores two
-	// cache entries. Then insert at a position that invalidates only the higher
-	// one, exercising the "posCache[n] = posCache[i]" keep path.
+	// search markers. Then insert at a position that invalidates only the
+	// higher-index marker, exercising the marker-cache "keep entries below the
+	// invalidation point" path.
 	doc := newTestDoc(1)
 	txt := doc.GetText("t")
 	// Two separate transactions → two separate items after squashRuns.
 	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "abc", nil) })
 	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 3, "def", nil) })
-	// Insert at index 4 → leftNeighbourAt(4) scans both items and stores:
-	//   (3, item_abc) and (6, item_def) in the cache.
-	// integrate then calls invalidatePosCacheFrom(4):
-	//   entry (3, item_abc): 3 < 4 → KEPT   ← exercises the keep path
-	//   entry (6, item_def): 6 >= 4 → dropped
+	// Insert at index 4 → leftNeighbourAt(4) scans both items and stores search
+	// markers at (3, item_abc) and (6, item_def).
+	// integrate then invalidates markers from index 4:
+	//   marker (3, item_abc): 3 < 4 → KEPT   ← exercises the keep path
+	//   marker (6, item_def): 6 >= 4 → dropped
 	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 4, "X", nil) })
 	assert.Equal(t, 7, txt.Len())
 }

--- a/crdt/coverage_test.go
+++ b/crdt/coverage_test.go
@@ -1468,34 +1468,30 @@ func TestUnit_RelPos_AssocNeg_AtLastItem(t *testing.T) {
 	require.NotNil(t, rp.Item, "should anchor to last item's clock")
 }
 
-// ── storePosCache: circular-overwrite wrap (posCacheWr resets to 0) ──────────
+// ── search-marker cache: large sequential doc + end append ───────────────────
 
-func TestUnit_StorePosCache_CircularWrap(t *testing.T) {
-	// storePosCache's circular-overwrite path is only triggered when the cache
-	// is already FULL (posCacheLen==posLRUSize) and ONE MORE call is made.
-	// That requires a leftNeighbourAt scan of posLRUSize*2+1 items starting
-	// from an empty cache (i.e. after a remote apply, which doesn't populate
-	// the cache).
-	//
-	// Build a doc with posLRUSize*2+2 single-char items from client 2.
+func TestUnit_SearchMarker_LargeDocEndAppend(t *testing.T) {
+	// Regression carried over from the old posCache circular-wrap test: build a
+	// long document from many single-char items (well past maxSearchMarker so
+	// the marker cache saturates and starts evicting), apply it remotely (which
+	// clears markers), then a positioned append must still resolve correctly.
 	docSrc := newTestDoc(2)
 	txtSrc := docSrc.GetText("t")
-	total := posLRUSize*2 + 2
+	total := maxSearchMarker*2 + 2
 	for i := 0; i < total; i++ {
 		n := txtSrc.Len()
 		docSrc.Transact(func(txn *Transaction) { txtSrc.Insert(txn, n, "x", nil) })
 	}
 
-	// Apply remotely to docDst — leaves cache empty.
+	// Apply remotely to docDst — invalidatePosCache (→ clearMarkers) leaves the
+	// marker cache empty.
 	v1 := EncodeStateAsUpdateV1(docSrc, nil)
 	docDst := newTestDoc(1)
 	require.NoError(t, ApplyUpdateV1(docDst, v1, nil))
 
-	// Insert at the very end: leftNeighbourAt(total) scans all `total` items
-	// from start (cache is empty after remote apply). The first posLRUSize
-	// calls fill the cache; the next posLRUSize calls do circular writes
-	// (posCacheWr: 0→posLRUSize-1); the (2*posLRUSize+1)th call increments
-	// posCacheWr to posLRUSize → triggers the `posCacheWr = 0` wrap.
+	// Insert at the very end: leftNeighbourAt(total) walks from start (markers
+	// empty after remote apply), saturating and LRU-evicting markers along the
+	// way, and must resolve the append correctly.
 	txtDst := docDst.GetText("t")
 	docDst.Transact(func(txn *Transaction) { txtDst.Insert(txn, total, "Z", nil) })
 	assert.Equal(t, total+1, txtDst.Len())

--- a/crdt/delete_set.go
+++ b/crdt/delete_set.go
@@ -144,15 +144,19 @@ func (ds *DeleteSet) applyToPartial(txn *Transaction) DeleteSet {
 					end = itemEnd
 				}
 				item.delete(txn)
-				// Remote applies run with txn.Local==true (transactInternal
-				// hardcodes it), so item.delete's own posCache invalidation
-				// (guarded on !txn.Local) is dead here — and unlike local
-				// deleteRange, this path never cleared the cache. A stale
-				// posCache would then mis-resolve the next local positioned
-				// insert, since cached (index→item) entries for still-live items
-				// after the tombstone now carry an index that is too high (#160).
+				// Search-marker invalidation for the remote delete-apply path
+				// (the v1.31.6 stale-cache class, #181). Remote applies run with
+				// txn.Local==true (transactInternal hardcodes it), so
+				// item.delete's own marker invalidation (guarded on !txn.Local)
+				// is dead here. The rendered index of the tombstoned item is not
+				// tracked by this delete-set walk, so a precise
+				// updateMarkerChanges(index, -len) is not available — we clear all
+				// markers, which is always safe (the next lookup repopulates via a
+				// cold walk). Without this, still-live markers after the tombstone
+				// would keep an index that is now too high and mis-resolve the next
+				// local positioned insert (#160).
 				if item.Parent != nil && item.Content.IsCountable() {
-					item.Parent.invalidatePosCache()
+					item.Parent.clearMarkers()
 				}
 				applied = end - r.Clock
 			}

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -199,26 +199,25 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 		item.Right.Left = item
 	}
 
-	// Update logical length and, if necessary, invalidate the position cache.
-	// When the item is appended at the end (item.Right == nil), all existing
-	// cache entries remain valid — no previously-cached position shifts.
-	// For middle insertions we must discard cache entries at and after the
-	// insertion point. When the caller set insertHint (local inserts where the
-	// logical index is known) we do a partial clear, preserving entries before
-	// the hint position so the next nearby lookup can resume from a cache hit
-	// rather than rescanning from t.start. For remote updates (no hint) we fall
-	// back to a full clear.
+	// Update logical length and maintain the search markers (G1). When the item
+	// is appended at the end (item.Right == nil), no previously-cached position
+	// shifts, so markers stay valid untouched. For a middle insertion with a
+	// known local index (insertHint), updateMarkerChanges shifts every marker at
+	// or after the insertion point right by the inserted length while preserving
+	// markers before it — so a subsequent nearby lookup still gets a cache hit.
+	// For hintless middle insertions (remote applies, where the rendered index
+	// is not known here) we conservatively clear all markers.
 	if !item.Deleted && item.Content.IsCountable() {
 		item.Parent.length += item.Content.Len()
 		if item.Right != nil {
 			if hint := item.Parent.insertHint; hint > 0 {
 				item.Parent.insertHint = 0
-				item.Parent.invalidatePosCacheFrom(hint)
+				item.Parent.updateMarkerChanges(hint, item.Content.Len())
 			} else {
-				item.Parent.invalidatePosCache()
+				item.Parent.clearMarkers()
 			}
 		} else {
-			item.Parent.insertHint = 0 // reset even on end-append (no cache action needed)
+			item.Parent.insertHint = 0 // end-append: markers before the end stay valid.
 		}
 	}
 
@@ -350,11 +349,16 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 // delete marks this item as a tombstone. The item stays in the linked list so
 // that position references from other items (via Origin) remain valid.
 //
-// Cache invalidation strategy: for remote transactions (txn.Local == false)
-// we clear the entire posCache here because the caller doesn't know the
-// logical position. For local transactions the caller (e.g., deleteRange)
-// is responsible for calling invalidatePosCacheFrom before scanning, so we
-// skip the redundant full clear to avoid O(n²) behaviour.
+// Search-marker invalidation strategy: for remote transactions
+// (txn.Local == false) we clear all markers here because the caller doesn't
+// know the rendered position of the deleted item. For local transactions the
+// caller (deleteRange) performs the precise updateMarkerChanges(index, -len)
+// once, after tombstoning the range, so we skip any per-item work here (also
+// avoiding O(n²) clears across a multi-item delete). NOTE: transactInternal
+// hardcodes txn.Local=true even for remote applies, so this branch is dead on
+// the ApplyUpdate path — the remote delete-apply invalidation lives in
+// delete_set.go (applyToPartial). This branch only fires for the rare direct
+// item.delete under an explicitly non-local transaction.
 //
 // Cascade: when this item wraps a ContentType (nested YMap/YArray/YText/…),
 // every child item is recursively deleted so the delete-set encoded on the
@@ -370,7 +374,7 @@ func (item *Item) delete(txn *Transaction) {
 	if item.Parent != nil && item.Content.IsCountable() {
 		item.Parent.length -= item.Content.Len()
 		if !txn.Local {
-			item.Parent.invalidatePosCache()
+			item.Parent.clearMarkers()
 		}
 	}
 	txn.deleteSet.add(item.ID, item.Content.Len())
@@ -421,11 +425,17 @@ func splitItem(txn *Transaction, item *Item, offset int) *Item {
 	}
 	item.Right = right
 	txn.doc.store.insertItem(right)
-	// The split shortens item's content, invalidating any cached boundary that
-	// pointed to item's old end position. Clear the entire position cache so
-	// subsequent leftNeighbourAt calls re-scan rather than using stale entries.
+	// A split does not move any rendered position — the two halves occupy exactly
+	// the range the original item did, and a marker pointing at the original
+	// (now-left) half keeps a correct rendered start (renderedStep recomputes its
+	// shortened length on the fly). So finer maintenance is unnecessary here; we
+	// nonetheless clear all markers, conservatively, because a split is a
+	// structural rewrite and clearing is always safe (correctness over reuse; a
+	// future task may relax this to a no-op). Clearing here also means the
+	// deleteRange updateMarkerChanges below operates on an empty set whenever a
+	// boundary split occurred — still correct.
 	if item.Parent != nil {
-		item.Parent.invalidatePosCache()
+		item.Parent.clearMarkers()
 	}
 	// #78 H2 — track the right half so tryMergeWithLefts can reverse the split
 	// at transaction commit if no item ends up inserted between the two halves.

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -265,6 +265,15 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 		}
 	}
 
+	// Yjs parity note: once any ContentMove item is integrated into this type,
+	// mark hasMoves so YArray.Get/Slice know the marker-based fast path
+	// (search_marker.go's renderedStep, which is move-oblivious) can no
+	// longer be trusted and must fall back to the full move-aware walk. See
+	// the hasMoves doc comment on abstractType (abstract_type.go).
+	if _, ok := item.Content.(*ContentMove); ok && item.Parent != nil {
+		item.Parent.hasMoves = true
+	}
+
 	// Track ContentString items for end-of-transaction run squashing.
 	if _, ok := item.Content.(*ContentString); ok {
 		txn.newItems = append(txn.newItems, item)

--- a/crdt/item.go
+++ b/crdt/item.go
@@ -265,13 +265,18 @@ func (item *Item) integrate(txn *Transaction, offset int) {
 		}
 	}
 
-	// Yjs parity note: once any ContentMove item is integrated into this type,
-	// mark hasMoves so YArray.Get/Slice know the marker-based fast path
-	// (search_marker.go's renderedStep, which is move-oblivious) can no
-	// longer be trusted and must fall back to the full move-aware walk. See
-	// the hasMoves doc comment on abstractType (abstract_type.go).
+	// Search-marker invalidation for moves (G5). renderedStep is fully
+	// move-aware, so markers CAN accelerate move-containing arrays — but a
+	// ContentMove changes rendered positions in a way the insertHint shift
+	// above cannot express: it is non-countable (so the length/marker block was
+	// skipped for it entirely) yet its arbitration re-renders the target at the
+	// destination and blanks the target's original slot. Any cached marker may
+	// now report a stale rendered start, so clear them all. Clearing is always
+	// safe (a subsequent lookup repopulates via a cold walk) and moves are rare
+	// enough that a full clear per move is acceptable. Covers both a fresh move
+	// and a re-arbitration that changes which move wins a target.
 	if _, ok := item.Content.(*ContentMove); ok && item.Parent != nil {
-		item.Parent.hasMoves = true
+		item.Parent.clearMarkers()
 	}
 
 	// Track ContentString items for end-of-transaction run squashing.
@@ -383,6 +388,21 @@ func (item *Item) delete(txn *Transaction) {
 	if item.Parent != nil && item.Content.IsCountable() {
 		item.Parent.length -= item.Content.Len()
 		if !txn.Local {
+			item.Parent.clearMarkers()
+		}
+	}
+	// Move-related deletes change rendered positions in ways the plain
+	// updateMarkerChanges index-shift can't model (G5): tombstoning a
+	// ContentMove stops it rendering its target at the destination (the target
+	// may re-render at its origin), and tombstoning a moved-away item removes a
+	// rendered position at the destination rather than at the item's physical
+	// slot. Either way, clear all markers — always safe, and independent of
+	// txn.Local since local move-deletes also take this path. ContentMove is
+	// non-countable, so the block above never runs for it.
+	if item.Parent != nil {
+		if _, ok := item.Content.(*ContentMove); ok {
+			item.Parent.clearMarkers()
+		} else if item.MovedBy != nil {
 			item.Parent.clearMarkers()
 		}
 	}

--- a/crdt/search_marker.go
+++ b/crdt/search_marker.go
@@ -1,0 +1,172 @@
+package crdt
+
+// maxSearchMarker is the maximum number of search markers cached per
+// abstractType, matching the value used by the Yjs reference implementation
+// (ArraySearchMarker). A small fixed cap keeps the nearest-marker scan O(1)
+// while still giving good hit rates for typical access patterns (sequential
+// edits, cursor-local edits, etc).
+const maxSearchMarker = 80
+
+// searchMarker pins a rendered position (index) to the item that starts at
+// that position, plus a timestamp used by later tasks for LRU-style
+// eviction/refresh policy. Task 1 only defines the struct and a read-only
+// lookup; nothing yet writes to t.markers (that lands in later tasks that
+// replace posCache).
+type searchMarker struct {
+	item      *Item
+	index     int
+	timestamp uint64
+}
+
+// renderedStep reports how a single item contributes to rendered (visible)
+// position. This is the single shared definition of position-contribution
+// used by marker-based lookups.
+//
+// Task 1 ships the non-move version: a deleted item contributes nothing, and
+// a countable, non-deleted item contributes its Content.Len(); everything
+// else (formatting marks, moves, non-countable content) contributes 0.
+// renderAt is reserved for move-awareness (Task 5), where a moved item's
+// rendered contribution is attributed to a different item than the one being
+// stepped over; until then it is always nil.
+func (t *abstractType) renderedStep(item *Item) (countable bool, n int, renderAt *Item) {
+	if item == nil || item.Deleted || !item.Content.IsCountable() {
+		return false, 0, nil
+	}
+	return true, item.Content.Len(), nil
+}
+
+// findMarkerRO returns the item spanning the rendered position index, along
+// with the rendered start index of that item (the cumulative rendered length
+// of everything strictly before it). It is read-only: it never writes to
+// t.markers, t.markerTimestamp, or any other field — later tasks add
+// concurrent-reader tests that call this under an RLock, so mutating the
+// marker cache here would be a data race.
+//
+// Returns (nil, 0) for index<=0 or an empty type.
+//
+// When t.markers is empty or t.disableMarkers is set (the force-cold test
+// seam), this walks from t.start exactly like the marker-free oracle. When
+// markers are present, it starts from the nearest existing marker (by
+// |marker.index-index|, a linear scan over at most maxSearchMarker entries)
+// and walks right or left from there via renderedStep, accumulating rendered
+// length until the target index is bracketed.
+func (t *abstractType) findMarkerRO(index int) (*Item, int) {
+	if index <= 0 {
+		return nil, 0
+	}
+	if t.disableMarkers || len(t.markers) == 0 {
+		return t.walkColdFrom(t.start, 0, index)
+	}
+
+	// Find the nearest existing marker by |marker.index - index|.
+	best := -1
+	bestDist := 0
+	for i, m := range t.markers {
+		if m.item == nil {
+			continue
+		}
+		dist := m.index - index
+		if dist < 0 {
+			dist = -dist
+		}
+		if best == -1 || dist < bestDist {
+			best = i
+			bestDist = dist
+		}
+	}
+	if best == -1 {
+		return t.walkColdFrom(t.start, 0, index)
+	}
+
+	m := t.markers[best]
+	// The marker's item must itself be a valid (countable, non-deleted)
+	// anchor — that is the only kind of item the oracle ever returns, so a
+	// well-formed marker always points at one. If it doesn't (a stale
+	// marker), fall back to a full cold walk rather than risk a wrong
+	// answer.
+	countable, n, _ := t.renderedStep(m.item)
+	if !countable {
+		return t.walkColdFrom(t.start, 0, index)
+	}
+
+	// end is the rendered index immediately after m.item (i.e. the start of
+	// whatever the oracle's forward scan would look at next). Comparing
+	// index against end — not against m.index — is what correctly captures
+	// the oracle's left-to-right tie-breaking rule: when index lands
+	// exactly on the boundary between two items, the oracle's forward scan
+	// reaches (and returns) the EARLIER item first, because that item's
+	// "counted+n >= index" check fires before the later item is ever
+	// examined. See walkLeftFrom for why walking left handles that case
+	// correctly with a single pass (no need to re-check further left after
+	// stepping once past the tie).
+	end := m.index + n
+	if end >= index {
+		return t.walkLeftFrom(m.item, m.index, index)
+	}
+	// end < index: the target is strictly after m.item; every item up to
+	// and including m.item is guaranteed not to satisfy the oracle's
+	// condition (rendered length is monotonically non-decreasing along the
+	// list), so resuming the forward scan at m.item.Right with counted=end
+	// exactly replicates continuing the oracle's loop from t.start.
+	return t.walkColdFrom(m.item.Right, end, index)
+}
+
+// walkColdFrom walks Right starting at "from" (which starts at rendered
+// position "counted"), accumulating rendered length via renderedStep until
+// the target index is bracketed. This is exactly the oracle's algorithm,
+// just allowed to resume mid-list from an already-known-correct starting
+// point instead of always starting at t.start. It never writes to t.markers.
+func (t *abstractType) walkColdFrom(from *Item, counted int, index int) (*Item, int) {
+	for item := from; item != nil; item = item.Right {
+		countable, n, _ := t.renderedStep(item)
+		if !countable {
+			continue
+		}
+		if counted+n >= index {
+			return item, counted
+		}
+		counted += n
+	}
+	return nil, counted
+}
+
+// walkLeftFrom returns the leftmost (earliest, in list order) countable
+// non-deleted item that brackets index, given a starting candidate "cur"
+// already known to satisfy end(cur) = curS + len(cur) >= index (curS is
+// cur's own rendered start index, i.e. renderedStart(cur) == curS). It never
+// writes to t.markers.
+//
+// Because every countable, non-deleted item has length >= 1, rendered start
+// indices strictly increase from one countable item to the next, so at most
+// one predecessor step is ever needed to resolve an exact-boundary tie
+// (index == the current best's start): stepping to the immediately
+// preceding countable item (skipping over any deleted/non-countable items,
+// whose contribution is 0 and so don't shift the start index) always drops
+// the start index strictly below index, terminating the walk. The general
+// (non-tie, curS > index) case just repeats the same single-step logic
+// until the current best's start index falls below index.
+func (t *abstractType) walkLeftFrom(cur *Item, curS int, index int) (*Item, int) {
+	best, bestS := cur, curS
+	for bestS >= index {
+		p := best.Left
+		var pItem *Item
+		var pLen int
+		for p != nil {
+			countable, n, _ := t.renderedStep(p)
+			if countable {
+				pItem = p
+				pLen = n
+				break
+			}
+			p = p.Left
+		}
+		if pItem == nil {
+			// No earlier countable item exists (best is the first countable
+			// item in the type) — best is the answer.
+			break
+		}
+		best = pItem
+		bestS -= pLen
+	}
+	return best, bestS
+}

--- a/crdt/search_marker.go
+++ b/crdt/search_marker.go
@@ -111,6 +111,184 @@ func (t *abstractType) findMarkerRO(index int) (*Item, int) {
 	return t.walkColdFrom(m.item.Right, end, index)
 }
 
+// findMarkerMut is the mutating write-path counterpart of findMarkerRO. It
+// returns the same oracle-correct (item, renderedStart) answer, but as a side
+// effect it maintains t.markers: it refreshes the nearest marker in place when
+// the walk to the target was short, otherwise records a new marker (evicting
+// the oldest by timestamp once maxSearchMarker markers exist). It is the ONLY
+// place that writes to t.markers/t.markerTimestamp during normal operation, so
+// it must be called only under the document write lock. findMarkerRO must stay
+// read-only.
+//
+// Ports Yjs AbstractType.findMarker (src/types/AbstractType.js): locate the
+// nearest existing marker, walk right/left to the item containing index, then
+// walk left until that item can't merge with its left neighbour (same client &&
+// contiguous clock) so a marker never points at the middle of a mergeable run.
+func (t *abstractType) findMarkerMut(index int) (*Item, int) {
+	if index > 0 && !t.disableMarkers && t.start != nil {
+		t.markPositionAt(index)
+	}
+	// The answer itself is always produced by the read-only lookup, which is
+	// proven equal to the cold oracle for ANY (accurate) marker configuration
+	// — including the one markPositionAt just installed. Deriving the return
+	// value this way keeps the exact-boundary tie-breaking (returning the
+	// earlier item when index lands on an item boundary) in a single place.
+	return t.findMarkerRO(index)
+}
+
+// markPositionAt performs the Yjs findMarker walk purely for its side effect:
+// installing/refreshing a search marker at the canonical (non-mid-run) item
+// that contains rendered position index. It never returns the lookup result
+// (findMarkerMut derives that from findMarkerRO) and must run under the write
+// lock. Precondition: index > 0, !t.disableMarkers, t.start != nil.
+func (t *abstractType) markPositionAt(index int) {
+	// Nearest existing marker by |m.index - index| (linear scan, ≤ maxSearchMarker).
+	var marker *searchMarker
+	bestDist := 0
+	for i := range t.markers {
+		if t.markers[i].item == nil {
+			continue
+		}
+		d := t.markers[i].index - index
+		if d < 0 {
+			d = -d
+		}
+		if marker == nil || d < bestDist {
+			marker = &t.markers[i]
+			bestDist = d
+		}
+	}
+
+	p := t.start
+	pindex := 0
+	if marker != nil {
+		p = marker.item
+		pindex = marker.index
+		// We are using this marker; bump its recency so LRU eviction prefers
+		// genuinely stale entries.
+		t.markerTimestamp++
+		marker.timestamp = t.markerTimestamp
+	}
+
+	// Iterate right while the running index is still left of the target.
+	for p.Right != nil && pindex < index {
+		if !p.Deleted && p.Content.IsCountable() {
+			if index < pindex+p.Content.Len() {
+				break
+			}
+			pindex += p.Content.Len()
+		}
+		p = p.Right
+	}
+	// Iterate left if we overshot (marker started to the right of the target).
+	for p.Left != nil && pindex > index {
+		p = p.Left
+		if !p.Deleted && p.Content.IsCountable() {
+			pindex -= p.Content.Len()
+		}
+	}
+	// Iterate left until p can't merge with its left neighbour, so the marker
+	// never points at the middle of a run that a later merge would collapse.
+	for p.Left != nil &&
+		p.Left.ID.Client == p.ID.Client &&
+		p.Left.ID.Clock+uint64(p.Left.Content.Len()) == p.ID.Clock {
+		p = p.Left
+		if !p.Deleted && p.Content.IsCountable() {
+			pindex -= p.Content.Len()
+		}
+	}
+
+	// Refresh the nearest marker in place when the walk was short (Yjs uses
+	// float division here: with a document shorter than maxSearchMarker the
+	// threshold is < 1, so an existing marker is reused only when the walk
+	// landed exactly on it); otherwise install a fresh marker.
+	if marker != nil && float64(absInt(marker.index-pindex)) < float64(t.length)/float64(maxSearchMarker) {
+		marker.item = p
+		marker.index = pindex
+		t.markerTimestamp++
+		marker.timestamp = t.markerTimestamp
+		return
+	}
+	t.markPosition(p, pindex)
+}
+
+// markPosition records a new search marker for item at rendered position
+// index. When the cache is full it overwrites the marker with the oldest
+// timestamp (LRU eviction), matching Yjs markPosition. Write-lock only.
+func (t *abstractType) markPosition(item *Item, index int) {
+	t.markerTimestamp++
+	m := searchMarker{item: item, index: index, timestamp: t.markerTimestamp}
+	if len(t.markers) < maxSearchMarker {
+		t.markers = append(t.markers, m)
+		return
+	}
+	oldest := 0
+	for i := 1; i < len(t.markers); i++ {
+		if t.markers[i].timestamp < t.markers[oldest].timestamp {
+			oldest = i
+		}
+	}
+	t.markers[oldest] = m
+}
+
+// updateMarkerChanges shifts marker indices to account for an edit of size
+// delta (delta > 0 insert, delta < 0 delete) that begins at rendered position
+// index, and drops markers whose item has become deleted/invalid. Ports the
+// index-shift half of Yjs updateMarkerChanges. Write-lock only.
+//
+// Task 2 does not yet route the invalidation call sites through this method
+// (the invalidatePosCache* shims below use the conservative drop-from-index
+// behaviour instead); it is provided as the maintenance primitive that Task 3
+// will wire in once the exact insert/delete invalidation semantics are settled.
+func (t *abstractType) updateMarkerChanges(index, delta int) {
+	for i := len(t.markers) - 1; i >= 0; i-- {
+		m := &t.markers[i]
+		if m.item == nil || m.item.Deleted {
+			t.markers = append(t.markers[:i], t.markers[i+1:]...)
+			continue
+		}
+		if index < m.index || (delta < 0 && index == m.index) {
+			ni := m.index + delta
+			if ni < index {
+				ni = index
+			}
+			m.index = ni
+		}
+	}
+}
+
+// clearMarkers drops every search marker. Always safe: a subsequent lookup
+// simply falls back to a cold walk and repopulates markers. markerTimestamp is
+// intentionally left monotonic across clears.
+func (t *abstractType) clearMarkers() {
+	if len(t.markers) > 0 {
+		t.markers = t.markers[:0]
+	}
+}
+
+// dropMarkersFrom removes every marker whose recorded index is at or after
+// pos. It is the marker analogue of the old invalidatePosCacheFrom: an edit at
+// pos never shifts the rendered start of items that begin strictly before pos,
+// so those markers stay accurate and are kept, while markers at/after pos
+// (which would shift, or point into the edited region) are discarded.
+func (t *abstractType) dropMarkersFrom(pos int) {
+	n := 0
+	for i := range t.markers {
+		if t.markers[i].index < pos {
+			t.markers[n] = t.markers[i]
+			n++
+		}
+	}
+	t.markers = t.markers[:n]
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 // walkColdFrom walks Right starting at "from" (which starts at rendered
 // position "counted"), accumulating rendered length via renderedStep until
 // the target index is bracketed. This is exactly the oracle's algorithm,

--- a/crdt/search_marker.go
+++ b/crdt/search_marker.go
@@ -233,13 +233,30 @@ func (t *abstractType) markPosition(item *Item, index int) {
 
 // updateMarkerChanges shifts marker indices to account for an edit of size
 // delta (delta > 0 insert, delta < 0 delete) that begins at rendered position
-// index, and drops markers whose item has become deleted/invalid. Ports the
-// index-shift half of Yjs updateMarkerChanges. Write-lock only.
+// index, and drops markers whose item has become deleted/invalid. It is the
+// maintenance primitive wired into the local structural mutation sites (Task 3):
+// a positioned insert calls it with (index, +len), a positioned delete with
+// (index, -len) AFTER tombstoning the affected items. Write-lock only.
 //
-// Task 2 does not yet route the invalidation call sites through this method
-// (the invalidatePosCache* shims below use the conservative drop-from-index
-// behaviour instead); it is provided as the maintenance primitive that Task 3
-// will wire in once the exact insert/delete invalidation semantics are settled.
+// Shift condition — index <= m.index. Every marker whose recorded rendered
+// start is at or after the edit position shifts by delta; markers strictly
+// before the edit are untouched (an edit at index never moves the rendered
+// start of an item that ends at or before index). This is the "index <= m.index"
+// form the Yjs source notes "would actually suffice" (src/types/AbstractType.js).
+//
+// Why "<=" and not the "index < m.index || (delta<0 && index==m.index)" that a
+// literal port of Yjs's default branch uses: Yjs additionally marks items with a
+// boolean and de-dups a marker that lands on an already-marked item, so a marker
+// left un-shifted at the exact boundary is harmless there. Our findMarkerRO has
+// no such de-dup — it TRUSTS m.index as m.item's rendered start and re-walks from
+// it — so a marker sitting exactly at an insert position MUST shift, or it would
+// report a stale (too-low) start for the item that the insert pushed right. For
+// deletes the two forms coincide (the boundary marker's item is tombstoned and
+// dropped by the check above), so "<=" is correct for both directions.
+//
+// Post-condition (the invariant every caller relies on): each surviving marker
+// still satisfies renderedStart(m.item) == m.index, given the list and Deleted
+// flags are already updated for this edit.
 func (t *abstractType) updateMarkerChanges(index, delta int) {
 	for i := len(t.markers) - 1; i >= 0; i-- {
 		m := &t.markers[i]
@@ -247,7 +264,7 @@ func (t *abstractType) updateMarkerChanges(index, delta int) {
 			t.markers = append(t.markers[:i], t.markers[i+1:]...)
 			continue
 		}
-		if index < m.index || (delta < 0 && index == m.index) {
+		if index <= m.index {
 			ni := m.index + delta
 			if ni < index {
 				ni = index
@@ -264,22 +281,6 @@ func (t *abstractType) clearMarkers() {
 	if len(t.markers) > 0 {
 		t.markers = t.markers[:0]
 	}
-}
-
-// dropMarkersFrom removes every marker whose recorded index is at or after
-// pos. It is the marker analogue of the old invalidatePosCacheFrom: an edit at
-// pos never shifts the rendered start of items that begin strictly before pos,
-// so those markers stay accurate and are kept, while markers at/after pos
-// (which would shift, or point into the edited region) are discarded.
-func (t *abstractType) dropMarkersFrom(pos int) {
-	n := 0
-	for i := range t.markers {
-		if t.markers[i].index < pos {
-			t.markers[n] = t.markers[i]
-			n++
-		}
-	}
-	t.markers = t.markers[:n]
 }
 
 func absInt(x int) int {

--- a/crdt/search_marker.go
+++ b/crdt/search_marker.go
@@ -19,17 +19,55 @@ type searchMarker struct {
 }
 
 // renderedStep reports how a single item contributes to rendered (visible)
-// position. This is the single shared definition of position-contribution
-// used by marker-based lookups.
+// position. This is THE single shared definition of position-contribution — the
+// marker walk (findMarkerRO/markPositionAt/walkColdFrom/walkLeftFrom) and every
+// YArray positional walk (Get/Slice/ForEach) all decide countability, rendered
+// length, and which item holds the values from this one function, so there is
+// exactly one notion of "rendered position i" including ContentMove.
 //
-// Task 1 ships the non-move version: a deleted item contributes nothing, and
-// a countable, non-deleted item contributes its Content.Len(); everything
-// else (formatting marks, moves, non-countable content) contributes 0.
-// renderAt is reserved for move-awareness (Task 5), where a moved item's
-// rendered contribution is attributed to a different item than the one being
-// stepped over; until then it is always nil.
+// Returns:
+//   - countable: whether item occupies rendered positions (contributes to length)
+//   - n: the number of rendered positions it occupies
+//   - renderAt: the item whose Content actually holds the values rendered at this
+//     step. nil means "item itself"; non-nil is used only for a winning
+//     ContentMove, where the values come from the move's target, not the
+//     ContentMove item (which is non-countable on its own).
+//
+// Move-rendering model (identical to yarray.go's cold walks):
+//   - deleted item → contributes nothing.
+//   - a ContentMove that is the current WINNER for its target (target resolvable,
+//     target.MovedBy == this move, target live) → renders the target's values at
+//     this position; contributes target.Content.Len(), renderAt = target. A
+//     losing / target-less / target-deleted move renders nothing.
+//   - an item whose MovedBy != nil has been moved away and is rendered at its
+//     ContentMove's position, so it contributes nothing here.
+//   - any other non-countable content (formatting marks, non-winning moves) →
+//     contributes nothing.
+//   - otherwise → contributes Content.Len(), renderAt nil.
+//
+// YText has no moves and never sets MovedBy, so the move branches are inert for
+// text: the function collapses to "deleted/non-countable → 0, else Content.Len()".
 func (t *abstractType) renderedStep(item *Item) (countable bool, n int, renderAt *Item) {
-	if item == nil || item.Deleted || !item.Content.IsCountable() {
+	if item == nil || item.Deleted {
+		return false, 0, nil
+	}
+	if cm, ok := item.Content.(*ContentMove); ok {
+		// A ContentMove renders its target here only if this move won
+		// arbitration. Mirror yarray.go's resolution exactly.
+		if t.doc == nil || cm.Target == nil {
+			return false, 0, nil
+		}
+		target := t.doc.store.Find(*cm.Target)
+		if target == nil || target.MovedBy != item || target.Deleted {
+			return false, 0, nil
+		}
+		return true, target.Content.Len(), target
+	}
+	if !item.Content.IsCountable() {
+		return false, 0, nil
+	}
+	if item.MovedBy != nil {
+		// Moved away — rendered at its ContentMove's position, not here.
 		return false, 0, nil
 	}
 	return true, item.Content.Len(), nil
@@ -170,31 +208,37 @@ func (t *abstractType) markPositionAt(index int) {
 		marker.timestamp = t.markerTimestamp
 	}
 
-	// Iterate right while the running index is still left of the target.
+	// Iterate right while the running index is still left of the target. Rendered
+	// contribution (incl. ContentMove) comes from renderedStep so the marker's
+	// index tracks rendered — not physical — position, agreeing with findMarkerRO.
 	for p.Right != nil && pindex < index {
-		if !p.Deleted && p.Content.IsCountable() {
-			if index < pindex+p.Content.Len() {
+		if countable, n, _ := t.renderedStep(p); countable {
+			if index < pindex+n {
 				break
 			}
-			pindex += p.Content.Len()
+			pindex += n
 		}
 		p = p.Right
 	}
 	// Iterate left if we overshot (marker started to the right of the target).
 	for p.Left != nil && pindex > index {
 		p = p.Left
-		if !p.Deleted && p.Content.IsCountable() {
-			pindex -= p.Content.Len()
+		if countable, n, _ := t.renderedStep(p); countable {
+			pindex -= n
 		}
 	}
 	// Iterate left until p can't merge with its left neighbour, so the marker
 	// never points at the middle of a run that a later merge would collapse.
+	// The clock-contiguity condition is broader than true mergeability (which
+	// additionally requires matching MovedBy/Deleted/etc.), so it only ever
+	// backs the marker up further than strictly necessary — always safe. The
+	// pindex adjustment uses renderedStep so it stays the rendered start of p.
 	for p.Left != nil &&
 		p.Left.ID.Client == p.ID.Client &&
 		p.Left.ID.Clock+uint64(p.Left.Content.Len()) == p.ID.Clock {
 		p = p.Left
-		if !p.Deleted && p.Content.IsCountable() {
-			pindex -= p.Content.Len()
+		if countable, n, _ := t.renderedStep(p); countable {
+			pindex -= n
 		}
 	}
 

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -156,6 +156,147 @@ func TestSearchMarker_InsertMatchesCold_LargeRandom(t *testing.T) {
 	}
 }
 
+// TestSearchMarker_RemoteDeleteOnly_NoStale is the v1.31.6 stale-cache class
+// guard (Task 3, #181). A remote update that ONLY tombstones an item is applied
+// via ApplyUpdateV1 (which runs with txn.Local hardcoded true, so item.delete's
+// own !txn.Local invalidation is dead), then a positioned LOCAL insert follows.
+// If the remote delete-apply path fails to invalidate the search markers, the
+// still-live markers after the tombstone carry indices that are now one-too-high
+// and the insert resolves the wrong neighbour. The marker-run result must equal
+// the force-cold run.
+func TestSearchMarker_RemoteDeleteOnly_NoStale(t *testing.T) {
+	// The v1.31.6 stale-cache class: a remote update that ONLY tombstones an
+	// item applies with txn.Local hardcoded true (so item.delete's own
+	// !txn.Local invalidation is dead) and must still invalidate the search
+	// markers. A warmed cache holding markers for live items AFTER the deleted
+	// one would otherwise carry indices that are now too high, and the next
+	// positioned insert resolves the wrong neighbour.
+	//
+	// The cache is hand-seeded (as the read-only oracle tests do) because the
+	// write path snaps markers to run-starts, which would hide the exact tail
+	// marker this class needs; seeding models precisely the warmed state that
+	// v1.31.6 corrupted.
+	a := New(WithClientID(1))
+	arrA := a.GetArray("arr")
+	a.Transact(func(tr *Transaction) {
+		for _, v := range []any{"A", "B", "C", "D", "E"} { // 5 distinct (unmerged) items
+			arrA.Push(tr, []any{v})
+		}
+	})
+	at := arrA.baseType()
+
+	// Seed a correct, pre-delete warmed cache: markers for the live tail items.
+	seed := func() {
+		at.markers = at.markers[:0]
+		for _, p := range []int{4, 5} { // -> (D,3), (E,4)
+			it, idx := coldLeftNeighbour(at, p)
+			if it != nil {
+				at.markers = append(at.markers, searchMarker{item: it, index: idx})
+			}
+		}
+	}
+	seed()
+	// Sanity: with the correct warmed cache, findMarkerRO agrees with cold.
+	for i := 0; i <= arrA.Len(); i++ {
+		if gi, gx := at.findMarkerRO(i); func() bool { ci, cx := coldLeftNeighbour(at, i); return gi != ci || gx != cx }() {
+			t.Fatalf("pre-delete seed already stale at %d: got (%p,%d)", i, gi, gx)
+		}
+	}
+
+	// A remote peer tombstones "B" and ships ONLY that delete back.
+	b := New(WithClientID(2))
+	if err := ApplyUpdateV1(b, EncodeStateAsUpdateV1(a, nil), nil); err != nil {
+		t.Fatal(err)
+	}
+	arrB := b.GetArray("arr")
+	seed() // re-warm right before the delete apply (encoding above may have touched markers)
+	b.Transact(func(tr *Transaction) { arrB.Delete(tr, 1, 1) })
+	upd := EncodeStateAsUpdateV1(b, a.StateVector())
+	if err := ApplyUpdateV1(a, upd, nil); err != nil { // a live: [A C D E]; D,E shift left by 1
+		t.Fatal(err)
+	}
+
+	// The invariant the remote-delete apply must uphold: every surviving marker
+	// still resolves like the cold oracle. A stale (D,3)/(E,4) that survived the
+	// tombstone would make findMarkerRO return the wrong item near the tail.
+	for i := 0; i <= arrA.Len(); i++ {
+		gi, gx := at.findMarkerRO(i)
+		ci, cx := coldLeftNeighbour(at, i)
+		if gi != ci || gx != cx {
+			t.Fatalf("stale marker after remote delete-only apply at index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", i, gi, gx, ci, cx)
+		}
+	}
+
+	// And the end-to-end shape: a positioned insert after the remote delete must
+	// land where the cold walk would put it.
+	a.Transact(func(tr *Transaction) { arrA.Insert(tr, 4, []any{"Y"}) }) // append at end -> [A C D E Y]
+	j, err := arrA.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(j), `["A","C","D","E","Y"]`; got != want {
+		t.Fatalf("positioned insert after remote delete-only: got %s want %s", got, want)
+	}
+}
+
+// TestUpdateMarkerChanges_ShiftSemantics directly exercises the index-shift
+// primitive that Task 3 wires into the structural mutation sites. The subtle
+// invariant it must uphold: after the call, every surviving marker's recorded
+// index still equals its item's true rendered start. The exact-boundary case
+// (a marker whose index equals the edit position) is the one that made the
+// naive strict-less-than condition wrong for our re-walk-trusting findMarkerRO
+// (see the "index <= m.index" reasoning in search_marker.go).
+func TestUpdateMarkerChanges_ShiftSemantics(t *testing.T) {
+	live := &Item{Content: NewContentString("x")}         // countable, not deleted
+	dead := &Item{Content: NewContentString("y"), Deleted: true}
+
+	t.Run("insert shifts markers at or after the edit index", func(t *testing.T) {
+		at := &abstractType{markers: []searchMarker{
+			{item: live, index: 2}, // strictly before edit: must NOT move
+			{item: live, index: 5}, // exactly at edit: MUST move (boundary case)
+			{item: live, index: 9}, // after edit: must move
+		}}
+		at.updateMarkerChanges(5, +3) // insert 3 units at index 5
+		want := []int{2, 8, 12}
+		for i, w := range want {
+			if at.markers[i].index != w {
+				t.Fatalf("insert marker[%d].index=%d want %d", i, at.markers[i].index, w)
+			}
+		}
+	})
+
+	t.Run("delete shifts and clamps markers at or after the edit index", func(t *testing.T) {
+		at := &abstractType{markers: []searchMarker{
+			{item: live, index: 2},  // before delete: unchanged
+			{item: live, index: 10}, // after delete: shift left by 3
+		}}
+		at.updateMarkerChanges(4, -3) // delete 3 units at index 4
+		want := []int{2, 7}
+		for i, w := range want {
+			if at.markers[i].index != w {
+				t.Fatalf("delete marker[%d].index=%d want %d", i, at.markers[i].index, w)
+			}
+		}
+	})
+
+	t.Run("markers on deleted items are dropped", func(t *testing.T) {
+		at := &abstractType{markers: []searchMarker{
+			{item: live, index: 1},
+			{item: dead, index: 4}, // item became a tombstone: drop
+			{item: live, index: 8},
+		}}
+		at.updateMarkerChanges(4, -2)
+		if len(at.markers) != 2 {
+			t.Fatalf("expected deleted-item marker dropped, got %d markers", len(at.markers))
+		}
+		for _, m := range at.markers {
+			if m.item == dead {
+				t.Fatalf("deleted-item marker survived")
+			}
+		}
+	})
+}
+
 // TestSearchMarker_RO_IndexBeyondLen (carried over from Task 1 review): a
 // read-only lookup for index > Len() must match the cold oracle (both walk
 // off the end and return (nil, totalCounted)).

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -3,6 +3,8 @@ package crdt
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -339,6 +341,405 @@ func TestSearchMarker_RO_DisableMarkersIgnoresBadMarkers(t *testing.T) {
 		ci, cidx := coldLeftNeighbour(at, i)
 		if gi != ci || gidx != cidx {
 			t.Fatalf("index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", i, gi, gidx, ci, cidx)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 4: route positional ops through markers + single-cursor ApplyDelta (#181)
+//
+// Every test below builds the SAME document twice: once with markers live
+// (disableMarkers=false, the fast path this task adds) and once with
+// disableMarkers=true (forces every op back to its pre-Task-4 full linear
+// walk — the oracle). The two runs must be byte/value-identical. Where an
+// independent expectation is easy to compute (values are their own index,
+// or plain-ASCII string splicing), the test also checks the result against
+// that — so a bug shared by both the marker and cold-walk implementations
+// can't hide behind marker==cold agreement alone.
+
+// TestSearchMarker_ArrayGet_MatchesCold exercises YArray.Get's findMarkerRO
+// fast path (yarray.go). Values are inserted equal to their own index, so
+// the expected answer is independently known without re-deriving it from
+// the array's own Get/Slice logic.
+func TestSearchMarker_ArrayGet_MatchesCold(t *testing.T) {
+	idxs := []int{0, 1999, 1000, 3, 1500, 7, 1234, 1998}
+	build := func(cold bool) []any {
+		d := New(WithClientID(1))
+		arr := d.GetArray("a")
+		arr.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			for i := 0; i < 2000; i++ {
+				arr.Insert(tr, arr.Len(), []any{i})
+			}
+		})
+		out := make([]any, 0, len(idxs))
+		for _, idx := range idxs {
+			out = append(out, arr.Get(idx))
+		}
+		return out
+	}
+	got, cold := build(false), build(true)
+	if !reflect.DeepEqual(got, cold) {
+		t.Fatalf("marker/cold mismatch:\n got  %v\n cold %v", got, cold)
+	}
+	want := make([]any, len(idxs))
+	for i, idx := range idxs {
+		// arr[i] == i by construction, but NewContentAny normalises Go `int`
+		// values to int64 (matching the JSON-number convention used
+		// elsewhere), so the independent oracle must match that type.
+		want[i] = int64(idx)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v (independent oracle)", got, want)
+	}
+	// Out-of-bounds and negative indices must still behave like before.
+	d := New(WithClientID(1))
+	arr := d.GetArray("a")
+	d.Transact(func(tr *Transaction) { arr.Insert(tr, 0, []any{1, 2, 3}) })
+	if v := arr.Get(-1); v != nil {
+		t.Fatalf("Get(-1) = %v, want nil", v)
+	}
+	if v := arr.Get(3); v != nil {
+		t.Fatalf("Get(len) = %v, want nil", v)
+	}
+}
+
+// TestSearchMarker_ArraySlice_MatchesCold exercises YArray.Slice's
+// findMarkerRO-accelerated start lookup (yarray.go).
+func TestSearchMarker_ArraySlice_MatchesCold(t *testing.T) {
+	build := func(cold bool) [][]any {
+		d := New(WithClientID(1))
+		arr := d.GetArray("a")
+		arr.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			for i := 0; i < 2000; i++ {
+				arr.Insert(tr, arr.Len(), []any{i})
+			}
+		})
+		return [][]any{
+			arr.Slice(0, 10),
+			arr.Slice(500, 510),
+			arr.Slice(1990, 2000),
+			arr.Slice(1000, 1000), // empty range
+			arr.Slice(1995, 5000), // end clamps to Len()
+		}
+	}
+	got, cold := build(false), build(true)
+	if !reflect.DeepEqual(got, cold) {
+		t.Fatalf("marker/cold mismatch:\n got  %v\n cold %v", got, cold)
+	}
+	expectRange := func(s, e int) []any {
+		if e > 2000 {
+			e = 2000
+		}
+		out := make([]any, 0, e-s)
+		for i := s; i < e; i++ {
+			out = append(out, int64(i)) // NewContentAny normalises int -> int64
+		}
+		return out
+	}
+	want := [][]any{
+		expectRange(0, 10),
+		expectRange(500, 510),
+		expectRange(1990, 2000),
+		expectRange(1000, 1000),
+		expectRange(1995, 5000),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v (independent oracle)", got, want)
+	}
+}
+
+// TestSearchMarker_ArrayGetSlice_MoveGated_MatchesCold guards the hasMoves
+// gate added alongside this task's Get/Slice routing: search_marker.go's
+// renderedStep counts items by PHYSICAL position and doesn't yet know how to
+// render a ContentMove's target at its destination or skip an item that
+// moved away (that move-awareness is deferred to a later task), so an array
+// that has ever used Move must keep taking the original fully move-aware
+// walk regardless of disableMarkers. Without the gate this would silently
+// return wrong values instead of merely being slow.
+func TestSearchMarker_ArrayGetSlice_MoveGated_MatchesCold(t *testing.T) {
+	build := func(cold bool) ([]any, []any) {
+		d := New(WithClientID(1))
+		arr := d.GetArray("a")
+		arr.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			for _, v := range []any{"a", "b", "c", "d", "e"} {
+				arr.Push(tr, []any{v})
+			}
+			arr.Move(tr, 0, 3) // [b c d a e]
+		})
+		return arr.ToSlice(), []any{arr.Get(0), arr.Get(1), arr.Get(2), arr.Get(3), arr.Get(4)}
+	}
+	gotSlice, gotGet := build(false)
+	coldSlice, coldGet := build(true)
+	if !reflect.DeepEqual(gotSlice, coldSlice) || !reflect.DeepEqual(gotGet, coldGet) {
+		t.Fatalf("marker/cold mismatch: slice got=%v cold=%v; get got=%v cold=%v", gotSlice, coldSlice, gotGet, coldGet)
+	}
+	want := []any{"b", "c", "d", "a", "e"}
+	if !reflect.DeepEqual(gotSlice, want) {
+		t.Fatalf("ToSlice got %v want %v", gotSlice, want)
+	}
+	if !reflect.DeepEqual(gotGet, want) {
+		t.Fatalf("Get(0..4) got %v want %v", gotGet, want)
+	}
+}
+
+// cyclicText returns a length-n string where byte i is determined by i mod 7
+// (a period unlikely to accidentally line up with the small shift amounts a
+// boundary/off-by-a-few bug would introduce). Unlike a uniform "aaaa...", a
+// range shifted by a few positions but kept the same length still changes
+// the surviving/inserted substring content — so tests built on cyclicText
+// catch position bugs that a uniform-content oracle would render invisible
+// (e.g. deleting [2925,2965) instead of [2930,2970) from an all-'x' string
+// yields the same result either way; from cyclicText it does not).
+func cyclicText(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + i%7)
+	}
+	return string(b)
+}
+
+// TestSearchMarker_DeleteRange_MatchesCold_Random exercises deleteRange's
+// findMarkerMut-accelerated start lookup (yarray.go, shared by YArray.Delete
+// and YText.Delete) with many random-position deletes on a large document.
+func TestSearchMarker_DeleteRange_MatchesCold_Random(t *testing.T) {
+	build := func(cold bool) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		rng := rand.New(rand.NewSource(99))
+		d.Transact(func(tr *Transaction) {
+			for txt.Len() < 4000 {
+				txt.Insert(tr, txt.Len(), fmt.Sprintf("%d-", rng.Intn(1000)), nil)
+			}
+			for i := 0; i < 300 && txt.Len() > 20; i++ {
+				pos := rng.Intn(txt.Len() - 10)
+				n := 1 + rng.Intn(9)
+				txt.Delete(tr, pos, n)
+			}
+		})
+		return txt.ToString()
+	}
+	got, cold := build(false), build(true)
+	if got != cold {
+		t.Fatalf("marker/cold mismatch: len(got)=%d len(cold)=%d", len(got), len(cold))
+	}
+}
+
+// TestSearchMarker_DeleteRange_MatchesCold_Tail exercises the deleteRange
+// fast path for a delete anchored near the end of a large document — the
+// case an O(index) walk from the head would make expensive, and the case
+// most likely to trip up findMarkerMut's boundary tie-break if it were wired
+// in wrong (see the "counted+n <= index: skip forward" comment in
+// yarray.go's deleteRange). Content is cyclicText (not a uniform character)
+// so a start-position-shifted-but-same-length delete is actually detectable
+// (see cyclicText's doc comment) — this is what makes the independent
+// oracle discriminating rather than tautological.
+func TestSearchMarker_DeleteRange_MatchesCold_Tail(t *testing.T) {
+	const n = 3000
+	// Two variants: one where the tail delete lands exactly on an item
+	// boundary (single-char items), and one where it must split a large
+	// multi-char item mid-run — the latter is what actually exercises
+	// deleteRange's "counted < index: split at the start of the deletion"
+	// branch (a corrupted marker-derived `counted` that still finds the
+	// right bracket item can hide behind a boundary-aligned delete, since
+	// the split decision never triggers there).
+	base := cyclicText(n)
+	build := func(cold bool, bulk bool) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			if bulk {
+				txt.Insert(tr, 0, base, nil) // one big item
+				txt.Delete(tr, n-70, 40)     // mid-item, both boundaries
+			} else {
+				for i := 0; i < n; i++ {
+					txt.Insert(tr, txt.Len(), base[i:i+1], nil)
+				}
+				txt.Delete(tr, txt.Len()-50, 50) // exactly on an item boundary
+			}
+		})
+		return txt.ToString()
+	}
+	for _, bulk := range []bool{false, true} {
+		got, cold := build(false, bulk), build(true, bulk)
+		var want string
+		if bulk {
+			want = base[:n-70] + base[n-30:]
+		} else {
+			want = base[:n-50]
+		}
+		if got != cold {
+			t.Fatalf("bulk=%v marker/cold mismatch:\n got  %q\n cold %q", bulk, got, cold)
+		}
+		if got != want {
+			t.Fatalf("bulk=%v got %q want %q (independent oracle)", bulk, got, want)
+		}
+	}
+}
+
+// TestSearchMarker_Format_MatchesCold exercises YText.Format's
+// findTextPos/findMarkerMut-accelerated cursor resolution on a large
+// document (ytext.go). Content is cyclicText so a shifted-but-same-length
+// format range still produces a detectably different Delta (different
+// substrings in the surrounding plain runs), not just different lengths.
+func TestSearchMarker_Format_MatchesCold(t *testing.T) {
+	const n = 3000
+	base := cyclicText(n)
+	build := func(cold bool) []Delta {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			txt.Insert(tr, 0, base, nil)
+			txt.Format(tr, 1500, 100, Attributes{"bold": true})
+		})
+		return txt.ToDelta()
+	}
+	got, cold := build(false), build(true)
+	if !reflect.DeepEqual(got, cold) {
+		t.Fatalf("marker/cold mismatch:\n got  %v\n cold %v", got, cold)
+	}
+	want := []Delta{
+		{Op: DeltaOpInsert, Insert: base[:1500]},
+		{Op: DeltaOpInsert, Insert: base[1500:1600], Attributes: Attributes{"bold": true}},
+		{Op: DeltaOpInsert, Insert: base[1600:]},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v (independent oracle)", got, want)
+	}
+}
+
+// TestSearchMarker_CurrentAttributesAt_MatchesCold exercises
+// YText.currentAttributesAt's !hasFormatting short-circuit (returns empty
+// without walking, ytext.go) together with its ordinary full-walk fallback
+// once formatting exists — both are consulted by Insert whenever attrs is
+// non-empty. Attrs-carrying inserts happen before, at the hasFormatting
+// transition, and after, on a large document.
+func TestSearchMarker_CurrentAttributesAt_MatchesCold(t *testing.T) {
+	build := func(cold bool) []Delta {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			for i := 0; i < 2000; i++ {
+				txt.Insert(tr, txt.Len(), "a", nil)
+			}
+			// First attrs-carrying insert: hasFormatting is still false when
+			// currentAttributesAt is consulted here (it flips true only once
+			// this call's own opening marker integrates).
+			txt.Insert(tr, txt.Len(), "BOLD", Attributes{"bold": true})
+			for i := 0; i < 2000; i++ {
+				txt.Insert(tr, txt.Len(), "b", nil)
+			}
+			// hasFormatting is now true: exercises the full walk from
+			// txt.start, at a position before the only existing marker.
+			txt.Insert(tr, 500, "MID", Attributes{"bold": true})
+			txt.Insert(tr, txt.Len(), "END", Attributes{"italic": true})
+		})
+		return txt.ToDelta()
+	}
+	got, cold := build(false), build(true)
+	if !reflect.DeepEqual(got, cold) {
+		t.Fatalf("marker/cold mismatch:\n got  %v\n cold %v", got, cold)
+	}
+}
+
+// TestSearchMarker_ApplyDelta_MatchesCold exercises ApplyDelta's single
+// threaded itemTextPos cursor (ytext.go) across a full mix of insert/
+// delete/retain/retain+format ops on a large document. The independent
+// oracle applies the identical delta to a plain Go string via ordinary
+// slicing (no crdt code at all), so it also catches a bug shared by both the
+// marker and cold-cursor ygo code paths.
+func TestSearchMarker_ApplyDelta_MatchesCold(t *testing.T) {
+	const n = 3000
+	delta := []Delta{
+		{Op: DeltaOpRetain, Retain: 500},
+		{Op: DeltaOpInsert, Insert: "HELLO"},
+		{Op: DeltaOpDelete, Delete: 20},
+		{Op: DeltaOpRetain, Retain: 1000, Attributes: Attributes{"bold": true}},
+		{Op: DeltaOpInsert, Insert: "WORLD", Attributes: Attributes{"italic": true}},
+		{Op: DeltaOpRetain, Retain: 300},
+		{Op: DeltaOpDelete, Delete: 500},
+		{Op: DeltaOpInsert, Insert: "TAIL"},
+	}
+	base := cyclicText(n)
+	build := func(cold bool) (string, []Delta) {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			txt.Insert(tr, 0, base, nil)
+			txt.ApplyDelta(tr, delta)
+		})
+		return txt.ToString(), txt.ToDelta()
+	}
+	gotStr, gotDelta := build(false)
+	coldStr, coldDelta := build(true)
+	if gotStr != coldStr {
+		t.Fatalf("ToString marker/cold mismatch:\n got  %q\n cold %q", gotStr, coldStr)
+	}
+	if !reflect.DeepEqual(gotDelta, coldDelta) {
+		t.Fatalf("ToDelta marker/cold mismatch:\n got  %v\n cold %v", gotDelta, coldDelta)
+	}
+
+	// Independent oracle: replay the same delta over plain ASCII text with
+	// ordinary string slicing (quill-delta semantics), entirely outside the
+	// crdt package.
+	independentApply := func(base string, delta []Delta) string {
+		var out strings.Builder
+		pos := 0
+		for _, d := range delta {
+			switch d.Op {
+			case DeltaOpInsert:
+				if s, ok := d.Insert.(string); ok {
+					out.WriteString(s)
+				}
+			case DeltaOpRetain:
+				out.WriteString(base[pos : pos+d.Retain])
+				pos += d.Retain
+			case DeltaOpDelete:
+				pos += d.Delete
+			}
+		}
+		out.WriteString(base[pos:])
+		return out.String()
+	}
+	want := independentApply(base, delta)
+	if gotStr != want {
+		t.Fatalf("got %q want %q (independent oracle)", gotStr, want)
+	}
+}
+
+// TestSearchMarker_Format_MatchesCold_OutOfRange exercises findTextPos's
+// !hasFormatting fast path (ytext.go) at and beyond the document's length —
+// the case findTextPos must clamp pos.index to t.length exactly like the
+// walk-from-start loop does. Format itself clamps length so an out-of-range
+// index is a no-op either way; what this actually exercises is that
+// findTextPos's fast path doesn't panic or corrupt state when index >
+// t.length, agreeing with the cold walk on the (harmless) result.
+func TestSearchMarker_Format_MatchesCold_OutOfRange(t *testing.T) {
+	const n = 500
+	build := func(cold bool, idx int) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			txt.Insert(tr, 0, cyclicText(n), nil)
+			txt.Format(tr, idx, 10, Attributes{"bold": true})
+		})
+		return txt.ToString()
+	}
+	for _, idx := range []int{n, n + 1, n + 50} {
+		got, cold := build(false, idx), build(true, idx)
+		if got != cold {
+			t.Fatalf("idx=%d marker/cold mismatch:\n got  %q\n cold %q", idx, got, cold)
+		}
+		if got != cyclicText(n) {
+			t.Fatalf("idx=%d out-of-range Format changed content: got %q", idx, got)
 		}
 	}
 }

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -138,13 +138,16 @@ func TestSearchMarker_InsertMatchesCold(t *testing.T) {
 // still yield exactly the force-cold document. This exercises marker refresh,
 // LRU eviction, and the shim-driven invalidation across a long transaction.
 func TestSearchMarker_InsertMatchesCold_LargeRandom(t *testing.T) {
+	// 1000 iterations (well above maxSearchMarker=80) keeps the O(n^2) cold
+	// random insert/delete cost under the CI race budget while still
+	// exercising marker refresh, LRU eviction, and shim-driven invalidation.
 	build := func(cold bool) string {
 		d := New(WithClientID(1))
 		txt := d.GetText("t")
 		txt.baseType().disableMarkers = cold
 		rng := rand.New(rand.NewSource(7))
 		d.Transact(func(tr *Transaction) {
-			for i := 0; i < 3000; i++ {
+			for i := 0; i < 1000; i++ {
 				pos := rng.Intn(txt.Len() + 1)
 				txt.Insert(tr, pos, fmt.Sprintf("%d", rng.Intn(10)), nil)
 				if txt.Len() > 30 && rng.Intn(6) == 0 {
@@ -363,13 +366,16 @@ func TestSearchMarker_RO_DisableMarkersIgnoresBadMarkers(t *testing.T) {
 // the expected answer is independently known without re-deriving it from
 // the array's own Get/Slice logic.
 func TestSearchMarker_ArrayGet_MatchesCold(t *testing.T) {
-	idxs := []int{0, 1999, 1000, 3, 1500, 7, 1234, 1998}
+	// 800 elements (10x maxSearchMarker=80) keeps multiple markers in play
+	// while the O(n^2) force-cold build below stays well under the CI race
+	// budget; see search_marker_test.go doc comment for the sizing rationale.
+	idxs := []int{0, 799, 400, 3, 600, 7, 494, 798}
 	build := func(cold bool) []any {
 		d := New(WithClientID(1))
 		arr := d.GetArray("a")
 		arr.baseType().disableMarkers = cold
 		d.Transact(func(tr *Transaction) {
-			for i := 0; i < 2000; i++ {
+			for i := 0; i < 800; i++ {
 				arr.Insert(tr, arr.Len(), []any{i})
 			}
 		})
@@ -408,21 +414,24 @@ func TestSearchMarker_ArrayGet_MatchesCold(t *testing.T) {
 // TestSearchMarker_ArraySlice_MatchesCold exercises YArray.Slice's
 // findMarkerRO-accelerated start lookup (yarray.go).
 func TestSearchMarker_ArraySlice_MatchesCold(t *testing.T) {
+	// 800 elements (10x maxSearchMarker=80) keeps multiple markers in play
+	// while the O(n^2) force-cold build below stays well under the CI race
+	// budget; see search_marker_test.go doc comment for the sizing rationale.
 	build := func(cold bool) [][]any {
 		d := New(WithClientID(1))
 		arr := d.GetArray("a")
 		arr.baseType().disableMarkers = cold
 		d.Transact(func(tr *Transaction) {
-			for i := 0; i < 2000; i++ {
+			for i := 0; i < 800; i++ {
 				arr.Insert(tr, arr.Len(), []any{i})
 			}
 		})
 		return [][]any{
 			arr.Slice(0, 10),
-			arr.Slice(500, 510),
-			arr.Slice(1990, 2000),
-			arr.Slice(1000, 1000), // empty range
-			arr.Slice(1995, 5000), // end clamps to Len()
+			arr.Slice(200, 210),
+			arr.Slice(790, 800),
+			arr.Slice(400, 400),  // empty range
+			arr.Slice(795, 5000), // end clamps to Len()
 		}
 	}
 	got, cold := build(false), build(true)
@@ -430,8 +439,8 @@ func TestSearchMarker_ArraySlice_MatchesCold(t *testing.T) {
 		t.Fatalf("marker/cold mismatch:\n got  %v\n cold %v", got, cold)
 	}
 	expectRange := func(s, e int) []any {
-		if e > 2000 {
-			e = 2000
+		if e > 800 {
+			e = 800
 		}
 		out := make([]any, 0, e-s)
 		for i := s; i < e; i++ {
@@ -441,10 +450,10 @@ func TestSearchMarker_ArraySlice_MatchesCold(t *testing.T) {
 	}
 	want := [][]any{
 		expectRange(0, 10),
-		expectRange(500, 510),
-		expectRange(1990, 2000),
-		expectRange(1000, 1000),
-		expectRange(1995, 5000),
+		expectRange(200, 210),
+		expectRange(790, 800),
+		expectRange(400, 400),
+		expectRange(795, 5000),
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v want %v (independent oracle)", got, want)
@@ -675,13 +684,16 @@ func cyclicText(n int) string {
 // findMarkerMut-accelerated start lookup (yarray.go, shared by YArray.Delete
 // and YText.Delete) with many random-position deletes on a large document.
 func TestSearchMarker_DeleteRange_MatchesCold_Random(t *testing.T) {
+	// 1200-char doc (15x maxSearchMarker=80) keeps the O(n^2) cold random
+	// positioned-delete cost under the CI race budget while still exercising
+	// multiple markers across a randomised delete pattern.
 	build := func(cold bool) string {
 		d := New(WithClientID(1))
 		txt := d.GetText("t")
 		txt.baseType().disableMarkers = cold
 		rng := rand.New(rand.NewSource(99))
 		d.Transact(func(tr *Transaction) {
-			for txt.Len() < 4000 {
+			for txt.Len() < 1200 {
 				txt.Insert(tr, txt.Len(), fmt.Sprintf("%d-", rng.Intn(1000)), nil)
 			}
 			for i := 0; i < 300 && txt.Len() > 20; i++ {
@@ -708,7 +720,10 @@ func TestSearchMarker_DeleteRange_MatchesCold_Random(t *testing.T) {
 // (see cyclicText's doc comment) — this is what makes the independent
 // oracle discriminating rather than tautological.
 func TestSearchMarker_DeleteRange_MatchesCold_Tail(t *testing.T) {
-	const n = 3000
+	// n=800 (10x maxSearchMarker=80) keeps the O(n^2) force-cold, single-char
+	// sequential-append build (the "bulk=false" variant below) well under
+	// the CI race budget while still exercising multiple markers.
+	const n = 800
 	// Two variants: one where the tail delete lands exactly on an item
 	// boundary (single-char items), and one where it must split a large
 	// multi-char item mid-run — the latter is what actually exercises
@@ -790,24 +805,28 @@ func TestSearchMarker_Format_MatchesCold(t *testing.T) {
 // non-empty. Attrs-carrying inserts happen before, at the hasFormatting
 // transition, and after, on a large document.
 func TestSearchMarker_CurrentAttributesAt_MatchesCold(t *testing.T) {
+	// 500-char blocks (well above maxSearchMarker=80) keep the O(n^2)
+	// force-cold single-char-append build below under the CI race budget
+	// while still exercising multiple markers and the hasFormatting
+	// transition.
 	build := func(cold bool) []Delta {
 		d := New(WithClientID(1))
 		txt := d.GetText("t")
 		txt.baseType().disableMarkers = cold
 		d.Transact(func(tr *Transaction) {
-			for i := 0; i < 2000; i++ {
+			for i := 0; i < 500; i++ {
 				txt.Insert(tr, txt.Len(), "a", nil)
 			}
 			// First attrs-carrying insert: hasFormatting is still false when
 			// currentAttributesAt is consulted here (it flips true only once
 			// this call's own opening marker integrates).
 			txt.Insert(tr, txt.Len(), "BOLD", Attributes{"bold": true})
-			for i := 0; i < 2000; i++ {
+			for i := 0; i < 500; i++ {
 				txt.Insert(tr, txt.Len(), "b", nil)
 			}
 			// hasFormatting is now true: exercises the full walk from
 			// txt.start, at a position before the only existing marker.
-			txt.Insert(tr, 500, "MID", Attributes{"bold": true})
+			txt.Insert(tr, 125, "MID", Attributes{"bold": true})
 			txt.Insert(tr, txt.Len(), "END", Attributes{"italic": true})
 		})
 		return txt.ToDelta()
@@ -1134,7 +1153,11 @@ func diffSummary(a, b string) string {
 // the head fast path stays correct whether or not the marker cache beside it
 // is active.
 func TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers(t *testing.T) {
-	const n = 4000
+	// n=1000 (well above maxSearchMarker=80): the head/positioned delete loop
+	// below is self-limiting on len(want)>20/>10, so it naturally runs fewer
+	// iterations at smaller n — this keeps the O(n^2) cold positioned-delete
+	// cost under the CI race budget while still exercising multiple markers.
+	const n = 1000
 	base := cyclicText(n)
 
 	// replay runs the exact same delete sequence — driven only by the shared

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -1188,5 +1189,92 @@ func TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers(t *testing.
 	}
 	if got != oracle {
 		t.Fatalf("ygo result != independent-oracle (firstLiveCache/marker coexistence bug):\n%s", diffSummary(got, oracle))
+	}
+}
+
+// TestSearchMarker_ConcurrentReadersNoRace is the -race regression guard for
+// G2: it proves that concurrent readers consulting the search-marker cache
+// via findMarkerRO (under doc.mu.RLock) never race against a writer mutating
+// that same cache via findMarkerMut (under doc.mu.Lock, inside Transact).
+//
+// This intentionally exercises YArray, not YText. YText's only read paths
+// (ToString/ToDelta) walk t.start directly and never call findMarkerRO at
+// all — a test built on them would pass under -race no matter what
+// findMarkerRO did, because it would never touch t.markers concurrently in
+// the first place. YArray.Get is the one exported read op that calls
+// findMarkerRO (see yarray.go), so looping it concurrently with Transact
+// writes on the same array is what actually puts G2 (findMarkerRO must never
+// write t.markers/t.markerTimestamp) under test: if findMarkerRO ever
+// mutated shared state, or if a read op ever reached findMarkerMut instead,
+// `go test -race` would report a race between the reader goroutines' RLock
+// section and the writer's Lock section touching t.markers.
+//
+// The test asserts no panic (out-of-range Get during a concurrent shrink
+// must return nil, not crash) and that the array is left internally
+// consistent once the race stops. Its real value is only visible under
+// `-race`; run with `go test ./crdt/ -race -run TestSearchMarker_ConcurrentReadersNoRace`.
+func TestSearchMarker_ConcurrentReadersNoRace(t *testing.T) {
+	d := New(WithClientID(1))
+	arr := d.GetArray("a")
+
+	const seedLen = 64
+	seed := make([]any, seedLen)
+	for i := range seed {
+		seed[i] = i
+	}
+	d.Transact(func(tr *Transaction) { arr.Insert(tr, 0, seed) })
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				// ToSlice() (RLock) both reads a chunk of live state and gives
+				// us a length to probe with Get(); Get() itself (RLock) drives
+				// findMarkerRO directly against whatever the writer's Transact
+				// (Lock) is doing to t.markers concurrently.
+				s := arr.ToSlice()
+				if n := len(s); n > 0 {
+					_ = arr.Get(rng.Intn(n))
+				}
+				// Also probe indices that may already be out of range by the
+				// time Get runs (the writer shrinks/grows concurrently) —
+				// Get must degrade to nil, never panic or corrupt state.
+				_ = arr.Get(rng.Intn(seedLen * 2))
+			}
+		}(int64(i) + 1)
+	}
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 0; i < 200; i++ {
+		d.Transact(func(tr *Transaction) {
+			n := arr.Len()
+			switch {
+			case n == 0 || rng.Intn(3) == 0:
+				arr.Push(tr, []any{i})
+			case rng.Intn(2) == 0:
+				arr.Insert(tr, rng.Intn(n), []any{i})
+			default:
+				arr.Delete(tr, rng.Intn(n), 1)
+			}
+		})
+	}
+	close(done)
+	wg.Wait()
+
+	// Sanity check post-race: Len() (the running count maintained by the
+	// write path) must agree with the actual number of live elements a fresh
+	// RLock'd walk finds. A findMarkerRO/findMarkerMut race that corrupted
+	// t.markers could plausibly desync these even though nothing panicked.
+	if got, want := len(arr.ToSlice()), arr.Len(); got != want {
+		t.Fatalf("post-race inconsistency: len(ToSlice())=%d Len()=%d", got, want)
 	}
 }

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -1040,31 +1040,84 @@ func TestSearchMarker_AfterGC_MatchesCold(t *testing.T) {
 func TestSearchMarker_AfterGC_LargeDoc_MatchesCold(t *testing.T) {
 	const n = 3000
 	base := cyclicText(n)
+
+	// op records one loop iteration's parameters. Ops are precomputed by
+	// replaying the exact same rng-driven sequence against a plain Go string
+	// (see oracle below) rather than against the CRDT's own txt.Len(), so the
+	// two build() runs and the oracle all execute the identical sequence of
+	// (delPos, delN, insPos) regardless of what ygo itself reports for Len() —
+	// this is what makes the oracle independent: it cannot inherit a bug that
+	// both the marker and cold ygo code paths might share (e.g. in
+	// gcTxnDeleteSet's content-swap or deleteRange's accounting), because it
+	// never asks ygo for a length while deciding what to do next.
+	type op struct {
+		delPos, delN, insPos int
+	}
+	var ops []op
+	oracle := func() string {
+		want := base
+		rng := rand.New(rand.NewSource(42))
+		for i := 0; i < 200 && len(want) > 20; i++ {
+			delPos := rng.Intn(len(want) - 10)
+			delN := 1 + rng.Intn(9)
+			want = want[:delPos] + want[delPos+delN:]
+
+			insPos := rng.Intn(len(want) + 1)
+			want = want[:insPos] + "Z" + want[insPos:]
+
+			ops = append(ops, op{delPos, delN, insPos})
+		}
+		return want
+	}()
+
 	build := func(cold bool) string {
 		d := New(WithClientID(1), WithGC(true))
 		txt := d.GetText("t")
 		txt.baseType().disableMarkers = cold
 		d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, base, nil) })
-		rng := rand.New(rand.NewSource(42))
-		for i := 0; i < 200 && txt.Len() > 20; i++ {
+		for _, o := range ops {
 			// Each delete commits (and auto-GCs) in its own transaction so the
 			// NEXT operation always sees GC'd tombstones from the previous one.
-			d.Transact(func(tr *Transaction) {
-				pos := rng.Intn(txt.Len() - 10)
-				dn := 1 + rng.Intn(9)
-				txt.Delete(tr, pos, dn)
-			})
-			d.Transact(func(tr *Transaction) {
-				pos := rng.Intn(txt.Len() + 1)
-				txt.Insert(tr, pos, "Z", nil)
-			})
+			d.Transact(func(tr *Transaction) { txt.Delete(tr, o.delPos, o.delN) })
+			d.Transact(func(tr *Transaction) { txt.Insert(tr, o.insPos, "Z", nil) })
 		}
 		return txt.ToString()
 	}
 	got, cold := build(false), build(true)
 	if got != cold {
-		t.Fatalf("post-GC large-doc marker/cold mismatch: len(got)=%d len(cold)=%d", len(got), len(cold))
+		t.Fatalf("post-GC large-doc marker/cold mismatch:\n%s", diffSummary(got, cold))
 	}
+	if got != oracle {
+		t.Fatalf("post-GC large-doc ygo result != independent plain-Go oracle:\n%s", diffSummary(got, oracle))
+	}
+}
+
+// diffSummary reports the first index at which a and b differ, plus a
+// truncated %q window around it, for use in test failure messages where a
+// bare length comparison would hide where (and how) two long strings
+// actually diverge.
+func diffSummary(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	const window = 20
+	snippet := func(s string) string {
+		end := i + window
+		if end > len(s) {
+			end = len(s)
+		}
+		if i >= len(s) {
+			return "<end of string>"
+		}
+		return fmt.Sprintf("%q", s[i:end])
+	}
+	return fmt.Sprintf("len(a)=%d len(b)=%d, first diff at index %d\n a[%d:] = %s\n b[%d:] = %s",
+		len(a), len(b), i, i, snippet(a), i, snippet(b))
 }
 
 // TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers (G6)
@@ -1131,9 +1184,9 @@ func TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers(t *testing.
 
 	got, cold := build(false), build(true)
 	if got != cold {
-		t.Fatalf("marker/cold mismatch: len(got)=%d len(cold)=%d", len(got), len(cold))
+		t.Fatalf("marker/cold mismatch:\n%s", diffSummary(got, cold))
 	}
 	if got != oracle {
-		t.Fatalf("got len=%d != independent-oracle len=%d (firstLiveCache/marker coexistence bug)", len(got), len(oracle))
+		t.Fatalf("ygo result != independent-oracle (firstLiveCache/marker coexistence bug):\n%s", diffSummary(got, oracle))
 	}
 }

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -450,15 +450,14 @@ func TestSearchMarker_ArraySlice_MatchesCold(t *testing.T) {
 	}
 }
 
-// TestSearchMarker_ArrayGetSlice_MoveGated_MatchesCold guards the hasMoves
-// gate added alongside this task's Get/Slice routing: search_marker.go's
-// renderedStep counts items by PHYSICAL position and doesn't yet know how to
-// render a ContentMove's target at its destination or skip an item that
-// moved away (that move-awareness is deferred to a later task), so an array
-// that has ever used Move must keep taking the original fully move-aware
-// walk regardless of disableMarkers. Without the gate this would silently
-// return wrong values instead of merely being slow.
-func TestSearchMarker_ArrayGetSlice_MoveGated_MatchesCold(t *testing.T) {
+// TestSearchMarker_ArrayGetSlice_Move_MatchesCold checks that the move-aware
+// search-marker walk (G5) returns the same values via markers as via a full
+// cold walk for an array that uses Move. renderedStep now renders a winning
+// ContentMove's target at its destination and skips a moved-away item at its
+// origin, so YArray.Get/Slice route move-containing arrays through the marker
+// fast path (the earlier hasMoves bypass is gone). Independent oracle:
+// [b c d a e].
+func TestSearchMarker_ArrayGetSlice_Move_MatchesCold(t *testing.T) {
 	build := func(cold bool) ([]any, []any) {
 		d := New(WithClientID(1))
 		arr := d.GetArray("a")
@@ -483,6 +482,176 @@ func TestSearchMarker_ArrayGetSlice_MoveGated_MatchesCold(t *testing.T) {
 	if !reflect.DeepEqual(gotGet, want) {
 		t.Fatalf("Get(0..4) got %v want %v", gotGet, want)
 	}
+}
+
+// TestSearchMarker_WithMove_MatchesCold is the move-awareness oracle (G5): a
+// document containing an active ContentMove must return the same rendered order
+// via the marker fast path as via a full cold walk (disableMarkers), across
+// every index. Covers three ContentMove shapes — a move that WINS (renders its
+// target at the destination), a move that LOSES concurrent arbitration (present
+// in the linked list but renders nothing), and a move whose element is later
+// DELETED (renders nothing). renderedStep must count a moved-away item at its
+// rendered destination, not its physical list position, or markers diverge from
+// cold.
+func TestSearchMarker_WithMove_MatchesCold(t *testing.T) {
+	// Scenario 1: single winning move. [0 1 2 3 4], Move(4→1) => [0 4 1 2 3].
+	t.Run("winning", func(t *testing.T) {
+		build := func(cold bool) []any {
+			d := New(WithClientID(1))
+			arr := d.GetArray("a")
+			arr.baseType().disableMarkers = cold
+			d.Transact(func(tr *Transaction) {
+				for _, v := range []int{0, 1, 2, 3, 4} {
+					arr.Insert(tr, arr.Len(), []any{v})
+				}
+			})
+			d.Transact(func(tr *Transaction) { arr.Move(tr, 4, 1) })
+			out := make([]any, 0, arr.Len())
+			for i := 0; i < arr.Len(); i++ {
+				out = append(out, arr.Get(i))
+			}
+			return out
+		}
+		got, cold := build(false), build(true)
+		if !reflect.DeepEqual(got, cold) {
+			t.Fatalf("winning move: markers=%v cold=%v", got, cold)
+		}
+		want := []any{int64(0), int64(4), int64(1), int64(2), int64(3)}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("winning move: got %v want %v (independent oracle)", got, want)
+		}
+	})
+
+	// Scenario 2: a losing ContentMove. Two peers move the same element to
+	// different destinations; after merge both docs hold two ContentMove items
+	// targeting the same item — one wins, one loses (renders nothing). The
+	// lower ClientID wins, so doc1's destination is authoritative.
+	t.Run("losing", func(t *testing.T) {
+		build := func(cold bool) []any {
+			doc1 := newTestDoc(1)
+			doc2 := newTestDoc(2)
+			arr1 := doc1.GetArray("list")
+			arr2 := doc2.GetArray("list")
+			arr1.baseType().disableMarkers = cold
+			doc1.Transact(func(txn *Transaction) { arr1.Push(txn, []any{"a", "b", "c", "d"}) })
+			if err := ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, nil), nil); err != nil {
+				t.Fatal(err)
+			}
+			doc1.Transact(func(txn *Transaction) { arr1.Move(txn, 0, 1) }) // [b a c d]
+			doc2.Transact(func(txn *Transaction) { arr2.Move(txn, 0, 3) }) // [b c d a]
+			sv1, sv2 := doc1.store.StateVector(), doc2.store.StateVector()
+			if err := ApplyUpdateV1(doc1, EncodeStateAsUpdateV1(doc2, sv1), nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, sv2), nil); err != nil {
+				t.Fatal(err)
+			}
+			out := make([]any, 0, arr1.Len())
+			for i := 0; i < arr1.Len(); i++ {
+				out = append(out, arr1.Get(i))
+			}
+			return out
+		}
+		got, cold := build(false), build(true)
+		if !reflect.DeepEqual(got, cold) {
+			t.Fatalf("losing move: markers=%v cold=%v", got, cold)
+		}
+	})
+
+	// Scenario 3: warm markers across a move — after the move, further
+	// positioned inserts build/refresh markers under move presence (exercising
+	// markPositionAt's move-aware counting and findMarkerRO reading from a
+	// move-aware marker), then Get across all indices must equal cold and the
+	// independent oracle. Inserting into a move-containing array also exercises
+	// leftNeighbourAt on a move-aware bracket.
+	t.Run("warm-inserts-after-move", func(t *testing.T) {
+		build := func(cold bool) []any {
+			d := New(WithClientID(1))
+			arr := d.GetArray("a")
+			arr.baseType().disableMarkers = cold
+			d.Transact(func(tr *Transaction) {
+				for i := 0; i < 30; i++ {
+					arr.Insert(tr, arr.Len(), []any{i})
+				}
+				arr.Move(tr, 29, 5) // move last elem to index 5 (a ContentMove there)
+				// Positioned inserts after the move rebuild markers move-aware.
+				// Index 6 brackets the moved element's ContentMove in
+				// leftNeighbourAt, exercising the offset path on a move bracket.
+				arr.Insert(tr, 6, []any{99})
+				arr.Insert(tr, 3, []any{100})
+				arr.Insert(tr, 10, []any{101})
+				arr.Insert(tr, 20, []any{102})
+			})
+			out := make([]any, 0, arr.Len())
+			for i := 0; i < arr.Len(); i++ {
+				out = append(out, arr.Get(i))
+			}
+			return out
+		}
+		got, cold := build(false), build(true)
+		if !reflect.DeepEqual(got, cold) {
+			t.Fatalf("warm inserts after move: markers=%v cold=%v", got, cold)
+		}
+	})
+
+	// Scenario 4: a winning move whose element is then deleted — the
+	// ContentMove and its target both render nothing.
+	t.Run("deleted", func(t *testing.T) {
+		build := func(cold bool) []any {
+			d := New(WithClientID(1))
+			arr := d.GetArray("a")
+			arr.baseType().disableMarkers = cold
+			d.Transact(func(tr *Transaction) {
+				for _, v := range []int{0, 1, 2, 3, 4} {
+					arr.Insert(tr, arr.Len(), []any{v})
+				}
+			})
+			d.Transact(func(tr *Transaction) { arr.Move(tr, 4, 1) }) // [0 4 1 2 3]
+			d.Transact(func(tr *Transaction) { arr.Delete(tr, 1, 1) })
+			out := make([]any, 0, arr.Len())
+			for i := 0; i < arr.Len(); i++ {
+				out = append(out, arr.Get(i))
+			}
+			return out
+		}
+		got, cold := build(false), build(true)
+		if !reflect.DeepEqual(got, cold) {
+			t.Fatalf("deleted move: markers=%v cold=%v", got, cold)
+		}
+	})
+
+	// Scenario 5: many deletes at varied positions on a move-containing array.
+	// deleteRange positions its start via findMarkerMut (now move-aware) and
+	// then walks; markers ON vs force-cold must yield the identical document,
+	// guaranteeing the marker cache never changes which element a delete
+	// resolves to even when moves are present.
+	t.Run("delete-positions-after-move", func(t *testing.T) {
+		build := func(cold bool) []any {
+			d := New(WithClientID(1))
+			arr := d.GetArray("a")
+			arr.baseType().disableMarkers = cold
+			d.Transact(func(tr *Transaction) {
+				for i := 0; i < 40; i++ {
+					arr.Insert(tr, arr.Len(), []any{i})
+				}
+				arr.Move(tr, 39, 4)
+				arr.Move(tr, 10, 30)
+				arr.Delete(tr, 5, 3)
+				arr.Delete(tr, 0, 2)
+				arr.Delete(tr, 20, 4)
+				arr.Delete(tr, 15, 1)
+			})
+			out := make([]any, 0, arr.Len())
+			for i := 0; i < arr.Len(); i++ {
+				out = append(out, arr.Get(i))
+			}
+			return out
+		}
+		got, cold := build(false), build(true)
+		if !reflect.DeepEqual(got, cold) {
+			t.Fatalf("delete positions after move: markers=%v cold=%v", got, cold)
+		}
+	})
 }
 
 // cyclicText returns a length-n string where byte i is determined by i mod 7

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -995,3 +995,145 @@ func TestSearchMarker_Format_MatchesCold_OutOfRange(t *testing.T) {
 		}
 	}
 }
+
+// TestSearchMarker_AfterGC_MatchesCold (G7) exercises the interaction between
+// search markers and auto-GC (doc.gc=true, snapshot.go's gcTxnDeleteSet):
+// once a deleted range's Content is replaced with a ContentDeleted tombstone,
+// any search marker that used to point at one of those items must not be
+// consulted as if it were still live. GC only ever touches items that are
+// already item.Deleted (gcTxnDeleteSet/RunGC both gate on it), and every
+// marker-maintenance site keys off item.Deleted, not Content's concrete
+// type (updateMarkerChanges drops markers on m.item.Deleted; renderedStep
+// treats a Deleted item as non-countable regardless of Content) — so this
+// test is expected to already pass, serving as a regression guard for that
+// invariant rather than motivating new invalidation code.
+func TestSearchMarker_AfterGC_MatchesCold(t *testing.T) {
+	build := func(cold bool) string {
+		d := New(WithClientID(1), WithGC(true))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, "abcdefghij", nil) })
+		// Deletes "cdef"; auto-GC (d.gc=true) replaces its Content with a
+		// ContentDeleted tombstone at commit, per doc.go's gcTxnDeleteSet.
+		d.Transact(func(tr *Transaction) { txt.Delete(tr, 2, 4) })
+		// A positioned insert that must resolve its left-neighbour via
+		// findMarkerMut/leftNeighbourAt against a document that now contains
+		// a GC'd tombstone in the middle of the list.
+		d.Transact(func(tr *Transaction) { txt.Insert(tr, 3, "Z", nil) })
+		return txt.ToString()
+	}
+	got, cold := build(false), build(true)
+	if got != cold {
+		t.Fatalf("post-GC markers=%q cold=%q", got, cold)
+	}
+	if want := "abgZhij"; got != want {
+		t.Fatalf("got %q want %q (independent oracle: delete [2,6) from abcdefghij, then insert Z at 3)", got, want)
+	}
+}
+
+// TestSearchMarker_AfterGC_LargeDoc_MatchesCold stresses G7 further: many
+// scattered deletes across a large document, each committed in its own
+// transaction so auto-GC tombstones them before the next operation runs,
+// interleaved with positioned inserts/deletes that must route around the
+// GC'd items via the marker fast path. Guards against a marker surviving a
+// GC'd item and mis-reporting its rendered start.
+func TestSearchMarker_AfterGC_LargeDoc_MatchesCold(t *testing.T) {
+	const n = 3000
+	base := cyclicText(n)
+	build := func(cold bool) string {
+		d := New(WithClientID(1), WithGC(true))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, base, nil) })
+		rng := rand.New(rand.NewSource(42))
+		for i := 0; i < 200 && txt.Len() > 20; i++ {
+			// Each delete commits (and auto-GCs) in its own transaction so the
+			// NEXT operation always sees GC'd tombstones from the previous one.
+			d.Transact(func(tr *Transaction) {
+				pos := rng.Intn(txt.Len() - 10)
+				dn := 1 + rng.Intn(9)
+				txt.Delete(tr, pos, dn)
+			})
+			d.Transact(func(tr *Transaction) {
+				pos := rng.Intn(txt.Len() + 1)
+				txt.Insert(tr, pos, "Z", nil)
+			})
+		}
+		return txt.ToString()
+	}
+	got, cold := build(false), build(true)
+	if got != cold {
+		t.Fatalf("post-GC large-doc marker/cold mismatch: len(got)=%d len(cold)=%d", len(got), len(cold))
+	}
+}
+
+// TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers (G6)
+// exercises firstLiveCache and the search-marker cache side by side.
+// deleteRange's index<=0 branch (yarray.go) ALWAYS resolves the head item via
+// t.firstLiveFromStart — unconditionally, regardless of disableMarkers — so a
+// long run of delete-at-0 calls builds a large head-tombstone run that is
+// skipped in O(1) amortized per issue #86. Interleaved positioned deletes
+// elsewhere use findMarkerMut (or, under the force-cold seam, an equivalent
+// full walk). Comparing marker-enabled vs force-cold builds — AND both
+// against a plain-Go-string oracle that replays the identical operation
+// sequence — proves the two caches don't corrupt each other's bookkeeping:
+// the head fast path stays correct whether or not the marker cache beside it
+// is active.
+func TestSearchMarker_DeleteAtZero_FirstLiveCacheCoexistsWithMarkers(t *testing.T) {
+	const n = 4000
+	base := cyclicText(n)
+
+	// replay runs the exact same delete sequence — driven only by the shared
+	// rng and the current oracle length, so it stays in lockstep with
+	// whatever the CRDT actually did — against a plain Go string. Used both
+	// as the independent oracle and (via replay) to derive deterministic
+	// positions/lengths for the CRDT operations below.
+	replay := func(want string, rng *rand.Rand, headDeletes int) string {
+		for i := 0; i < headDeletes && len(want) > 20; i++ {
+			want = want[1:] // head delete, mirrors deleteRange's index<=0 path
+			if len(want) > 10 {
+				pos := 1 + rng.Intn(len(want)-5)
+				dn := 1 + rng.Intn(3)
+				if pos+dn > len(want) {
+					dn = len(want) - pos
+				}
+				want = want[:pos] + want[pos+dn:]
+			}
+		}
+		return want
+	}
+	oracle := replay(base, rand.New(rand.NewSource(7)), 1500)
+
+	build := func(cold bool) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, base, nil) })
+		rng := rand.New(rand.NewSource(7))
+		want := base
+		d.Transact(func(tr *Transaction) {
+			for i := 0; i < 1500 && len(want) > 20; i++ {
+				txt.Delete(tr, 0, 1) // head delete: exercises firstLiveCache
+				want = want[1:]
+				if len(want) > 10 {
+					pos := 1 + rng.Intn(len(want)-5)
+					dn := 1 + rng.Intn(3)
+					if pos+dn > len(want) {
+						dn = len(want) - pos
+					}
+					txt.Delete(tr, pos, dn) // positioned delete: exercises findMarkerMut
+					want = want[:pos] + want[pos+dn:]
+				}
+			}
+		})
+		return txt.ToString()
+	}
+
+	got, cold := build(false), build(true)
+	if got != cold {
+		t.Fatalf("marker/cold mismatch: len(got)=%d len(cold)=%d", len(got), len(cold))
+	}
+	if got != oracle {
+		t.Fatalf("got len=%d != independent-oracle len=%d (firstLiveCache/marker coexistence bug)", len(got), len(oracle))
+	}
+}

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -714,6 +714,89 @@ func TestSearchMarker_ApplyDelta_MatchesCold(t *testing.T) {
 	}
 }
 
+// TestApplyDelta_InsertDoesNotInheritPrecedingRetainFormat pins the corrected
+// (Yjs/Quill-aligned) YText.ApplyDelta insert-attribute semantics introduced
+// by the single-cursor rewrite (#181, commit 481c949): an Insert op's
+// formatting comes ONLY from that op's own Attributes field, never from a
+// preceding {retain, attributes} op's format bleeding through the shared
+// cursor. This is the documented Yjs/Quill delta rule (Yjs Text.js
+// applyDelta / the Quill delta spec): "insert" ops are formatted exclusively
+// by their own attributes map, and retain+attributes formats only the
+// retained range, closing itself with a matching negated marker immediately
+// after the range (Yjs insertNegatedAttributes) so nothing downstream
+// inherits it.
+//
+// TestSearchMarker_ApplyDelta_MatchesCold (above) is NOT discriminating for
+// this: both its marker and cold arms run the exact same ApplyDelta cursor
+// code (disableMarkers only gates search-marker usage in unrelated
+// positional lookups, not ApplyDelta's threaded cursor), and its only
+// attributed insert ("WORLD") already carries its own explicit Attributes,
+// so it never exercises the "insert with NO attributes right after a
+// formatted retain" case that changed behavior in 481c949. This test
+// asserts an explicit expected Delta/ToString, not marker==cold agreement,
+// so a silent regression back to the old bleed-through behavior is caught.
+// (Confirmed discriminating by hand: temporarily making applyDeltaInsert
+// re-derive its anchor from the index via leftNeighbourAt(pos.index) instead
+// of trusting the threaded pos.left pointer — i.e. reproducing the old
+// pre-#181 per-op index-based anchoring that let a same-index plain insert
+// land on the wrong side of a just-emitted format-closing marker — turns
+// this test red (got Insert:"abcX" with Attributes:{bold:true} instead of
+// separate "abc"/bold and "Xd"/plain runs). Reverted after confirming, not
+// committed.)
+//
+// NOTE: a Retain is deliberately placed between the two Insert ops below
+// (rather than putting them back-to-back) to sidestep a separate, unrelated
+// cursor bug also present in this rewrite: applyDeltaInsert only advances
+// pos.left past the newly-inserted item when the insert carries its own
+// attributes (diff non-empty); for a plain attribute-less insert, pos.left
+// is left stale, so a second Insert op immediately following it re-anchors
+// at the PRE-insert position and can integrate out of order (observed:
+// ApplyDelta([{Retain:3},{Insert:"X"},{Insert:"Y"}]) on "abcdefghij" yields
+// "abcYXdefghij" — X and Y swapped). That bug is out of scope for this test
+// (which only pins the insert-attribute/format-bleed semantic) and has been
+// flagged separately for a dedicated fix.
+func TestApplyDelta_InsertDoesNotInheritPrecedingRetainFormat(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) {
+		txt.Insert(tr, 0, "abcdefghij", nil) // 10 plain chars, no formatting
+		txt.ApplyDelta(tr, []Delta{
+			// Formats "abc" bold; the format must close itself and NOT leak
+			// past its own range into whatever comes next.
+			{Op: DeltaOpRetain, Retain: 3, Attributes: Attributes{"bold": true}},
+			// No attributes of its own -> must land PLAIN (the behavior this
+			// task is pinning), not bold-formatted from the preceding retain.
+			{Op: DeltaOpInsert, Insert: "X"},
+			// Plain retain over "d": no attributes, no format change. (Also
+			// sidesteps the unrelated back-to-back-insert cursor bug noted above.)
+			{Op: DeltaOpRetain, Retain: 1},
+			// Explicit attributes of its own -> must land bold.
+			{Op: DeltaOpInsert, Insert: "Y", Attributes: Attributes{"bold": true}},
+			// Plain retain over "e": no attributes, no format change.
+			{Op: DeltaOpRetain, Retain: 1},
+			// Deletes "fg".
+			{Op: DeltaOpDelete, Delete: 2},
+			// Trailing "hij" is left untouched (implicit retain-to-end).
+		})
+	})
+
+	wantStr := "abcXdYehij"
+	if got := txt.ToString(); got != wantStr {
+		t.Fatalf("ToString() = %q, want %q", got, wantStr)
+	}
+
+	want := []Delta{
+		{Op: DeltaOpInsert, Insert: "abc", Attributes: Attributes{"bold": true}},
+		{Op: DeltaOpInsert, Insert: "Xd"},
+		{Op: DeltaOpInsert, Insert: "Y", Attributes: Attributes{"bold": true}},
+		{Op: DeltaOpInsert, Insert: "ehij"},
+	}
+	got := txt.ToDelta()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToDelta() mismatch (Yjs-aligned insert-attribute semantics):\n got  %#v\n want %#v", got, want)
+	}
+}
+
 // TestSearchMarker_Format_MatchesCold_OutOfRange exercises findTextPos's
 // !hasFormatting fast path (ytext.go) at and beyond the document's length —
 // the case findTextPos must clamp pos.index to t.length exactly like the

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -1,0 +1,104 @@
+package crdt
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// coldLeftNeighbour is the reference (marker-free) linear walk used as the oracle.
+func coldLeftNeighbour(t *abstractType, index int) (*Item, int) {
+	if index <= 0 {
+		return nil, 0
+	}
+	counted := 0
+	for item := t.start; item != nil; item = item.Right {
+		if item.Deleted || !item.Content.IsCountable() {
+			continue
+		}
+		n := item.Content.Len()
+		if counted+n >= index {
+			return item, counted
+		}
+		counted += n
+	}
+	return nil, counted
+}
+
+func TestSearchMarker_ROMatchesCold_Text(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, "hello world foo bar baz", nil) })
+	at := txt.baseType()
+	for i := 0; i <= txt.Len(); i++ {
+		gi, gidx := at.findMarkerRO(i)
+		ci, cidx := coldLeftNeighbour(at, i)
+		if gi != ci || gidx != cidx {
+			t.Fatalf("index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", i, gi, gidx, ci, cidx)
+		}
+	}
+}
+
+// TestSearchMarker_ROMatchesCold_LargeDocRandom builds a ~5k-char document
+// via many separate inserts (so the linked list has many distinct items,
+// some possibly deleted), hand-seeds a handful of search markers with
+// correct (index, item) pairs taken from the cold oracle, and asserts that
+// findMarkerRO — using those markers as its nearest-marker starting points —
+// still agrees with the marker-free oracle for 500 random indices. This
+// exercises the nearest-marker-then-walk-right/left code paths in
+// findMarkerRO, not just the empty-markers fallback covered by the test
+// above.
+func TestSearchMarker_ROMatchesCold_LargeDocRandom(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+
+	rng := rand.New(rand.NewSource(42))
+
+	// Build a large, fragmented document: many small inserts at random
+	// positions, plus occasional deletes, so the linked list contains a
+	// realistic mix of live and tombstoned items.
+	d.Transact(func(tr *Transaction) {
+		for txt.Len() < 5000 {
+			chunk := fmt.Sprintf("chunk%d ", rng.Intn(100000))
+			pos := rng.Intn(txt.Len() + 1)
+			txt.Insert(tr, pos, chunk, nil)
+			if txt.Len() > 20 && rng.Intn(5) == 0 {
+				delPos := rng.Intn(txt.Len() - 10)
+				txt.Delete(tr, delPos, 3+rng.Intn(5))
+			}
+		}
+	})
+
+	at := txt.baseType()
+
+	// Hand-seed markers at a handful of positions using the cold oracle as
+	// the source of truth for (item, index) pairs, mimicking what a later
+	// write-path would install — but findMarkerRO itself must never write
+	// t.markers.
+	seedPositions := []int{1, 100, 777, 1234, 2500, 3333, 4321, 4999, txt.Len()}
+	markers := make([]searchMarker, 0, len(seedPositions))
+	for _, p := range seedPositions {
+		item, idx := coldLeftNeighbour(at, p)
+		if item == nil {
+			continue
+		}
+		markers = append(markers, searchMarker{item: item, index: idx})
+	}
+	at.markers = markers
+
+	for i := 0; i < 500; i++ {
+		idx := rng.Intn(txt.Len() + 1)
+		gi, gidx := at.findMarkerRO(idx)
+		ci, cidx := coldLeftNeighbour(at, idx)
+		if gi != ci || gidx != cidx {
+			t.Fatalf("index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", idx, gi, gidx, ci, cidx)
+		}
+	}
+
+	// Sanity: the marker slice itself must be untouched by findMarkerRO —
+	// it must still have exactly the entries we seeded (read-only lookup
+	// never appends/truncates/reassigns t.markers).
+	if len(at.markers) != len(markers) {
+		t.Fatalf("t.markers length changed by findMarkerRO: got %d, want %d", len(at.markers), len(markers))
+	}
+}

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -249,7 +249,7 @@ func TestSearchMarker_RemoteDeleteOnly_NoStale(t *testing.T) {
 // naive strict-less-than condition wrong for our re-walk-trusting findMarkerRO
 // (see the "index <= m.index" reasoning in search_marker.go).
 func TestUpdateMarkerChanges_ShiftSemantics(t *testing.T) {
-	live := &Item{Content: NewContentString("x")}         // countable, not deleted
+	live := &Item{Content: NewContentString("x")} // countable, not deleted
 	dead := &Item{Content: NewContentString("y"), Deleted: true}
 
 	t.Run("insert shifts markers at or after the edit index", func(t *testing.T) {

--- a/crdt/search_marker_test.go
+++ b/crdt/search_marker_test.go
@@ -102,3 +102,102 @@ func TestSearchMarker_ROMatchesCold_LargeDocRandom(t *testing.T) {
 		t.Fatalf("t.markers length changed by findMarkerRO: got %d, want %d", len(at.markers), len(markers))
 	}
 }
+
+// TestSearchMarker_InsertMatchesCold drives the mutating write-path lookup
+// (leftNeighbourAt → findMarkerMut) with several insert orderings and asserts
+// the resulting document is identical to a force-cold run (disableMarkers),
+// i.e. the search-marker maintenance never changes the position a local
+// insert resolves to.
+func TestSearchMarker_InsertMatchesCold(t *testing.T) {
+	build := func(cold bool, order []int) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		d.Transact(func(tr *Transaction) {
+			for _, pos := range order {
+				txt.Insert(tr, pos, "x", nil)
+			}
+		})
+		return txt.ToString()
+	}
+	seq := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	rev := []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	rnd := []int{0, 1, 0, 2, 1, 3, 0, 4, 2, 1}
+	for _, order := range [][]int{seq, rev, rnd} {
+		if got, want := build(false, order), build(true, order); got != want {
+			t.Fatalf("markers=%q cold=%q order=%v", got, want, order)
+		}
+	}
+}
+
+// TestSearchMarker_InsertMatchesCold_LargeRandom is a heavier version of the
+// above: many random inserts and deletes through the marker write path must
+// still yield exactly the force-cold document. This exercises marker refresh,
+// LRU eviction, and the shim-driven invalidation across a long transaction.
+func TestSearchMarker_InsertMatchesCold_LargeRandom(t *testing.T) {
+	build := func(cold bool) string {
+		d := New(WithClientID(1))
+		txt := d.GetText("t")
+		txt.baseType().disableMarkers = cold
+		rng := rand.New(rand.NewSource(7))
+		d.Transact(func(tr *Transaction) {
+			for i := 0; i < 3000; i++ {
+				pos := rng.Intn(txt.Len() + 1)
+				txt.Insert(tr, pos, fmt.Sprintf("%d", rng.Intn(10)), nil)
+				if txt.Len() > 30 && rng.Intn(6) == 0 {
+					txt.Delete(tr, rng.Intn(txt.Len()-5), 1+rng.Intn(4))
+				}
+			}
+		})
+		return txt.ToString()
+	}
+	if got, want := build(false), build(true); got != want {
+		t.Fatalf("marker/cold divergence:\n marker len=%d\n cold   len=%d", len(got), len(want))
+	}
+}
+
+// TestSearchMarker_RO_IndexBeyondLen (carried over from Task 1 review): a
+// read-only lookup for index > Len() must match the cold oracle (both walk
+// off the end and return (nil, totalCounted)).
+func TestSearchMarker_RO_IndexBeyondLen(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, "abcde", nil) })
+	at := txt.baseType()
+	for _, idx := range []int{txt.Len() + 1, txt.Len() + 5, txt.Len() + 100} {
+		gi, gidx := at.findMarkerRO(idx)
+		ci, cidx := coldLeftNeighbour(at, idx)
+		if gi != ci || gidx != cidx {
+			t.Fatalf("index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", idx, gi, gidx, ci, cidx)
+		}
+	}
+}
+
+// TestSearchMarker_RO_DisableMarkersIgnoresBadMarkers (carried over from Task
+// 1 review): with disableMarkers set, findMarkerRO must ignore t.markers
+// entirely and fall back to the cold walk — even when t.markers is populated
+// with deliberately wrong (item, index) pairs.
+func TestSearchMarker_RO_DisableMarkersIgnoresBadMarkers(t *testing.T) {
+	d := New(WithClientID(1))
+	txt := d.GetText("t")
+	d.Transact(func(tr *Transaction) { txt.Insert(tr, 0, "hello world foo bar", nil) })
+	at := txt.baseType()
+
+	// Populate markers with garbage: point every marker at the first item but
+	// claim wildly wrong indices. If findMarkerRO consulted these it would
+	// return wrong answers.
+	at.markers = []searchMarker{
+		{item: at.start, index: 9999},
+		{item: at.start, index: -50},
+		{item: at.start, index: 3},
+	}
+	at.disableMarkers = true
+
+	for i := 0; i <= txt.Len()+2; i++ {
+		gi, gidx := at.findMarkerRO(i)
+		ci, cidx := coldLeftNeighbour(at, i)
+		if gi != ci || gidx != cidx {
+			t.Fatalf("index %d: findMarkerRO=(%p,%d) cold=(%p,%d)", i, gi, gidx, ci, cidx)
+		}
+	}
+}

--- a/crdt/transaction.go
+++ b/crdt/transaction.go
@@ -226,8 +226,13 @@ func squashRuns(txn *Transaction) {
 				cs := left.Content.(*ContentString)
 				cs.Str = sb.String()
 				cs.utf16Len = utf16Len(cs.Str)
+				// A run squash absorbs the right items into left and splices them
+				// out of the linked list; a marker still pointing at an absorbed
+				// (now off-list) item would walk from a dangling node. Rendered
+				// positions are unchanged, but relocating each marker is Task 5's
+				// mergeWith concern — here we clear all markers (always safe).
 				if left.Parent != nil {
-					left.Parent.invalidatePosCache()
+					left.Parent.clearMarkers()
 				}
 				// Compact items slice: skip over all absorbed entries.
 				items = append(items[:i+1], items[j:]...)
@@ -404,8 +409,12 @@ func tryMergeWithLeft(item *Item, store *StructStore) bool {
 	if item.Right != nil {
 		item.Right.Left = left
 	}
+	// item is absorbed into left and removed from the list. A marker still
+	// pointing at item would be left dangling; rendered positions don't change,
+	// but marker relocation on merge is Task 5's mergeWith concern, so clear all
+	// markers here (always safe).
 	if left.Parent != nil {
-		left.Parent.invalidatePosCache()
+		left.Parent.clearMarkers()
 	}
 
 	// Remove item from the store's per-client slice.

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -678,13 +678,36 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 		item, counted = t.findMarkerMut(index)
 	}
 	for item != nil && length > 0 {
-		if item.Deleted || !item.Content.IsCountable() {
+		// Rendered contribution via the single shared, move-aware definition —
+		// the SAME one Get/Slice/ForEach use to resolve values — so deleteRange's
+		// counting can never drift out of step with what Get reports at a rendered
+		// index (the #181 bug: the old loop counted raw physical IsCountable/Len,
+		// so on a moved array it skipped the winning ContentMove, counted the
+		// moved-away item at its origin, and thus deleted the wrong element).
+		countable, n, renderAt := t.renderedStep(item)
+		if !countable {
 			item = item.Right
 			continue
 		}
-		n := item.Content.Len()
 		if counted+n <= index {
 			counted += n
+			item = item.Right
+			continue
+		}
+		if renderAt != nil {
+			// Winning ContentMove: the rendered values come from the moved TARGET
+			// (renderAt), not from this ContentMove item. TargetLen is always 1
+			// (Move() forces single-element targets; resolveMovedItem trims remote
+			// moves to it), so n == 1 — the moved element is atomic and can only be
+			// fully within the deletion range here (counted >= index, since an
+			// integer index cannot land strictly inside a width-1 rendered step).
+			// Deleting the target makes BOTH the target's origin slot and this
+			// ContentMove render nothing (renderedStep drops a deleted-target move),
+			// which is exactly how Yjs removes a moved element: the DELETE lands on
+			// the moved content, matching Get(i). No split of the target is needed
+			// or safe (splitItem would not carry MovedBy to the right half).
+			renderAt.delete(txn)
+			length -= n
 			item = item.Right
 			continue
 		}

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -1,6 +1,9 @@
 package crdt
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // arraySub pairs a unique subscription ID with a YArrayEvent callback.
 type arraySub struct {
@@ -706,6 +709,24 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 			// which is exactly how Yjs removes a moved element: the DELETE lands on
 			// the moved content, matching Get(i). No split of the target is needed
 			// or safe (splitItem would not carry MovedBy to the right half).
+			//
+			// Defensive guard (#181 follow-up): the line above assumes n <= length,
+			// which today always holds because n == 1 (TargetLen is forced to 1 by
+			// Move() and resolveMovedItem only ever clamps a remote target DOWN to
+			// <= TargetLen, never merges multiple items up to it) and length >= 1
+			// here (the loop guard). But TargetLen travels over the wire
+			// (update.go/update_v2.go encode it verbatim), so a hand-built or
+			// adversarial update could carry TargetLen > 1 against an item that is
+			// already exactly that wide, producing n > 1. If that ever collides
+			// with a smaller remaining length, unconditionally deleting the whole
+			// target below would silently delete more rendered positions than the
+			// caller asked for — and we can't fix it by partially deleting the
+			// target instead, because splitItem does not carry MovedBy to the right
+			// half, so a partial-target delete would corrupt the move. Fail loudly
+			// rather than silently over-deleting.
+			if n > length {
+				panic(fmt.Sprintf("crdt: deleteRange: winning ContentMove target width %d exceeds remaining delete length %d at rendered index %d (multi-element ContentMove targets are unsupported)", n, length, index))
+			}
 			renderAt.delete(txn)
 			length -= n
 			item = item.Right

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -2,7 +2,6 @@ package crdt
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // arraySub pairs a unique subscription ID with a YArrayEvent callback.
@@ -716,16 +715,14 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 			// <= TargetLen, never merges multiple items up to it) and length >= 1
 			// here (the loop guard). But TargetLen travels over the wire
 			// (update.go/update_v2.go encode it verbatim), so a hand-built or
-			// adversarial update could carry TargetLen > 1 against an item that is
-			// already exactly that wide, producing n > 1. If that ever collides
-			// with a smaller remaining length, unconditionally deleting the whole
-			// target below would silently delete more rendered positions than the
-			// caller asked for — and we can't fix it by partially deleting the
-			// target instead, because splitItem does not carry MovedBy to the right
-			// half, so a partial-target delete would corrupt the move. Fail loudly
-			// rather than silently over-deleting.
+			// foreign update could carry TargetLen > 1 against an item that is
+			// already exactly that wide, producing n > 1. A library must never
+			// panic on wire-derived input, so clamp instead of failing loudly: the
+			// width-1 (n == 1) path is untouched and byte-identical, and clamping
+			// only bounds how much of the caller's remaining delete length this
+			// malformed/foreign multi-width moved target can consume.
 			if n > length {
-				panic(fmt.Sprintf("crdt: deleteRange: winning ContentMove target width %d exceeds remaining delete length %d at rendered index %d (multi-element ContentMove targets are unsupported)", n, length, index))
+				n = length
 			}
 			renderAt.delete(txn)
 			length -= n

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -252,6 +252,38 @@ func (a *YArray) Get(index int) any {
 		defer doc.mu.RUnlock()
 	}
 	t := &a.abstractType
+	if index < 0 {
+		return nil
+	}
+
+	// Marker fast path: skip the O(index) walk from t.start via findMarkerRO
+	// (safe under RLock — it never mutates t.markers). Only valid when this
+	// array has never used Move: renderedStep counts items by PHYSICAL
+	// position and doesn't yet know how to render a ContentMove's target at
+	// its destination or skip an item that moved away, so a document with
+	// moves keeps the full move-aware walk below (see hasMoves doc comment).
+	//
+	// index+1 converts Get's "which element" (0-based) numbering to
+	// findMarkerRO's "insert-before" numbering: findMarkerRO(index+1) brackets
+	// the item whose rendered range [start, start+n) contains index, with
+	// start==the item's own rendered start — exactly what the cold loop below
+	// computes as `counted`. The tie-break at an exact item boundary agrees
+	// too: findMarkerRO returns the earlier item when start+n == index+1,
+	// which is precisely the cold loop's `counted+n > index` bracket.
+	if !t.disableMarkers && !t.hasMoves {
+		item, start := t.findMarkerRO(index + 1)
+		if item == nil {
+			return nil
+		}
+		switch c := item.Content.(type) {
+		case *ContentAny:
+			return c.Vals[index-start]
+		case *ContentType:
+			return c.Type.owner
+		}
+		return nil
+	}
+
 	counted := 0
 	for item := t.start; item != nil; item = item.Right {
 		if item.Deleted {
@@ -445,8 +477,20 @@ func (a *YArray) Slice(start, end int) []any {
 		return nil
 	}
 	result := make([]any, 0, end-start)
+
+	// Marker fast path: jump straight to the item bracketing `start` instead
+	// of walking from t.start — same hasMoves/disableMarkers safety gate as
+	// Get (see its comment). Once positioned, the loop body below (unchanged,
+	// move-aware) still visits every item through `end` to collect values, so
+	// only the O(start) prefix walk is skipped, not the O(end-start) work.
+	var item *Item
 	counted := 0
-	for item := t.start; item != nil && counted < end; item = item.Right {
+	if !t.disableMarkers && !t.hasMoves {
+		item, counted = t.findMarkerRO(start + 1)
+	} else {
+		item = t.start
+	}
+	for ; item != nil && counted < end; item = item.Right {
 		if item.Deleted {
 			continue
 		}
@@ -678,14 +722,38 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 	// needed during the walk, clears all markers, in which case the call below
 	// is a no-op on the empty set — still correct.
 	origLen := length
-	counted := 0
-	// Start the walk at firstLiveFromStart, not t.start: leading tombstones
-	// accumulated by earlier head-deletes are skipped in O(1) via the cache,
-	// turning the previous O(N) per-call leading-skip into O(1) amortized.
-	// firstLiveFromStart returns the first non-deleted item; subsequent
-	// non-countable items (e.g. ContentFormat) are still handled by the
-	// existing skip branch below. Closes the deleteRange half of #86.
-	item := t.firstLiveFromStart()
+	var item *Item
+	var counted int
+	if index <= 0 {
+		// index<=0 has no meaningful "bracket item" under findMarkerMut (it
+		// always answers (nil,0) there, by design — that's the correct
+		// leftNeighbourAt/insert-before-everything answer, not a delete
+		// start). Start the walk at firstLiveFromStart, not t.start: leading
+		// tombstones accumulated by earlier head-deletes are skipped in O(1)
+		// via the cache, turning the previous O(N) per-call leading-skip into
+		// O(1) amortized. firstLiveFromStart returns the first non-deleted
+		// item; subsequent non-countable items (e.g. ContentFormat) are still
+		// handled by the existing skip branch below. Closes the deleteRange
+		// half of #86.
+		item = t.firstLiveFromStart()
+		counted = 0
+	} else {
+		// Marker fast path: findMarkerMut brackets index directly (counted <=
+		// index <= counted+n) instead of summing lengths from the document
+		// head, closing the O(index) walk this function used to do on every
+		// call. Its tie-break (returns the earlier item when an item's range
+		// ends exactly at index) is reconciled by the same "counted+n <=
+		// index: skip forward" branch below that a full walk from t.start
+		// would also have to pass through — the very next loop iteration
+		// advances past a boundary-tied item exactly as if we'd walked here.
+		// It also respects t.disableMarkers internally (falls back to the
+		// identical cold walk), so this is safe under the force-cold test
+		// seam too. As a write-path call it also installs/refreshes a marker
+		// at the pre-delete position; updateMarkerChanges below (which always
+		// runs afterward) correctly shifts or drops it along with every other
+		// marker once the range is tombstoned.
+		item, counted = t.findMarkerMut(index)
+	}
 	for item != nil && length > 0 {
 		if item.Deleted || !item.Content.IsCountable() {
 			item = item.Right

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -256,72 +256,37 @@ func (a *YArray) Get(index int) any {
 		return nil
 	}
 
-	// Marker fast path: skip the O(index) walk from t.start via findMarkerRO
-	// (safe under RLock — it never mutates t.markers). Only valid when this
-	// array has never used Move: renderedStep counts items by PHYSICAL
-	// position and doesn't yet know how to render a ContentMove's target at
-	// its destination or skip an item that moved away, so a document with
-	// moves keeps the full move-aware walk below (see hasMoves doc comment).
+	// Single position definition (G5): findMarkerRO brackets the PHYSICAL item
+	// whose rendered range [start, start+n) contains index, using renderedStep
+	// — the one shared, move-aware notion of how each item contributes to
+	// rendered position. It internally handles the force-cold seam
+	// (t.disableMarkers → full walk from t.start) and an empty marker cache, so
+	// there is no separate inline cold walk to drift out of sync. It is safe
+	// under RLock (never mutates t.markers).
 	//
 	// index+1 converts Get's "which element" (0-based) numbering to
 	// findMarkerRO's "insert-before" numbering: findMarkerRO(index+1) brackets
-	// the item whose rendered range [start, start+n) contains index, with
-	// start==the item's own rendered start — exactly what the cold loop below
-	// computes as `counted`. The tie-break at an exact item boundary agrees
-	// too: findMarkerRO returns the earlier item when start+n == index+1,
-	// which is precisely the cold loop's `counted+n > index` bracket.
-	if !t.disableMarkers && !t.hasMoves {
-		item, start := t.findMarkerRO(index + 1)
-		if item == nil {
-			return nil
-		}
-		switch c := item.Content.(type) {
-		case *ContentAny:
-			return c.Vals[index-start]
-		case *ContentType:
-			return c.Type.owner
-		}
+	// the item whose rendered range contains index, with start == the item's
+	// own rendered start. The tie-break at an exact item boundary agrees too:
+	// findMarkerRO returns the earlier item when start+n == index+1.
+	//
+	// For a winning ContentMove the bracketing physical item is the ContentMove
+	// itself; renderedStep reports its rendered contribution as the moved
+	// target's, so renderAt points at the value-bearing target item. For a
+	// plain item renderAt is nil and the value comes from the item itself.
+	item, start := t.findMarkerRO(index + 1)
+	if item == nil {
 		return nil
 	}
-
-	counted := 0
-	for item := t.start; item != nil; item = item.Right {
-		if item.Deleted {
-			continue
-		}
-		if cm, ok := item.Content.(*ContentMove); ok {
-			if a.doc != nil {
-				target := a.doc.store.Find(*cm.Target)
-				if target != nil && target.MovedBy == item && !target.Deleted {
-					n := target.Content.Len()
-					if counted+n > index {
-						if ca, ok := target.Content.(*ContentAny); ok {
-							return ca.Vals[index-counted]
-						}
-						return nil
-					}
-					counted += n
-				}
-			}
-			continue
-		}
-		if !item.Content.IsCountable() {
-			continue
-		}
-		if item.MovedBy != nil {
-			continue
-		}
-		n := item.Content.Len()
-		if counted+n > index {
-			switch c := item.Content.(type) {
-			case *ContentAny:
-				return c.Vals[index-counted]
-			case *ContentType:
-				return c.Type.owner
-			}
-			return nil
-		}
-		counted += n
+	valItem := item
+	if _, _, renderAt := t.renderedStep(item); renderAt != nil {
+		valItem = renderAt
+	}
+	switch c := valItem.Content.(type) {
+	case *ContentAny:
+		return c.Vals[index-start]
+	case *ContentType:
+		return c.Type.owner
 	}
 	return nil
 }
@@ -478,50 +443,34 @@ func (a *YArray) Slice(start, end int) []any {
 	}
 	result := make([]any, 0, end-start)
 
-	// Marker fast path: jump straight to the item bracketing `start` instead
-	// of walking from t.start — same hasMoves/disableMarkers safety gate as
-	// Get (see its comment). Once positioned, the loop body below (unchanged,
-	// move-aware) still visits every item through `end` to collect values, so
-	// only the O(start) prefix walk is skipped, not the O(end-start) work.
-	var item *Item
-	counted := 0
-	if !t.disableMarkers && !t.hasMoves {
-		item, counted = t.findMarkerRO(start + 1)
-	} else {
-		item = t.start
-	}
+	// Marker fast path: jump straight to the physical item bracketing `start`
+	// via findMarkerRO instead of walking from t.start (it handles the
+	// force-cold seam and empty cache internally, so the disableMarkers path
+	// funnels through the same code). Once positioned, the loop still visits
+	// every item through `end` to collect values, so only the O(start) prefix
+	// walk is skipped, not the O(end-start) work.
+	//
+	// The loop derives countability, rendered length and the value-bearing
+	// item from renderedStep — the same shared, move-aware definition
+	// findMarkerRO used to position `counted` — so the collection walk can
+	// never drift out of step with the bracket it started from.
+	item, counted := t.findMarkerRO(start + 1)
 	for ; item != nil && counted < end; item = item.Right {
-		if item.Deleted {
+		countable, n, renderAt := t.renderedStep(item)
+		if !countable {
 			continue
 		}
-		if cm, ok := item.Content.(*ContentMove); ok {
-			if a.doc != nil {
-				target := a.doc.store.Find(*cm.Target)
-				if target != nil && target.MovedBy == item && !target.Deleted {
-					if ca, ok := target.Content.(*ContentAny); ok {
-						for _, v := range ca.Vals {
-							if counted >= start && counted < end {
-								result = append(result, v)
-							}
-							counted++
-							if counted >= end {
-								break
-							}
-						}
-					}
-				}
-			}
-			continue
+		valItem := item
+		if renderAt != nil {
+			valItem = renderAt
 		}
-		if !item.Content.IsCountable() {
-			continue
-		}
-		if item.MovedBy != nil {
-			continue
-		}
-		ca, ok := item.Content.(*ContentAny)
+		ca, ok := valItem.Content.(*ContentAny)
 		if !ok {
-			counted++
+			// Countable but not a plain-value item (e.g. a nested ContentType):
+			// advance the rendered cursor by its full contribution without
+			// emitting values, matching the position accounting used to bracket
+			// `start`.
+			counted += n
 			continue
 		}
 		for _, v := range ca.Vals {
@@ -546,31 +495,19 @@ func (a *YArray) ForEach(fn func(index int, value any)) {
 	}
 	t := &a.abstractType
 	index := 0
+	// Same shared position definition as Get/Slice: renderedStep decides
+	// countability and, for a winning ContentMove, points renderAt at the
+	// value-bearing target so the move is expanded at its destination.
 	for item := t.start; item != nil; item = item.Right {
-		if item.Deleted {
+		countable, _, renderAt := t.renderedStep(item)
+		if !countable {
 			continue
 		}
-		if cm, ok := item.Content.(*ContentMove); ok {
-			if a.doc != nil {
-				target := a.doc.store.Find(*cm.Target)
-				if target != nil && target.MovedBy == item && !target.Deleted {
-					if ca, ok := target.Content.(*ContentAny); ok {
-						for _, v := range ca.Vals {
-							fn(index, v)
-							index++
-						}
-					}
-				}
-			}
-			continue
+		valItem := item
+		if renderAt != nil {
+			valItem = renderAt
 		}
-		if !item.Content.IsCountable() {
-			continue
-		}
-		if item.MovedBy != nil {
-			continue
-		}
-		if ca, ok := item.Content.(*ContentAny); ok {
+		if ca, ok := valItem.Content.(*ContentAny); ok {
 			for _, v := range ca.Vals {
 				fn(index, v)
 				index++
@@ -607,38 +544,24 @@ func (a *YArray) Move(txn *Transaction, fromIndex, toIndex int) {
 	}
 	t := &a.abstractType
 
-	// Walk the rendered array to find the physical item at fromIndex.
-	// ContentMove items are "expanded" in rendering order; items with MovedBy
-	// set are skipped at their original position.
+	// Walk the rendered array to find the item at fromIndex, using the same
+	// shared renderedStep definition as Get/Slice/ForEach and the marker walk:
+	// a winning ContentMove is expanded at its destination (renderAt = the
+	// moved target), and an item that moved away contributes nothing at its
+	// origin. targetItem is the value-bearing item to relocate.
 	counted := 0
 	var targetItem *Item
 	var targetOff int
 	for item := t.start; item != nil; item = item.Right {
-		if item.Deleted {
+		countable, n, renderAt := t.renderedStep(item)
+		if !countable {
 			continue
 		}
-		if cm, ok := item.Content.(*ContentMove); ok {
-			// ContentMove renders the target here if this move won.
-			if a.doc != nil {
-				target := a.doc.store.Find(*cm.Target)
-				if target != nil && target.MovedBy == item && !target.Deleted {
-					n := target.Content.Len()
-					if counted+n > fromIndex {
-						targetItem = target
-						targetOff = fromIndex - counted
-						break
-					}
-					counted += n
-				}
-			}
-			continue
-		}
-		if !item.Content.IsCountable() || item.MovedBy != nil {
-			continue
-		}
-		n := item.Content.Len()
 		if counted+n > fromIndex {
 			targetItem = item
+			if renderAt != nil {
+				targetItem = renderAt
+			}
 			targetOff = fromIndex - counted
 			break
 		}

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -668,13 +668,16 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 	if length <= 0 {
 		return
 	}
-	// For local transactions, invalidate only the cache entries at and after the
-	// deletion start. Entries before index remain valid and can be reused by a
-	// subsequent leftNeighbourAt call near the same location.
-	// For remote transactions, item.delete handles cache invalidation.
-	if txn.Local {
-		t.invalidatePosCacheFrom(index)
-	}
+	// Search-marker maintenance (G1) happens AFTER the tombstoning below: once
+	// the affected items carry Deleted=true, updateMarkerChanges(index, -deleted)
+	// both drops markers that now point at a tombstone and shifts the survivors
+	// after the deleted region left by the number of rendered positions removed,
+	// preserving markers before index for a subsequent nearby lookup. Doing it
+	// up-front (the old drop-from-index shim) would discard reusable markers and
+	// could not distinguish shift-vs-drop. splitItem, if a boundary split is
+	// needed during the walk, clears all markers, in which case the call below
+	// is a no-op on the empty set — still correct.
+	origLen := length
 	counted := 0
 	// Start the walk at firstLiveFromStart, not t.start: leading tombstones
 	// accumulated by earlier head-deletes are skipped in O(1) via the cache,
@@ -712,5 +715,11 @@ func deleteRange(t *abstractType, txn *Transaction, index, length int) {
 			item.delete(txn)
 			length = 0
 		}
+	}
+	// Shift/drop markers for the rendered positions actually removed. length is
+	// whatever could not be deleted (deletion ran past the end), so the number
+	// of removed positions is origLen-length. Zero → no-op.
+	if deleted := origLen - length; deleted > 0 {
+		t.updateMarkerChanges(index, -deleted)
 	}
 }

--- a/crdt/yarray_move_delete_test.go
+++ b/crdt/yarray_move_delete_test.go
@@ -113,6 +113,149 @@ func TestUnit_YArray_DeleteMoved_HeadFastPathUnmovedIntact(t *testing.T) {
 	assert.Equal(t, []any{"c", "d"}, arr.ToSlice())
 }
 
+// TestInteg_YArray_DeleteMovedElement_TwoPeer_ConcurrentNeighborDelete: peer A
+// deletes the moved element ("e", rendered via the winning ContentMove) while
+// peer B concurrently deletes a different, plain element rendered adjacent to
+// it ("b"). The two deletes target two distinct items, so this is an ordinary
+// (non-ambiguous) YATA delete-delete case: both removals apply independently
+// and both peers converge to the same array with both elements gone,
+// regardless of exchange order.
+func TestInteg_YArray_DeleteMovedElement_TwoPeer_ConcurrentNeighborDelete(t *testing.T) {
+	doc1 := newTestDoc(1)
+	doc2 := newTestDoc(2)
+	arr1 := doc1.GetArray("list")
+	arr2 := doc2.GetArray("list")
+
+	doc1.Transact(func(txn *Transaction) { arr1.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, nil), nil))
+
+	// Both peers learn the move (created by doc1): [a,e,b,c,d].
+	doc1.Transact(func(txn *Transaction) { arr1.Move(txn, 4, 1) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, doc2.store.StateVector()), nil))
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr1.ToSlice())
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr2.ToSlice())
+
+	sv1 := doc1.store.StateVector()
+	sv2 := doc2.store.StateVector()
+
+	// Concurrent: doc1 deletes the moved element "e" (rendered index 1);
+	// doc2 deletes its rendered neighbor "b" (rendered index 2) — a plain
+	// element, not the moved target itself.
+	doc1.Transact(func(txn *Transaction) { arr1.Delete(txn, 1, 1) })
+	doc2.Transact(func(txn *Transaction) { arr2.Delete(txn, 2, 1) })
+
+	u1to2 := EncodeStateAsUpdateV1(doc1, sv2)
+	u2to1 := EncodeStateAsUpdateV1(doc2, sv1)
+	require.NoError(t, ApplyUpdateV1(doc2, u1to2, nil))
+	require.NoError(t, ApplyUpdateV1(doc1, u2to1, nil))
+
+	s1 := arr1.ToSlice()
+	s2 := arr2.ToSlice()
+	assert.Equal(t, s1, s2, "peers converge")
+	assert.Equal(t, []any{"a", "c", "d"}, s1, "both the moved element and its neighbor are gone")
+}
+
+// TestInteg_YArray_DeleteMovedElement_TwoPeer_ConcurrentReMove: peer A deletes
+// the moved element ("e") while peer B, still on the pre-delete state,
+// concurrently issues a SECOND Move on that same element (re-moving an
+// already-moved target — Move() walks through a winning ContentMove to the
+// real target item, so this creates a second ContentMove pointing at the same,
+// now-concurrently-deleted, target).
+//
+// This is intentionally not asserted to a single fully-specified physical
+// structure: integrate()'s ContentMove arbitration
+// (target.MovedBy == nil || item.ID.Client < target.MovedBy.ID.Client) does
+// not consult target.Deleted, so which of the two ContentMove items "wins"
+// MovedBy is a structural detail. But renderedStep DOES gate on
+// target.Deleted before rendering a winning move's target, so a deleted
+// target renders nothing no matter which move claims it — the outcome is
+// well-defined at the rendered-value level even though the winning-move
+// bookkeeping is not something this test pins down. We assert convergence and
+// that the deleted element is gone from the rendered result on both peers.
+func TestInteg_YArray_DeleteMovedElement_TwoPeer_ConcurrentReMove(t *testing.T) {
+	doc1 := newTestDoc(1)
+	doc2 := newTestDoc(2)
+	arr1 := doc1.GetArray("list")
+	arr2 := doc2.GetArray("list")
+
+	doc1.Transact(func(txn *Transaction) { arr1.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, nil), nil))
+
+	// Both peers learn the first move (created by doc1): [a,e,b,c,d].
+	doc1.Transact(func(txn *Transaction) { arr1.Move(txn, 4, 1) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, doc2.store.StateVector()), nil))
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr1.ToSlice())
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr2.ToSlice())
+
+	sv1 := doc1.store.StateVector()
+	sv2 := doc2.store.StateVector()
+
+	// Concurrent: doc1 deletes the moved element "e" (rendered index 1);
+	// doc2, unaware of the delete, re-moves the SAME element ("e", still at
+	// its own rendered index 1) to a new destination.
+	doc1.Transact(func(txn *Transaction) { arr1.Delete(txn, 1, 1) })
+	doc2.Transact(func(txn *Transaction) { arr2.Move(txn, 1, 3) })
+
+	u1to2 := EncodeStateAsUpdateV1(doc1, sv2)
+	u2to1 := EncodeStateAsUpdateV1(doc2, sv1)
+	require.NoError(t, ApplyUpdateV1(doc2, u1to2, nil))
+	require.NoError(t, ApplyUpdateV1(doc1, u2to1, nil))
+
+	s1 := arr1.ToSlice()
+	s2 := arr2.ToSlice()
+	assert.Equal(t, s1, s2, "peers converge")
+	assert.NotContains(t, s1, "e", "deleted target is gone even though a concurrent re-move also claimed it")
+	assert.ElementsMatch(t, []any{"a", "b", "c", "d"}, s1, "the four plain elements survive")
+}
+
+// TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardPanics exercises the
+// defensive guard added to deleteRange's renderAt branch (#181 follow-up).
+// Under Move()'s own invariant a ContentMove's target is always width 1, so
+// n <= length always holds there. But TargetLen travels over the wire
+// (update.go/update_v2.go encode it verbatim) and resolveMovedItem only ever
+// clamps a target DOWN to <= TargetLen — it never merges narrower items UP to
+// it — so a hand-built or adversarial ContentMove with TargetLen > 1 pointing
+// at an item that is already that wide (e.g. a single Push of several values)
+// can make a winning move render n > 1. This test constructs exactly that
+// (bypassing the normal Move() API, which cannot produce it) and asserts that
+// deleting fewer rendered positions than the target's width panics instead of
+// silently deleting the whole multi-element target.
+func TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardPanics(t *testing.T) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("list")
+	t2 := &arr.abstractType
+
+	var item1 *Item
+	doc.Transact(func(txn *Transaction) {
+		arr.Push(txn, []any{"x", "y"}) // single ContentAny item, width 2
+		item1 = t2.start
+	})
+	require.Equal(t, 2, item1.Content.Len(), "single Push of 2 values is one width-2 item")
+
+	doc.Transact(func(txn *Transaction) {
+		targetID := item1.ID
+		moveItem := &Item{
+			ID:          ID{Client: doc.clientID, Clock: doc.store.NextClock(doc.clientID)},
+			Left:        nil,
+			OriginRight: &targetID,
+			Parent:      t2,
+			Content:     NewContentMove(&targetID, 2), // TargetLen=2: violates the width-1 invariant
+		}
+		moveItem.integrate(txn, 0)
+	})
+	require.NotNil(t, item1.MovedBy, "hand-built ContentMove must win arbitration")
+
+	// Rendered array is now [x,y] (the moved-in target at index 0). Deleting
+	// only 1 rendered position (n=2 > length=1) must panic rather than
+	// silently deleting both "x" and "y".
+	require.Equal(t, []any{"x", "y"}, arr.ToSlice())
+	assert.PanicsWithValue(t,
+		"crdt: deleteRange: winning ContentMove target width 2 exceeds remaining delete length 1 at rendered index 0 (multi-element ContentMove targets are unsupported)",
+		func() {
+			doc.Transact(func(txn *Transaction) { arr.Delete(txn, 0, 1) })
+		})
+}
+
 // TestInteg_YArray_DeleteMovedElement_TwoPeer_Converge: peer A deletes a moved
 // element while peer B concurrently inserts; after exchanging deltas both peers
 // converge and the moved element is gone.

--- a/crdt/yarray_move_delete_test.go
+++ b/crdt/yarray_move_delete_test.go
@@ -208,19 +208,22 @@ func TestInteg_YArray_DeleteMovedElement_TwoPeer_ConcurrentReMove(t *testing.T) 
 	assert.ElementsMatch(t, []any{"a", "b", "c", "d"}, s1, "the four plain elements survive")
 }
 
-// TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardPanics exercises the
-// defensive guard added to deleteRange's renderAt branch (#181 follow-up).
-// Under Move()'s own invariant a ContentMove's target is always width 1, so
+// TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardClamps exercises the
+// defensive guard in deleteRange's renderAt branch (#181 follow-up). Under
+// Move()'s own invariant a ContentMove's target is always width 1, so
 // n <= length always holds there. But TargetLen travels over the wire
 // (update.go/update_v2.go encode it verbatim) and resolveMovedItem only ever
 // clamps a target DOWN to <= TargetLen — it never merges narrower items UP to
-// it — so a hand-built or adversarial ContentMove with TargetLen > 1 pointing
-// at an item that is already that wide (e.g. a single Push of several values)
+// it — so a hand-built or foreign ContentMove with TargetLen > 1 pointing at
+// an item that is already that wide (e.g. a single Push of several values)
 // can make a winning move render n > 1. This test constructs exactly that
-// (bypassing the normal Move() API, which cannot produce it) and asserts that
-// deleting fewer rendered positions than the target's width panics instead of
-// silently deleting the whole multi-element target.
-func TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardPanics(t *testing.T) {
+// (bypassing the normal Move() API, which cannot produce it) and asserts
+// that deleting fewer rendered positions than the target's width does NOT
+// panic — a library must never crash on wire-derived/foreign input — and
+// leaves the array in a state where Get/Slice/ToSlice stay coherent with
+// each other (no partial, MovedBy-corrupting split of the target; the whole
+// target is consumed instead).
+func TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardClamps(t *testing.T) {
 	doc := newTestDoc(1)
 	arr := doc.GetArray("list")
 	t2 := &arr.abstractType
@@ -246,14 +249,23 @@ func TestUnit_YArray_DeleteMoved_MultiWidthTargetGuardPanics(t *testing.T) {
 	require.NotNil(t, item1.MovedBy, "hand-built ContentMove must win arbitration")
 
 	// Rendered array is now [x,y] (the moved-in target at index 0). Deleting
-	// only 1 rendered position (n=2 > length=1) must panic rather than
-	// silently deleting both "x" and "y".
+	// only 1 rendered position (n=2 > length=1) must NOT panic. The guard
+	// clamps n down to the remaining length rather than partially deleting
+	// the target (unsafe: splitItem doesn't carry MovedBy to the right
+	// half), so the whole width-2 target is consumed by this single-position
+	// delete request.
 	require.Equal(t, []any{"x", "y"}, arr.ToSlice())
-	assert.PanicsWithValue(t,
-		"crdt: deleteRange: winning ContentMove target width 2 exceeds remaining delete length 1 at rendered index 0 (multi-element ContentMove targets are unsupported)",
-		func() {
-			doc.Transact(func(txn *Transaction) { arr.Delete(txn, 0, 1) })
-		})
+	assert.NotPanics(t, func() {
+		doc.Transact(func(txn *Transaction) { arr.Delete(txn, 0, 1) })
+	})
+
+	// The clamp fully deletes the moved target (both "x" and "y"); the array
+	// is left empty, and Get/Slice/ToSlice/Len must all agree on that — no
+	// stale or partially-visible remnant of the malformed move.
+	assert.True(t, item1.Deleted, "clamp must fully consume the multi-width target, not partially split it")
+	assert.Equal(t, 0, arr.Len())
+	assert.Equal(t, []any{}, arr.ToSlice())
+	assert.Equal(t, []any{}, getAll(arr))
 }
 
 // TestInteg_YArray_DeleteMovedElement_TwoPeer_Converge: peer A deletes a moved

--- a/crdt/yarray_move_delete_test.go
+++ b/crdt/yarray_move_delete_test.go
@@ -1,0 +1,153 @@
+package crdt
+
+// Move-aware deleteRange tests (#181): on an array with an active ContentMove,
+// Get/Slice and Delete must agree about which element renders at rendered index
+// i. Delete(i, n) must remove exactly the elements Get reports at rendered
+// indices [i, i+n); for a winning ContentMove the delete applies to the moved
+// TARGET item (the moved content), matching Yjs YArray move+delete semantics.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getAll snapshots the rendered elements via Get(i) so tests can assert Delete
+// removed exactly the elements Get reported (the coherence property).
+func getAll(a *YArray) []any {
+	out := make([]any, 0, a.Len())
+	for i := 0; i < a.Len(); i++ {
+		out = append(out, a.Get(i))
+	}
+	return out
+}
+
+// assertDeleteRemovesRendered deletes [i, i+n) and asserts the result equals the
+// pre-delete rendered slice with exactly indices [i, i+n) removed — i.e. Delete
+// removed exactly what Get reported there.
+func assertDeleteRemovesRendered(t *testing.T, doc *Doc, a *YArray, i, n int) {
+	t.Helper()
+	before := getAll(a)
+	require.GreaterOrEqual(t, len(before), i+n, "range in bounds")
+	want := make([]any, 0, len(before)-n)
+	want = append(want, before[:i]...)
+	want = append(want, before[i+n:]...)
+	doc.Transact(func(txn *Transaction) { a.Delete(txn, i, n) })
+	assert.Equal(t, want, a.ToSlice(), "Delete(%d,%d) removes rendered [%d,%d)", i, n, i, i+n)
+	// Coherence: Get after delete matches ToSlice.
+	assert.Equal(t, a.ToSlice(), getAll(a), "Get coherent with ToSlice after delete")
+}
+
+func newMovedArray(t *testing.T, from, to int) (*Doc, *YArray) {
+	t.Helper()
+	doc := newTestDoc(1)
+	arr := doc.GetArray("list")
+	doc.Transact(func(txn *Transaction) { arr.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	doc.Transact(func(txn *Transaction) { arr.Move(txn, from, to) })
+	return doc, arr
+}
+
+// [a,b,c,d,e] + Move(4->1) renders [a,e,b,c,d]; Get(1)=="e".
+func TestUnit_YArray_DeleteMoved_WinningMove_DeletesTarget(t *testing.T) {
+	doc, arr := newMovedArray(t, 4, 1)
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr.ToSlice(), "move renders")
+	require.Equal(t, "e", arr.Get(1), "Get(1) is the moved element")
+	assertDeleteRemovesRendered(t, doc, arr, 1, 1) // must delete "e", not "b"
+	assert.Equal(t, []any{"a", "b", "c", "d"}, arr.ToSlice())
+}
+
+// Delete a plain element AFTER the moved one: rendered [a,e,b,c,d], Delete(2,1)
+// removes "b".
+func TestUnit_YArray_DeleteMoved_PlainAfterMove(t *testing.T) {
+	doc, arr := newMovedArray(t, 4, 1)
+	require.Equal(t, "b", arr.Get(2))
+	assertDeleteRemovesRendered(t, doc, arr, 2, 1)
+	assert.Equal(t, []any{"a", "e", "c", "d"}, arr.ToSlice())
+}
+
+// Multi-delete spanning the moved element: [a,e,b,c,d], Delete(1,2) removes
+// "e","b".
+func TestUnit_YArray_DeleteMoved_MultiSpanningMove(t *testing.T) {
+	doc, arr := newMovedArray(t, 4, 1)
+	assertDeleteRemovesRendered(t, doc, arr, 1, 2)
+	assert.Equal(t, []any{"a", "c", "d"}, arr.ToSlice())
+}
+
+// Delete spanning the boundary from a plain element into the moved element:
+// [a,e,b,c,d], Delete(0,2) removes "a","e".
+func TestUnit_YArray_DeleteMoved_SpanBoundaryIntoMove(t *testing.T) {
+	doc, arr := newMovedArray(t, 4, 1)
+	assertDeleteRemovesRendered(t, doc, arr, 0, 2)
+	assert.Equal(t, []any{"b", "c", "d"}, arr.ToSlice())
+}
+
+// Backward move: [a,b,c,d,e] + Move(1->3) renders [a,c,d,b,e]; Delete the moved
+// "b" at rendered index 3.
+func TestUnit_YArray_DeleteMoved_BackwardMove(t *testing.T) {
+	doc, arr := newMovedArray(t, 1, 3)
+	require.Equal(t, []any{"a", "c", "d", "b", "e"}, arr.ToSlice(), "backward move renders")
+	require.Equal(t, "b", arr.Get(3))
+	assertDeleteRemovesRendered(t, doc, arr, 3, 1)
+	assert.Equal(t, []any{"a", "c", "d", "e"}, arr.ToSlice())
+}
+
+// Deleting every rendered index one at a time keeps Get/Delete coherent and
+// drains the array (moved element included) with no ghost elements.
+func TestUnit_YArray_DeleteMoved_DrainAllCoherent(t *testing.T) {
+	doc, arr := newMovedArray(t, 4, 1) // [a,e,b,c,d]
+	for arr.Len() > 0 {
+		want := getAll(arr)[1:] // dropping rendered index 0
+		doc.Transact(func(txn *Transaction) { arr.Delete(txn, 0, 1) })
+		assert.Equal(t, want, arr.ToSlice())
+	}
+	assert.Equal(t, []any{}, arr.ToSlice())
+}
+
+// Head fast path (#86) on a non-moved array must be unaffected.
+func TestUnit_YArray_DeleteMoved_HeadFastPathUnmovedIntact(t *testing.T) {
+	doc := newTestDoc(1)
+	arr := doc.GetArray("list")
+	doc.Transact(func(txn *Transaction) { arr.Push(txn, []any{"a", "b", "c", "d"}) })
+	doc.Transact(func(txn *Transaction) { arr.Delete(txn, 0, 2) })
+	assert.Equal(t, []any{"c", "d"}, arr.ToSlice())
+}
+
+// TestInteg_YArray_DeleteMovedElement_TwoPeer_Converge: peer A deletes a moved
+// element while peer B concurrently inserts; after exchanging deltas both peers
+// converge and the moved element is gone.
+func TestInteg_YArray_DeleteMovedElement_TwoPeer_Converge(t *testing.T) {
+	doc1 := newTestDoc(1)
+	doc2 := newTestDoc(2)
+	arr1 := doc1.GetArray("list")
+	arr2 := doc2.GetArray("list")
+
+	doc1.Transact(func(txn *Transaction) { arr1.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, nil), nil))
+
+	// Both peers learn the move (created by doc1): [a,e,b,c,d].
+	doc1.Transact(func(txn *Transaction) { arr1.Move(txn, 4, 1) })
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, doc2.store.StateVector()), nil))
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr1.ToSlice())
+	require.Equal(t, []any{"a", "e", "b", "c", "d"}, arr2.ToSlice())
+
+	sv1 := doc1.store.StateVector()
+	sv2 := doc2.store.StateVector()
+
+	// Concurrent: doc1 deletes the moved element "e" (rendered index 1);
+	// doc2 inserts "x" at the head.
+	doc1.Transact(func(txn *Transaction) { arr1.Delete(txn, 1, 1) })
+	doc2.Transact(func(txn *Transaction) { arr2.Insert(txn, 0, []any{"x"}) })
+
+	u1to2 := EncodeStateAsUpdateV1(doc1, sv2)
+	u2to1 := EncodeStateAsUpdateV1(doc2, sv1)
+	require.NoError(t, ApplyUpdateV1(doc2, u1to2, nil))
+	require.NoError(t, ApplyUpdateV1(doc1, u2to1, nil))
+
+	s1 := arr1.ToSlice()
+	s2 := arr2.ToSlice()
+	assert.Equal(t, s1, s2, "peers converge")
+	assert.NotContains(t, s1, "e", "deleted moved element is gone")
+	assert.Contains(t, s1, "x", "concurrent insert survives")
+	assert.Equal(t, []any{"x", "a", "b", "c", "d"}, s1)
+}

--- a/crdt/yarray_move_insert_test.go
+++ b/crdt/yarray_move_insert_test.go
@@ -1,0 +1,140 @@
+package crdt
+
+// Move-aware Insert tests (#181, PR #190 review comment 1): on an array with an
+// active ContentMove, Insert must anchor at the correct PHYSICAL neighbour for
+// the requested RENDERED position, so the inserted element lands where the
+// move-aware Get/Slice/deleteRange would place rendered index i.
+//
+// The subtle path is leftNeighbourAt's append/beyond-end fallback (hit when the
+// requested index exceeds the rendered length). It used to walk t.start tracking
+// the last `!Deleted && IsCountable` item — which is MOVE-BLIND: a winning
+// ContentMove is non-countable (its rendered element would be skipped) and a
+// moved-away item is still countable (but renders elsewhere). When the winning
+// ContentMove is the PHYSICAL tail (element moved TO the end), the old fallback
+// picked the last plain item instead of the ContentMove, so an append-beyond-end
+// slotted the new element BEFORE the moved element instead of after it. The fix
+// walks via the shared renderedStep so the fallback anchors after the last item
+// that actually RENDERS.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMovedArray builds [a,b,c,d,e], applies Move(from,to), and optionally
+// forces the marker-free cold walk (disableMarkers) so every assertion can be
+// exercised on both the marker fast path and the cold oracle.
+func buildMovedArray(t *testing.T, from, to int, coldWalk bool) (*Doc, *YArray) {
+	t.Helper()
+	doc := newTestDoc(1)
+	arr := doc.GetArray("list")
+	arr.disableMarkers = coldWalk
+	doc.Transact(func(txn *Transaction) { arr.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	doc.Transact(func(txn *Transaction) { arr.Move(txn, from, to) })
+	return doc, arr
+}
+
+// assertInsertCoherent inserts vals at index and asserts (1) the rendered order
+// equals want, and (2) Insert is coherent with the move-aware readers: ToSlice,
+// Get(i) for every i, and Slice(0,Len) all agree.
+func assertInsertCoherent(t *testing.T, doc *Doc, a *YArray, index int, vals []any, want []any) {
+	t.Helper()
+	doc.Transact(func(txn *Transaction) { a.Insert(txn, index, vals) })
+	got := a.ToSlice()
+	assert.Equal(t, want, got, "Insert(%d) rendered order", index)
+	assert.Equal(t, got, getAll(a), "Get coherent with ToSlice after Insert(%d)", index)
+	assert.Equal(t, got, a.Slice(0, a.Len()), "Slice coherent with ToSlice after Insert(%d)", index)
+}
+
+// Element moved TO the end: [a,b,c,d,e] + Move(0->4) renders [b,c,d,e,a]. The
+// winning ContentMove is the PHYSICAL tail; the last plain item ("e"...merged
+// [b,c,d,e]) is NOT the rendered tail. This is the move-blind fallback's failure
+// case: an append-beyond-end must land AFTER the moved "a".
+func TestUnit_YArray_InsertMoved_AppendBeyondEnd_AfterMovedTail(t *testing.T) {
+	for _, cold := range []bool{false, true} {
+		t.Run(map[bool]string{false: "markers", true: "cold"}[cold], func(t *testing.T) {
+			doc, arr := buildMovedArray(t, 0, 4, cold)
+			require.Equal(t, []any{"b", "c", "d", "e", "a"}, arr.ToSlice(), "move renders")
+			require.Equal(t, "a", arr.Get(4), "moved element renders at the tail")
+
+			// Insert BEYOND the end (index > Len): must append after the rendered
+			// tail "a". Old move-blind fallback anchored after the last plain item
+			// and produced [b,c,d,e,z,a] instead.
+			assertInsertCoherent(t, doc, arr, arr.Len()+1, []any{"z"},
+				[]any{"b", "c", "d", "e", "a", "z"})
+		})
+	}
+}
+
+// Append exactly at Len() (in-bounds, does NOT hit the fallback — goes through
+// the move-aware findMarkerMut). Must also land after the moved tail.
+func TestUnit_YArray_InsertMoved_AppendAtLen_AfterMovedTail(t *testing.T) {
+	for _, cold := range []bool{false, true} {
+		t.Run(map[bool]string{false: "markers", true: "cold"}[cold], func(t *testing.T) {
+			doc, arr := buildMovedArray(t, 0, 4, cold)
+			require.Equal(t, []any{"b", "c", "d", "e", "a"}, arr.ToSlice())
+			assertInsertCoherent(t, doc, arr, arr.Len(), []any{"z"},
+				[]any{"b", "c", "d", "e", "a", "z"})
+		})
+	}
+}
+
+// Mid insert on a moved array: [b,c,d,e,a] + Insert(2,"z") -> [b,c,z,d,e,a].
+func TestUnit_YArray_InsertMoved_Mid(t *testing.T) {
+	for _, cold := range []bool{false, true} {
+		t.Run(map[bool]string{false: "markers", true: "cold"}[cold], func(t *testing.T) {
+			doc, arr := buildMovedArray(t, 0, 4, cold)
+			assertInsertCoherent(t, doc, arr, 2, []any{"z"},
+				[]any{"b", "c", "z", "d", "e", "a"})
+		})
+	}
+}
+
+// Element moved TO the FRONT: [a,b,c,d,e] + Move(4->0) renders [e,a,b,c,d]. Here
+// the moved-away item ("e") is the physical tail; both fallbacks happen to agree
+// (a moved-away tail renders at the front, so appending physically after it still
+// renders last) — this pins that behaviour so the fix doesn't regress it.
+func TestUnit_YArray_InsertMoved_AppendBeyondEnd_MovedToFront(t *testing.T) {
+	for _, cold := range []bool{false, true} {
+		t.Run(map[bool]string{false: "markers", true: "cold"}[cold], func(t *testing.T) {
+			doc, arr := buildMovedArray(t, 4, 0, cold)
+			require.Equal(t, []any{"e", "a", "b", "c", "d"}, arr.ToSlice(), "move-to-front renders")
+			assertInsertCoherent(t, doc, arr, arr.Len()+1, []any{"z"},
+				[]any{"e", "a", "b", "c", "d", "z"})
+		})
+	}
+}
+
+// Insert at the head on a moved array is unaffected by the fallback but must
+// still be coherent: [b,c,d,e,a] + Insert(0,"z") -> [z,b,c,d,e,a].
+func TestUnit_YArray_InsertMoved_Head(t *testing.T) {
+	for _, cold := range []bool{false, true} {
+		t.Run(map[bool]string{false: "markers", true: "cold"}[cold], func(t *testing.T) {
+			doc, arr := buildMovedArray(t, 0, 4, cold)
+			assertInsertCoherent(t, doc, arr, 0, []any{"z"},
+				[]any{"z", "b", "c", "d", "e", "a"})
+		})
+	}
+}
+
+// Convergence: peer 1 moves an element to the end then appends beyond the end;
+// peer 2 receives the updates and must converge to the identical rendered order.
+// Guards that the anchor the move-aware fallback picks is a real, wire-encodable
+// YATA position (not just locally correct).
+func TestInteg_YArray_InsertMoved_AppendBeyondEnd_Converges(t *testing.T) {
+	doc1 := newTestDoc(1)
+	doc2 := newTestDoc(2)
+	arr1 := doc1.GetArray("list")
+	arr2 := doc2.GetArray("list")
+
+	doc1.Transact(func(txn *Transaction) { arr1.Push(txn, []any{"a", "b", "c", "d", "e"}) })
+	doc1.Transact(func(txn *Transaction) { arr1.Move(txn, 0, 4) })            // -> [b,c,d,e,a]
+	doc1.Transact(func(txn *Transaction) { arr1.Insert(txn, 6, []any{"z"}) }) // beyond end -> append
+	require.Equal(t, []any{"b", "c", "d", "e", "a", "z"}, arr1.ToSlice())
+
+	require.NoError(t, ApplyUpdateV1(doc2, EncodeStateAsUpdateV1(doc1, nil), nil))
+	assert.Equal(t, arr1.ToSlice(), arr2.ToSlice(), "peers converge")
+	assert.Equal(t, []any{"b", "c", "d", "e", "a", "z"}, arr2.ToSlice())
+}

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -1412,9 +1412,17 @@ func (t *abstractType) applyDeltaInsert(txn *Transaction, pos *itemTextPos, text
 		t.insertHint = pos.index
 	}
 	item.integrate(txn, 0)
+	// Always advance the anchor past the just-inserted item — regardless of
+	// whether it carried its own attributes (diff non-empty) — so the cursor
+	// invariant (pos.left/pos.right bracket the position immediately after
+	// this insert) holds for whatever op comes next. Previously this was
+	// only done inside the `len(diff) > 0` branch below (as part of setting
+	// up the closing-marker chain's origin), which left pos stale after a
+	// plain attribute-less insert: the following op would re-anchor at the
+	// PRE-insert position and could integrate out of order (#181 follow-up).
+	left = item
 
 	if len(diff) > 0 {
-		left = item
 		origin = &ID{
 			Client: item.ID.Client,
 			Clock:  item.ID.Clock + uint64(item.Content.Len()) - 1,

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -495,8 +495,7 @@ func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attribu
 // once any formatting exists, the exact walk resumes so scattered markers
 // anywhere before anchor are still picked up correctly (search markers only
 // track rendered position, not accumulated attribute state, so they cannot
-// safely shortcut this in general — see the abstractType.hasMoves comment
-// for the parallel reasoning on the Move side). Gated on t.disableMarkers too
+	// safely shortcut this in general). Gated on t.disableMarkers too
 // so the force-cold test seam still exercises the full walk.
 func (txt *YText) currentAttributesAt(anchor *Item) Attributes {
 	t := &txt.abstractType

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -485,7 +485,24 @@ func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attribu
 // Added in v1.13.0 (#71 vectors A2 + A3). The caller is responsible for
 // not invoking this with stale anchor pointers; YText.Insert calls it
 // immediately after leftNeighbourAt.
+//
+// Marker-era fast path (#181): a ContentFormat item can only ever exist if
+// hasFormatting is true (item.go sets it the first time one integrates, and
+// it is sticky), so when hasFormatting is false the walk below is guaranteed
+// to find nothing and always returns an empty map — we can skip it entirely
+// rather than walk from txt.start to anchor. This is what keeps a first-ever
+// attrs-carrying Insert on an otherwise-plain document O(1) instead of O(n);
+// once any formatting exists, the exact walk resumes so scattered markers
+// anywhere before anchor are still picked up correctly (search markers only
+// track rendered position, not accumulated attribute state, so they cannot
+// safely shortcut this in general — see the abstractType.hasMoves comment
+// for the parallel reasoning on the Move side). Gated on t.disableMarkers too
+// so the force-cold test seam still exercises the full walk.
 func (txt *YText) currentAttributesAt(anchor *Item) Attributes {
+	t := &txt.abstractType
+	if !t.disableMarkers && !t.hasFormatting {
+		return make(Attributes)
+	}
 	attrs := make(Attributes)
 	if anchor == nil {
 		return attrs
@@ -776,14 +793,6 @@ func (txt *YText) Format(txn *Transaction, index, length int, attrs Attributes) 
 	}
 	t := &txt.abstractType
 
-	// Deterministic emission order — Go map iteration is randomized, but
-	// linked-list order is observable, so sort keys.
-	keys := make([]string, 0, len(attrs))
-	for k := range attrs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
 	// Faithful port of Yjs JS YText.formatText (yjs@13.6.30), built on an
 	// ItemTextListPosition-equivalent cursor (itemTextPos). The previous ygo
 	// implementation deleted ALL same-key markers in the range, which
@@ -793,7 +802,33 @@ func (txt *YText) Format(txn *Transaction, index, length int, attrs Attributes) 
 	// after the range (the "negated" map), deletes only in-range overlapping
 	// markers, and restores the post-range state — matching Yjs across fresh and
 	// applyUpdate-loaded docs (the un-split-run case, yjs#606).
+	//
+	// findTextPos resolves the cursor (marker-accelerated for the common
+	// never-formatted-before-this-call case, #181); the rest of the algorithm
+	// lives in applyFormatAtPos, shared with ApplyDelta's single-threaded
+	// cursor so a Retain-with-attributes delta op doesn't re-resolve position
+	// from scratch (#181 single-cursor requirement).
 	pos := t.findTextPos(txn, index)
+	t.applyFormatAtPos(txn, pos, length, attrs)
+}
+
+// applyFormatAtPos is Format's core algorithm, parameterised over an
+// already-resolved cursor so callers that already hold a live itemTextPos
+// (ApplyDelta's single threaded cursor) don't pay for a fresh findTextPos
+// walk per op. Format itself is just findTextPos + this call. Mirrors Yjs JS
+// YText.formatText's body (see Format's doc comment for the full rationale).
+func (t *abstractType) applyFormatAtPos(txn *Transaction, pos *itemTextPos, length int, attrs Attributes) {
+	if len(attrs) == 0 || length <= 0 {
+		return
+	}
+	// Deterministic emission order — Go map iteration is randomized, but
+	// linked-list order is observable, so sort keys.
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	minimizeAttributeChanges(pos, attrs)
 	negated := t.insertAttributes(txn, pos, keys, attrs)
 
@@ -875,6 +910,35 @@ func (p *itemTextPos) forward() {
 	p.right = p.right.Right
 }
 
+// advance moves the cursor forward by exactly n countable units from wherever
+// it currently sits, splitting the boundary item if n lands inside it and
+// updating cur as any live ContentFormat markers are passed. This is
+// forward's per-item step body generalised to "consume n units" instead of
+// "consume one item" — the shared core of findTextPos (which starts a fresh
+// cursor at t.start and advances it to index) and ApplyDelta's single
+// threaded cursor (which advances an already-live cursor by each delta op's
+// Retain amount without re-resolving position from t.start every time, #181).
+func (p *itemTextPos) advance(txn *Transaction, n int) {
+	count := n
+	for p.right != nil && count > 0 {
+		if cf, ok := p.right.Content.(*ContentFormat); ok {
+			if !p.right.Deleted {
+				updateAttr(p.cur, cf)
+			}
+		} else if !p.right.Deleted {
+			itemLen := p.right.Content.Len()
+			if count < itemLen {
+				splitItem(txn, p.right, count) // clean boundary mid-item
+				itemLen = p.right.Content.Len()
+			}
+			p.index += itemLen
+			count -= itemLen
+		}
+		p.left = p.right
+		p.right = p.right.Right
+	}
+}
+
 // updateAttr applies a ContentFormat marker to an attribute map: a nil value
 // clears the key (no formatting), a non-nil value sets it.
 func updateAttr(attrs Attributes, cf *ContentFormat) {
@@ -916,25 +980,40 @@ func (t *abstractType) skipDeletedForTextAnchor(left *Item) *Item {
 // boundary item when index falls inside it, with cur reflecting the format
 // state at index. Mirrors Yjs findPosition/findNextPosition.
 func (t *abstractType) findTextPos(txn *Transaction, index int) *itemTextPos {
-	pos := &itemTextPos{right: t.start, cur: make(Attributes)}
-	count := index
-	for pos.right != nil && count > 0 {
-		if cf, ok := pos.right.Content.(*ContentFormat); ok {
-			if !pos.right.Deleted {
-				updateAttr(pos.cur, cf)
-			}
-		} else if !pos.right.Deleted {
-			n := pos.right.Content.Len()
-			if count < n {
-				splitItem(txn, pos.right, count) // clean boundary at index
-				n = pos.right.Content.Len()
-			}
-			pos.index += n
-			count -= n
+	// Marker fast path (#181): a ContentFormat item can only exist if
+	// hasFormatting is true (sticky, set by item.go on first integration), so
+	// with !hasFormatting the walk below would never touch the `if cf, ok :=
+	// ...ContentFormat` branch and cur would stay empty regardless of where
+	// we start it from — the walk purely becomes "find/split the boundary
+	// item at index", exactly what leftNeighbourAt (already marker-routed)
+	// computes. index<=0 is special-cased to match the original walk's
+	// "cursor before everything" answer exactly: leftNeighbourAt(index<=0)
+	// answers the different question "append at the physical end" once index
+	// is out of [1,length], which is right for insert-before-everything at
+	// index==0 but wrong for a negative index (the original walk here never
+	// runs its loop for count<=0 and returns right=t.start unconditionally).
+	if !t.disableMarkers && !t.hasFormatting {
+		if index <= 0 {
+			return &itemTextPos{right: t.start, cur: make(Attributes)}
 		}
-		pos.left = pos.right
-		pos.right = pos.right.Right
+		left, offset := t.leftNeighbourAt(index)
+		if offset > 0 {
+			splitItem(txn, left, offset)
+		}
+		pidx := index
+		if pidx > t.length {
+			pidx = t.length
+		}
+		pos := &itemTextPos{left: left, index: pidx, cur: make(Attributes)}
+		if left != nil {
+			pos.right = left.Right
+		} else {
+			pos.right = t.start
+		}
+		return pos
 	}
+	pos := &itemTextPos{right: t.start, cur: make(Attributes)}
+	pos.advance(txn, index)
 	return pos
 }
 
@@ -1207,22 +1286,210 @@ func (txt *YText) ApplyDelta(txn *Transaction, delta []Delta) {
 		txt.buffer(func(txn *Transaction) { txt.ApplyDelta(txn, delta) })
 		return
 	}
-	pos := 0
+	t := &txt.abstractType
+	// Single threaded cursor (#181): every op below advances the SAME
+	// itemTextPos instead of each op independently re-resolving its own
+	// position from an int index (which — even with the marker routing the
+	// rest of this task adds to deleteRange/findTextPos — still pays an
+	// O(maxSearchMarker) nearest-marker scan plus a local walk per call).
+	// Threading one cursor drops that to true O(1) continuation, since each
+	// op leaves pos sitting exactly where the next one needs to start.
+	// pos starts at index 0 — equivalent to t.findTextPos(txn, 0), just
+	// without that call's marker-lookup machinery for a position we already
+	// know statically.
+	pos := &itemTextPos{right: t.start, cur: make(Attributes)}
 	for _, d := range delta {
 		switch d.Op {
 		case DeltaOpInsert:
 			if s, ok := d.Insert.(string); ok {
-				txt.Insert(txn, pos, s, d.Attributes)
-				pos += utf16Len(s)
+				t.applyDeltaInsert(txn, pos, s, d.Attributes)
 			}
 		case DeltaOpDelete:
-			deleteRange(&txt.abstractType, txn, pos, d.Delete)
+			t.applyDeltaDelete(txn, pos, d.Delete)
 		case DeltaOpRetain:
 			if len(d.Attributes) > 0 {
-				txt.Format(txn, pos, d.Retain, d.Attributes)
+				t.applyFormatAtPos(txn, pos, d.Retain, d.Attributes)
+			} else {
+				pos.advance(txn, d.Retain)
 			}
-			pos += d.Retain
 		}
+	}
+}
+
+// applyDeltaInsert inserts text at the cursor pos, mirroring YText.Insert's
+// item construction (attribute open/close markers, tombstone-skipping
+// anchor) exactly — but sourcing the "current attributes" diff input from
+// pos.cur (already tracked incrementally by the cursor) instead of a fresh
+// currentAttributesAt walk from t.start. This is safe because the opening
+// markers this function inserts are always paired with closing markers that
+// restore the exact pre-insert value (or absence) for each touched key, so
+// the net effect on the ambient format state — and therefore on pos.cur — is
+// zero: leaving pos.cur untouched here is equivalent to (and cheaper than)
+// walking it past the new markers. Advances pos past the inserted run.
+func (t *abstractType) applyDeltaInsert(txn *Transaction, pos *itemTextPos, text string, attrs Attributes) {
+	if text == "" {
+		return
+	}
+
+	// Anchor after any adjacent tombstones (Yjs text-insert parity, #160),
+	// same as YText.Insert. Resync pos.right so the cursor invariant
+	// (right == left.Right, or t.start when left is nil) holds afterward.
+	left := t.skipDeletedForTextAnchor(pos.left)
+	pos.left = left
+	if left != nil {
+		pos.right = left.Right
+	} else {
+		pos.right = t.start
+	}
+
+	type diffEntry struct {
+		key    string
+		newVal any
+		oldVal any
+		hadKey bool
+	}
+	var diff []diffEntry
+	if len(attrs) > 0 {
+		keys := make([]string, 0, len(attrs))
+		for k := range attrs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			newVal := attrs[k]
+			oldVal, hadKey := pos.cur[k]
+			if !hadKey && newVal == nil {
+				continue
+			}
+			if hadKey && reflect.DeepEqual(oldVal, newVal) {
+				continue
+			}
+			diff = append(diff, diffEntry{key: k, newVal: newVal, oldVal: oldVal, hadKey: hadKey})
+		}
+	}
+
+	var origin *ID
+	var originRight *ID
+	if left != nil {
+		end := left.ID.Clock + uint64(left.Content.Len()) - 1
+		origin = &ID{Client: left.ID.Client, Clock: end}
+		if left.Right != nil {
+			id := left.Right.ID
+			originRight = &id
+		}
+	} else if t.start != nil {
+		id := t.start.ID
+		originRight = &id
+	}
+
+	clock := txn.doc.store.NextClock(txn.doc.clientID)
+
+	for _, d := range diff {
+		fmtItem := &Item{
+			ID:          ID{Client: txn.doc.clientID, Clock: clock},
+			Origin:      origin,
+			OriginRight: originRight,
+			Left:        left,
+			Parent:      t,
+			Content:     NewContentFormat(d.key, d.newVal),
+		}
+		fmtItem.integrate(txn, 0)
+		left = fmtItem
+		origin = &ID{Client: fmtItem.ID.Client, Clock: fmtItem.ID.Clock}
+		originRight = nil
+		clock = txn.doc.store.NextClock(txn.doc.clientID)
+	}
+
+	item := &Item{
+		ID:          ID{Client: txn.doc.clientID, Clock: clock},
+		Origin:      origin,
+		OriginRight: originRight,
+		Left:        left,
+		Parent:      t,
+		Content:     NewContentString(text),
+	}
+	if pos.index > 0 {
+		t.insertHint = pos.index
+	}
+	item.integrate(txn, 0)
+
+	if len(diff) > 0 {
+		left = item
+		origin = &ID{
+			Client: item.ID.Client,
+			Clock:  item.ID.Clock + uint64(item.Content.Len()) - 1,
+		}
+		if left.Right != nil {
+			rid := left.Right.ID
+			originRight = &rid
+		} else {
+			originRight = nil
+		}
+		clock = txn.doc.store.NextClock(txn.doc.clientID)
+
+		for _, d := range diff {
+			var revertVal any
+			if d.hadKey {
+				revertVal = d.oldVal
+			}
+			closeItem := &Item{
+				ID:          ID{Client: txn.doc.clientID, Clock: clock},
+				Origin:      origin,
+				OriginRight: originRight,
+				Left:        left,
+				Parent:      t,
+				Content:     NewContentFormat(d.key, revertVal),
+			}
+			closeItem.integrate(txn, 0)
+			left = closeItem
+			origin = &ID{Client: closeItem.ID.Client, Clock: closeItem.ID.Clock}
+			originRight = nil
+			clock = txn.doc.store.NextClock(txn.doc.clientID)
+		}
+	}
+
+	pos.left = left
+	pos.index += utf16Len(text)
+}
+
+// applyDeltaDelete deletes length countable units starting at the cursor pos,
+// mirroring deleteRange's per-item tombstone walk exactly but resuming from
+// the already-known cursor instead of re-resolving the start item — pos.right
+// is already the correct bracket item, so (unlike deleteRange) no leading
+// split-at-index-in-item step is needed. A delete never advances the cursor's
+// logical index (pos.index is left unchanged; only pos.left/pos.right move).
+// Live ContentFormat markers within the deleted span are walked over (their
+// contribution to pos.cur is applied) rather than skipped blindly, since a
+// delete never removes a marker itself (deleteRange only tombstones countable
+// content) and any such marker is still live and in scope at the cursor after
+// the delete completes.
+func (t *abstractType) applyDeltaDelete(txn *Transaction, pos *itemTextPos, length int) {
+	if length <= 0 {
+		return
+	}
+	origLen := length
+	for pos.right != nil && length > 0 {
+		item := pos.right
+		if !item.Deleted {
+			if cf, ok := item.Content.(*ContentFormat); ok {
+				updateAttr(pos.cur, cf)
+			} else if item.Content.IsCountable() {
+				n := item.Content.Len()
+				if n <= length {
+					item.delete(txn)
+					length -= n
+				} else {
+					splitItem(txn, item, length)
+					item.delete(txn)
+					length = 0
+				}
+			}
+		}
+		pos.left = pos.right
+		pos.right = pos.right.Right
+	}
+	if deleted := origLen - length; deleted > 0 {
+		t.updateMarkerChanges(pos.index, -deleted)
 	}
 }
 

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -495,7 +495,7 @@ func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attribu
 // once any formatting exists, the exact walk resumes so scattered markers
 // anywhere before anchor are still picked up correctly (search markers only
 // track rendered position, not accumulated attribute state, so they cannot
-	// safely shortcut this in general). Gated on t.disableMarkers too
+// safely shortcut this in general). Gated on t.disableMarkers too
 // so the force-cold test seam still exercises the full walk.
 func (txt *YText) currentAttributesAt(anchor *Item) Attributes {
 	t := &txt.abstractType

--- a/provider/websocket/cluster.go
+++ b/provider/websocket/cluster.go
@@ -228,6 +228,7 @@ func (s *Server) Inject(ctx context.Context, in cluster.Inbound) error {
 		if err != nil {
 			return err
 		}
+		rm.clearIdle() // #183: relay activity mutates immediately; no registration delay.
 		if err := crdt.ApplyUpdateV1(rm.doc, in.Data, s.relaySentinel); err != nil {
 			return err
 		}
@@ -243,6 +244,7 @@ func (s *Server) Inject(ctx context.Context, in cluster.Inbound) error {
 		if err != nil {
 			return err
 		}
+		rm.clearIdle() // #183: relay activity mutates immediately; no registration delay.
 		if err := rm.awareness.ApplyUpdate(in.Data, s.relaySentinel); err != nil {
 			return err
 		}

--- a/provider/websocket/cluster_hooks.go
+++ b/provider/websocket/cluster_hooks.go
@@ -18,11 +18,24 @@ import (
 // GetDoc, which exposes the room's *crdt.Doc.
 func (s *Server) GetAwareness(room string) (*awareness.Awareness, bool) {
 	s.rmu.RLock()
-	defer s.rmu.RUnlock()
-	if r, ok := s.rooms[room]; ok {
-		return r.awareness, true
+	r, ok := s.rooms[room]
+	s.rmu.RUnlock()
+	if !ok {
+		return nil, false
 	}
-	return nil, false
+	// A room still performing its off-lock load (#182), or one whose load failed
+	// (placeholder already removed), is reported as not-yet-resident — mirroring
+	// GetDoc's contract — so callers never see the awareness of a room that is not
+	// fully live.
+	select {
+	case <-r.ready:
+		if r.loadErr != nil {
+			return nil, false
+		}
+		return r.awareness, true
+	default:
+		return nil, false
+	}
 }
 
 // Rooms returns the names of all rooms currently resident in the server, in

--- a/provider/websocket/idle_sweep.go
+++ b/provider/websocket/idle_sweep.go
@@ -1,0 +1,214 @@
+package websocket
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// defaultIdleSweepCap bounds the derived sweep cadence so a very large
+// RoomIdleTimeout does not leave eviction latency unbounded.
+const defaultIdleSweepCap = 30 * time.Second
+
+// ensureIdleSweeper starts the single per-Server idle-room sweeper goroutine the
+// first time it is called while RoomIdleTimeout > 0. It is a cheap sync.Once
+// fast-path on every subsequent call and a complete no-op in eager-evict mode
+// (RoomIdleTimeout == 0), so calling it on every room creation is safe. The
+// goroutine runs until Shutdown closes s.shutdownCh, then closes s.sweeperDone.
+func (s *Server) ensureIdleSweeper() {
+	if s.RoomIdleTimeout <= 0 {
+		return
+	}
+	s.sweeperOnce.Do(func() {
+		s.sweeperStarted.Store(true)
+		go s.idleSweepLoop()
+	})
+}
+
+// idleSweepInterval returns how often the sweeper wakes. Tests may set
+// s.idleSweepInterval for a short deterministic period; otherwise it is derived
+// from RoomIdleTimeout (half the timeout, clamped to [1s, defaultIdleSweepCap])
+// so eviction latency stays bounded without polling needlessly often.
+func (s *Server) idleSweepIntervalDur() time.Duration {
+	if s.idleSweepInterval > 0 {
+		return s.idleSweepInterval
+	}
+	d := s.RoomIdleTimeout / 2
+	if d < time.Second {
+		d = time.Second
+	}
+	if d > defaultIdleSweepCap {
+		d = defaultIdleSweepCap
+	}
+	return d
+}
+
+// idleSweepLoop is the sweeper goroutine body. It ticks at idleSweepIntervalDur
+// and evicts expired / over-cap idle rooms each tick until Shutdown fires. It
+// closes s.sweeperDone on exit so Shutdown / tests can observe a clean stop.
+func (s *Server) idleSweepLoop() {
+	defer close(s.sweeperDone)
+	ticker := time.NewTicker(s.idleSweepIntervalDur())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.shutdownCh:
+			return
+		case <-ticker.C:
+			s.sweepIdleRooms(time.Now())
+		}
+	}
+}
+
+// idleCandidate is a snapshot of one idle-resident room taken under s.rmu.
+type idleCandidate struct {
+	name      string
+	rm        *room
+	idleSince time.Time
+}
+
+// sweepIdleRooms performs one sweep pass. It snapshots the idle-resident rooms
+// under s.rmu (O(1) per room; no I/O and no flush under the lock), then decides
+// which to evict: any room idle longer than RoomIdleTimeout, plus — when
+// MaxResidentRooms > 0 — the least-recently-idle rooms in excess of the bound
+// (LRU). Each eviction goes through evictIdleRoom, which re-checks emptiness
+// under rm.mu and performs the v1.37.0 flush-before-evict teardown. s.rmu is
+// never held across a flush or eviction.
+func (s *Server) sweepIdleRooms(now time.Time) {
+	timeout := s.RoomIdleTimeout
+	if timeout <= 0 {
+		return
+	}
+
+	// Snapshot idle-resident rooms. A room counts as idle only when it is empty
+	// (len(peers)==0) AND carries a non-zero idleSince stamp — i.e. genuinely
+	// idle, not merely looked up. Skip rooms still loading (ready not closed):
+	// idleSince is only ever stamped post-load, so this is belt-and-braces.
+	var idle []idleCandidate
+	s.rmu.RLock()
+	for name, rm := range s.rooms {
+		select {
+		case <-rm.ready:
+		default:
+			continue
+		}
+		rm.mu.Lock()
+		if len(rm.peers) == 0 && !rm.idleSince.IsZero() {
+			idle = append(idle, idleCandidate{name: name, rm: rm, idleSince: rm.idleSince})
+		}
+		rm.mu.Unlock()
+	}
+	s.rmu.RUnlock()
+
+	if len(idle) == 0 {
+		return
+	}
+
+	// Order least-recently-idle first so the LRU overflow slice is the oldest
+	// rooms and eviction below happens oldest-first.
+	sort.Slice(idle, func(i, j int) bool {
+		return idle[i].idleSince.Before(idle[j].idleSince)
+	})
+
+	// overflow is how many of the oldest idle rooms must go purely to satisfy the
+	// MaxResidentRooms LRU bound, independent of the timeout.
+	overflow := 0
+	if s.MaxResidentRooms > 0 && len(idle) > s.MaxResidentRooms {
+		overflow = len(idle) - s.MaxResidentRooms
+	}
+
+	for i, c := range idle {
+		expired := now.Sub(c.idleSince) >= timeout
+		lru := i < overflow
+		if expired || lru {
+			// evictIdleRoom re-verifies peers==0 and the exact idle stamp under
+			// rm.mu before committing, so a room that was rejoined or re-stamped
+			// between the snapshot and here is safely left alone.
+			s.evictIdleRoom(c.name, c.rm, c.idleSince)
+		}
+	}
+}
+
+// evictIdleRoom evicts a single idle-resident room using the identical teardown
+// primitives as handleDisconnect / CloseRoom: a flush-before-evict durability
+// barrier (flushReq/ack, no lock held across it), a pointer-identity guarded
+// delete from s.rooms under s.rmu+rm.mu, closing persistStop, waiting persistDone,
+// stopping awareness auto-expiry, tearing down relay observers, and firing
+// OnUnloadDocument. It is purpose-built for the sweeper rather than shared with
+// those two paths (whose eviction is interleaved with peer removal, semaphore
+// release, OnLastPeer, and awareness-removal broadcasts) so their reviewed code
+// is left untouched; the teardown sequence itself is byte-for-byte the same.
+//
+// CRITICAL: expectIdle is the idleSince observed in the snapshot. Eviction
+// commits only if, under rm.mu, the room is STILL empty AND idleSince is
+// unchanged. A rejoin clears idleSince (→ zero); any join/leave churn restamps
+// it to a different time.Now(); relay/Apply activity clears it via clearIdle.
+// All three make the Equal check fail, so the sweeper never evicts a room that
+// became active — it evicts on emptiness, never on the stale stamp alone.
+//
+// On flush failure the room + worker are kept alive (matching handleDisconnect):
+// the retained batch is retried on the next sweep / teardown, and a reconnect
+// meanwhile finds the warm in-memory doc rather than reloading a stale store.
+func (s *Server) evictIdleRoom(name string, rm *room, expectIdle time.Time) bool {
+	// FLUSH-BEFORE-EVICT (#175 follow-up). Make the pending coalesced batch
+	// durable while rm is still in s.rooms and the worker is still alive. No lock
+	// is held across the send/ack; the ack is buffered (cap 1) so the worker
+	// never blocks. Guard against a worker that already exited (raced by
+	// CloseRoom/handleDisconnect/shutdown) via the persistDone branch.
+	flushOK := true
+	if rm.flushReq != nil {
+		ack := make(chan bool, 1)
+		select {
+		case rm.flushReq <- ack:
+			flushOK = <-ack
+		case <-rm.persistDone:
+			// Worker already gone; its exit-flush handled durability best-effort.
+		}
+	}
+	if !flushOK {
+		// Abort: keep room + worker alive so the retained batch is retried later.
+		return false
+	}
+
+	evicted := false
+	s.rmu.Lock()
+	rm.mu.Lock()
+	// Re-check under the locks: only evict a room that is STILL empty and STILL
+	// carries the exact idle stamp we snapshotted. This mirrors handleDisconnect's
+	// own re-check and is the guarantee that we never evict on idleSince alone.
+	if len(rm.peers) == 0 && rm.idleSince.Equal(expectIdle) {
+		if current, ok := s.rooms[name]; ok && current == rm {
+			delete(s.rooms, name)
+			evicted = true
+		}
+		if rm.persistStop != nil {
+			select {
+			case <-rm.persistStop:
+				// already closed by a racing CloseRoom
+			default:
+				close(rm.persistStop)
+			}
+		}
+	}
+	rm.mu.Unlock()
+	s.rmu.Unlock()
+
+	if !evicted {
+		return false
+	}
+
+	// Wait for the persistence goroutine to drain and exit before the room
+	// reference becomes garbage.
+	if rm.persistDone != nil {
+		<-rm.persistDone
+	}
+	// Stop awareness auto-expiry, tear down relay observers, fire OnUnloadDocument.
+	rm.awareness.Destroy()
+	s.teardownRelayRoom(rm, name)
+	if hook := s.OnUnloadDocument; hook != nil {
+		s.safeHook("OnUnloadDocument", func() {
+			hook(context.Background(), name)
+		})
+	}
+	return true
+}

--- a/provider/websocket/idle_sweep_test.go
+++ b/provider/websocket/idle_sweep_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/reearth/ygo/crdt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
 )
 
 // newUnloadSignal wires OnUnloadDocument to a buffered per-room channel so a

--- a/provider/websocket/idle_sweep_test.go
+++ b/provider/websocket/idle_sweep_test.go
@@ -1,0 +1,239 @@
+package websocket
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUnloadSignal wires OnUnloadDocument to a buffered per-room channel so a
+// test can wait deterministically for a specific room's eviction (rather than
+// sleeping). Returns a func that blocks until the named room has been unloaded
+// or the deadline fires.
+func newUnloadSignal(s *Server) (waitUnloaded func(t *testing.T, name string, d time.Duration) bool) {
+	var mu sync.Mutex
+	chans := map[string]chan struct{}{}
+	get := func(name string) chan struct{} {
+		mu.Lock()
+		defer mu.Unlock()
+		ch, ok := chans[name]
+		if !ok {
+			ch = make(chan struct{}, 1)
+			chans[name] = ch
+		}
+		return ch
+	}
+	s.OnUnloadDocument = func(_ context.Context, name string) {
+		select {
+		case get(name) <- struct{}{}:
+		default:
+		}
+	}
+	return func(t *testing.T, name string, d time.Duration) bool {
+		t.Helper()
+		select {
+		case <-get(name):
+			return true
+		case <-time.After(d):
+			return false
+		}
+	}
+}
+
+// The background sweeper must evict a room whose idle time exceeds
+// RoomIdleTimeout: OnUnloadDocument fires, the room is gone from s.rooms, and
+// the durable flush ran before eviction.
+func TestIdleSweep_EvictsRoomAfterTimeout(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = 30 * time.Millisecond
+	s.idleSweepInterval = 5 * time.Millisecond
+	waitUnloaded := newUnloadSignal(s)
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hi", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-lastPeer // room stamped idle
+
+	// Sanity: the durable flush ran before the room could be swept.
+	require.GreaterOrEqual(t, a.storeCount(), 1, "durable flush must run before eviction")
+
+	require.True(t, waitUnloaded(t, "room", 2*time.Second),
+		"sweeper must fire OnUnloadDocument for a room idle past RoomIdleTimeout")
+
+	_, present, _ := roomState(s, "room")
+	assert.False(t, present, "swept room must be gone from s.rooms")
+	require.True(t, s.sweeperStarted.Load(), "sweeper goroutine must have started")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// The sweeper must NEVER evict a room that has a live peer, even when a stale
+// idle stamp is present: it rechecks len(peers)==0, not idleSince alone. Here a
+// peer rejoins within the idle window (which clears idleSince); the room must
+// survive well past RoomIdleTimeout.
+func TestIdleSweep_DoesNotEvictRejoinedRoom(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = 30 * time.Millisecond
+	s.idleSweepInterval = 5 * time.Millisecond
+	waitUnloaded := newUnloadSignal(s)
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	_ = connA.Close()
+	<-lastPeer // stamped idle
+
+	// Rejoin before the sweeper reaps it; registration clears idleSince.
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	drainWS(t, connB, docB)
+
+	// Wait well past several idle-timeout windows: an occupied room must survive.
+	assert.False(t, waitUnloaded(t, "room", 300*time.Millisecond),
+		"sweeper must NOT evict a room with a live peer")
+
+	rm, present, idleSince := roomState(s, "room")
+	require.True(t, present, "rejoined room must stay resident")
+	require.NotNil(t, rm)
+	assert.True(t, idleSince.IsZero(), "a room with a live peer must not carry an idle stamp")
+
+	_ = connB.Close()
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// White-box guard: even if a room ends up with an idle stamp AND a peer present
+// (the exact stale-stamp state the sweeper must be robust against), a direct
+// sweep must not evict it — it rechecks emptiness under rm.mu.
+func TestIdleSweep_ReCheckPeersUnderLock(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = 10 * time.Millisecond
+	waitUnloaded := newUnloadSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+
+	// Force the pathological state: an expired idle stamp on an OCCUPIED room.
+	rm, present, _ := roomState(s, "room")
+	require.True(t, present)
+	rm.mu.Lock()
+	require.NotEmpty(t, rm.peers, "peer A must be registered")
+	rm.idleSince = time.Now().Add(-time.Hour) // long expired
+	rm.mu.Unlock()
+
+	// Direct sweep: must skip the occupied room despite the expired stamp.
+	s.sweepIdleRooms(time.Now())
+
+	_, stillPresent, _ := roomState(s, "room")
+	assert.True(t, stillPresent, "sweeper must not evict a room that still has a peer")
+	assert.False(t, waitUnloaded(t, "room", 50*time.Millisecond),
+		"OnUnloadDocument must not fire for an occupied room")
+
+	_ = connA.Close()
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// With MaxResidentRooms=N, creating the (N+1)-th idle room must trigger LRU
+// eviction of the least-recently-idle room (smallest idleSince) first.
+func TestIdleSweep_MaxResidentRoomsLRU(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	// A long timeout so timeout-based eviction never fires — isolate LRU.
+	s.RoomIdleTimeout = 10 * time.Second
+	s.idleSweepInterval = 5 * time.Millisecond
+	s.MaxResidentRooms = 2
+	waitUnloaded := newUnloadSignal(s)
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Create three idle rooms with strictly increasing idleSince stamps.
+	makeIdle := func(room string) {
+		doc := crdt.New(crdt.WithClientID(1))
+		conn := dialWS(t, ts, room)
+		drainWS(t, conn, doc)
+		_ = conn.Close()
+		<-lastPeer // stamped idle
+	}
+	makeIdle("room1") // least-recently-idle
+	time.Sleep(3 * time.Millisecond)
+	makeIdle("room2")
+	time.Sleep(3 * time.Millisecond)
+	makeIdle("room3") // most-recently-idle; pushes idle count to 3 > Max(2)
+
+	require.True(t, waitUnloaded(t, "room1", 2*time.Second),
+		"LRU: the least-recently-idle room (room1) must be evicted first")
+
+	_, p1, _ := roomState(s, "room1")
+	_, p2, _ := roomState(s, "room2")
+	_, p3, _ := roomState(s, "room3")
+	assert.False(t, p1, "room1 (oldest idle) must be evicted by the LRU bound")
+	assert.True(t, p2, "room2 must remain resident")
+	assert.True(t, p3, "room3 must remain resident")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// The sweeper must stop on Shutdown: Shutdown returns and the sweeper loop
+// exits (its done channel closes). RoomIdleTimeout==0 must start no sweeper.
+func TestIdleSweep_StopsOnShutdown(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Minute
+	s.idleSweepInterval = 5 * time.Millisecond
+	ts := httptest.NewServer(s)
+
+	// A room creation must lazily start the sweeper.
+	doc := crdt.New(crdt.WithClientID(1))
+	conn := dialWS(t, ts, "room")
+	drainWS(t, conn, doc)
+	require.True(t, s.sweeperStarted.Load(), "sweeper must start lazily when RoomIdleTimeout>0")
+	_ = conn.Close()
+	ts.Close()
+
+	require.NoError(t, s.Shutdown(context.Background()))
+	select {
+	case <-s.sweeperDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweeper loop did not exit after Shutdown")
+	}
+}
+
+// RoomIdleTimeout==0 (eager-evict) must start no sweeper at all.
+func TestIdleSweep_ZeroTimeoutStartsNoSweeper(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	// RoomIdleTimeout left at zero.
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	doc := crdt.New(crdt.WithClientID(1))
+	conn := dialWS(t, ts, "room")
+	drainWS(t, conn, doc)
+	_ = conn.Close()
+
+	assert.False(t, s.sweeperStarted.Load(), "RoomIdleTimeout=0 must start no sweeper")
+	require.NoError(t, s.Shutdown(context.Background()))
+}

--- a/provider/websocket/idle_sweep_test.go
+++ b/provider/websocket/idle_sweep_test.go
@@ -155,6 +155,109 @@ func TestIdleSweep_ReCheckPeersUnderLock(t *testing.T) {
 	require.NoError(t, s.Shutdown(context.Background()))
 }
 
+// White-box guard on the COMMIT-PHASE recheck inside evictIdleRoom itself
+// (idle_sweep.go ~179), as distinct from TestIdleSweep_ReCheckPeersUnderLock
+// above which only exercises the SNAPSHOT-phase filter in sweepIdleRooms (an
+// occupied room is excluded from the candidate list before evictIdleRoom is
+// ever called). Here evictIdleRoom is invoked directly with a stale
+// expectIdle captured before a re-activation, so only the
+// `rm.idleSince.Equal(expectIdle)` + peers-under-lock recheck inside
+// evictIdleRoom can save the room.
+//
+// Case (a): the room is rejoined (a peer registers) between the snapshot and
+// the evictIdleRoom call — registration clears idleSince to zero, so
+// len(rm.peers)==0 already fails and the Equal check also fails.
+func TestEvictIdleRoom_CommitPhaseSkipsRejoinedRoom(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Hour // irrelevant: evictIdleRoom is called directly
+	waitUnloaded := newUnloadSignal(s)
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	_ = connA.Close()
+	<-lastPeer // last peer left; room stamped idle
+
+	rm, present, staleExpectIdle := roomState(s, "room")
+	require.True(t, present)
+	require.False(t, staleExpectIdle.IsZero(), "idleSince must be stamped after last peer leaves")
+
+	// Re-activation between snapshot and commit: a rejoin registers a new peer,
+	// which clears idleSince (per the peer-registration fix, #183).
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	drainWS(t, connB, docB)
+
+	_, _, liveIdleSince := roomState(s, "room")
+	require.True(t, liveIdleSince.IsZero(), "rejoin must have cleared idleSince")
+
+	// Call evictIdleRoom DIRECTLY with the now-stale snapshot value, simulating
+	// a sweep pass whose snapshot predates the rejoin.
+	evicted := s.evictIdleRoom("room", rm, staleExpectIdle)
+	assert.False(t, evicted, "commit-phase recheck must refuse to evict a rejoined room")
+
+	_, stillPresent, _ := roomState(s, "room")
+	assert.True(t, stillPresent, "rejoined room must remain in s.rooms")
+	assert.False(t, waitUnloaded(t, "room", 50*time.Millisecond),
+		"OnUnloadDocument must not fire for a rejoined room")
+
+	_ = connB.Close()
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// Case (b): the room churns (leaves again, re-stamping idleSince to a fresh
+// instant) between the snapshot and the evictIdleRoom call. len(rm.peers)==0
+// still holds, so only the `idleSince.Equal(expectIdle)` half of the guard can
+// save the room — it must fail because the two time.Time instants differ.
+func TestEvictIdleRoom_CommitPhaseSkipsChurnedIdleStamp(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Hour // irrelevant: evictIdleRoom is called directly
+	waitUnloaded := newUnloadSignal(s)
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	_ = connA.Close()
+	<-lastPeer // last peer left; room stamped idle
+
+	rm, present, staleExpectIdle := roomState(s, "room")
+	require.True(t, present)
+	require.False(t, staleExpectIdle.IsZero(), "idleSince must be stamped after last peer leaves")
+
+	// Simulate churn: another join+leave cycle re-stamps idleSince to a fresh
+	// instant without ever registering as "occupied" at the moment we look.
+	// A short sleep guarantees the new time.Now() is a distinct instant from
+	// staleExpectIdle (monotonic clock reading granularity).
+	time.Sleep(2 * time.Millisecond)
+	rm.mu.Lock()
+	rm.idleSince = time.Now()
+	freshIdleSince := rm.idleSince
+	rm.mu.Unlock()
+	require.False(t, freshIdleSince.Equal(staleExpectIdle),
+		"test setup must produce a genuinely different idleSince instant")
+
+	// Call evictIdleRoom DIRECTLY with the now-stale snapshot value, simulating
+	// a sweep pass whose snapshot predates the churn.
+	evicted := s.evictIdleRoom("room", rm, staleExpectIdle)
+	assert.False(t, evicted, "commit-phase recheck must refuse to evict on a stale idle stamp")
+
+	_, stillPresent, idleSinceAfter := roomState(s, "room")
+	assert.True(t, stillPresent, "churned room must remain in s.rooms")
+	assert.True(t, idleSinceAfter.Equal(freshIdleSince), "idleSince must be left untouched by the aborted eviction")
+	assert.False(t, waitUnloaded(t, "room", 50*time.Millisecond),
+		"OnUnloadDocument must not fire on a stale idle stamp")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
 // With MaxResidentRooms=N, creating the (N+1)-th idle room must trigger LRU
 // eviction of the least-recently-idle room (smallest idleSince) first.
 func TestIdleSweep_MaxResidentRoomsLRU(t *testing.T) {

--- a/provider/websocket/idle_test.go
+++ b/provider/websocket/idle_test.go
@@ -323,8 +323,17 @@ func TestIdleRoom_ZeroTimeoutPreservesEagerEvict(t *testing.T) {
 	a := &idleRecordAdapter{}
 	s := NewServerWithPersistence(a) // RoomIdleTimeout left at zero value
 	var unloaded int32
-	s.OnUnloadDocument = func(_ context.Context, _ string) {
+	// newUnloadSignal (idle_sweep_test.go) is the deterministic wait point for
+	// OnUnloadDocument. Chain it behind our own counter-incrementing hook: the
+	// teardown order is OnLastPeer THEN OnUnloadDocument (peer.go), so <-lastPeer
+	// alone does NOT guarantee OnUnloadDocument has fired yet — asserting
+	// unloaded==1 right after <-lastPeer races the async teardown goroutine.
+	// Waiting on waitUnloaded (in addition to <-lastPeer) closes that gap.
+	waitUnloaded := newUnloadSignal(s)
+	signalOnUnload := s.OnUnloadDocument
+	s.OnUnloadDocument = func(ctx context.Context, name string) {
 		atomic.AddInt32(&unloaded, 1)
+		signalOnUnload(ctx, name)
 	}
 	lastPeer := newLastPeerSignal(s)
 	ts := httptest.NewServer(s)
@@ -338,7 +347,9 @@ func TestIdleRoom_ZeroTimeoutPreservesEagerEvict(t *testing.T) {
 	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
 
 	_ = connA.Close()
-	<-lastPeer
+	<-lastPeer // teardown decision made (1->0 transition)
+	require.True(t, waitUnloaded(t, "room", 2*time.Second),
+		"OnUnloadDocument must fire on eager eviction")
 
 	_, present, _ := roomState(s, "room")
 	assert.False(t, present, "RoomIdleTimeout=0 must evict the room eagerly, unchanged from prior releases")

--- a/provider/websocket/idle_test.go
+++ b/provider/websocket/idle_test.go
@@ -2,12 +2,14 @@ package websocket
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	gws "github.com/gorilla/websocket"
 	"github.com/reearth/ygo/crdt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +48,18 @@ func (a *idleRecordAdapter) storeCount() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return len(a.stores)
+}
+
+// dialWSHeader dials the test server like dialWS but attaches extra request
+// headers to the handshake (used to mark a specific connection so a test hook
+// can single it out). Registers a t.Cleanup to close the conn at test end.
+func dialWSHeader(t *testing.T, ts *httptest.Server, room string, h http.Header) *gws.Conn {
+	t.Helper()
+	u := "ws" + ts.URL[len("http"):] + "/" + room
+	conn, _, err := gws.DefaultDialer.Dial(u, h)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
 }
 
 // roomState looks up the room directly (internal test, same package) and
@@ -147,6 +161,95 @@ func TestIdleRoom_RejoinReusesWarmDocNoReload(t *testing.T) {
 	_, present, idleSince := roomState(s, "room")
 	assert.True(t, present)
 	assert.True(t, idleSince.IsZero(), "rejoin must clear idleSince")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// A last-peer-leave that overlaps a concurrent rejoin must never leave a stale
+// idle stamp on a room that ends up occupied (#183). This reproduces the exact
+// causal-point bug: when idleSince was cleared at room LOOKUP (getOrCreateRoom),
+// the joining peer B cleared it BEFORE it had registered in rm.peers, then the
+// sole departing peer A — seeing the room empty (B not yet registered) — flushed
+// and stamped idleSince=now, and B finally registered onto an occupied room
+// whose stale stamp nothing cleared. Task 12's sweeper could then evict a room
+// holding a LIVE peer.
+//
+// The interleaving is forced deterministically rather than raced: the joining
+// peer B is parked inside the WebSocket Upgrade (via a CheckOrigin that blocks),
+// which is exactly the window between getOrCreateRoom returning and the peer
+// registering in rm.peers. While B is parked we drop A and wait for its teardown
+// stamp to complete, then release B so it registers onto the just-stamped room.
+//
+//   - pre-fix: registration did not clear idleSince → the stamp survives on the
+//     occupied room → RED.
+//   - fixed:   registration clears idleSince in the same rm.mu section that adds
+//     the peer, after the stamp → idleSince==zero → GREEN.
+func TestIdleRoom_ConcurrentLeaveRejoinNoStaleStampOnOccupiedRoom(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Minute // idle mode: empty rooms are stamped, not evicted
+
+	// Force the leave/rejoin interleaving. CheckOrigin runs inside Upgrade —
+	// after getOrCreateRoom has returned but before the peer is registered in
+	// rm.peers — so blocking there parks the joining peer B precisely in the
+	// lookup→registration window. Only B carries the marker header; A and any
+	// other dial pass straight through.
+	bInUpgrade := make(chan struct{}) // closed once B is parked mid-Upgrade
+	releaseB := make(chan struct{})   // closed to let B finish upgrading + register
+	var bParkOnce sync.Once
+	s.upgrader.CheckOrigin = func(r *http.Request) bool {
+		if r.Header.Get("X-Test-Slow-Join") == "1" {
+			bParkOnce.Do(func() { close(bInUpgrade) })
+			<-releaseB
+		}
+		return true
+	}
+
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// A joins and fully registers.
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+
+	// B starts dialing with the slow-join marker and blocks mid-Upgrade: past
+	// getOrCreateRoom (which, on pre-fix code, has just cleared idleSince) but
+	// not yet registered in rm.peers.
+	bDone := make(chan struct{})
+	go func() {
+		defer close(bDone)
+		docB := crdt.New(crdt.WithClientID(2))
+		h := http.Header{"X-Test-Slow-Join": {"1"}}
+		connB := dialWSHeader(t, ts, "room", h)
+		drainWS(t, connB, docB)
+	}()
+	<-bInUpgrade // B is now parked in the lookup→registration window.
+
+	// Drop A while B is parked. A is the only registered peer, so
+	// handleDisconnect sees the room empty, flushes durably, and STAMPS
+	// idleSince. OnLastPeer fires after that stamp decision, so its receipt is a
+	// barrier: idleSince is settled by the time we read it below.
+	_ = connA.Close()
+	<-lastPeer
+
+	// At this instant the room is genuinely empty and MUST be stamped idle — the
+	// fix must not suppress legitimate stamping.
+	_, present, idleEmpty := roomState(s, "room")
+	require.True(t, present, "idle room must stay resident (RoomIdleTimeout > 0)")
+	require.False(t, idleEmpty.IsZero(), "a genuinely-empty room must be stamped idle")
+
+	// Release B: it finishes upgrading and registers onto the stamped room.
+	close(releaseB)
+	<-bDone // B has received its handshake (sent only after registration).
+
+	// The room now holds a LIVE, registered peer. Its idle stamp MUST be gone.
+	rm, present, idleOccupied := roomState(s, "room")
+	require.True(t, present)
+	require.NotNil(t, rm)
+	assert.True(t, idleOccupied.IsZero(),
+		"a room with a live registered peer must NOT carry a stale idle stamp (got %v)", idleOccupied)
 
 	require.NoError(t, s.Shutdown(context.Background()))
 }

--- a/provider/websocket/idle_test.go
+++ b/provider/websocket/idle_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -10,9 +11,12 @@ import (
 	"time"
 
 	gws "github.com/gorilla/websocket"
-	"github.com/reearth/ygo/crdt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+	ygsync "github.com/reearth/ygo/sync"
 )
 
 // idleRecordAdapter records LoadDoc and StoreUpdate call counts so tests can
@@ -50,16 +54,47 @@ func (a *idleRecordAdapter) storeCount() int {
 	return len(a.stores)
 }
 
-// dialWSHeader dials the test server like dialWS but attaches extra request
+// dialConnErr dials the test server like dialWS but attaches extra request
 // headers to the handshake (used to mark a specific connection so a test hook
-// can single it out). Registers a t.Cleanup to close the conn at test end.
-func dialWSHeader(t *testing.T, ts *httptest.Server, room string, h http.Header) *gws.Conn {
-	t.Helper()
+// can single it out), and reports failure via a returned error instead of
+// require. This makes it safe to call from a goroutine other than the one
+// running the test — a failed require.NoError off the test goroutine invokes
+// t.FailNow from the wrong goroutine, which is unsafe/undefined (testifylint
+// go-require). The caller (on the main test goroutine) is responsible for
+// asserting on the returned error and for closing the conn.
+func dialConnErr(ts *httptest.Server, room string, h http.Header) (*gws.Conn, error) {
 	u := "ws" + ts.URL[len("http"):] + "/" + room
 	conn, _, err := gws.DefaultDialer.Dial(u, h)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = conn.Close() })
-	return conn
+	if err != nil {
+		return nil, fmt.Errorf("dial: %w", err)
+	}
+	return conn, nil
+}
+
+// drainConnErr is the error-returning equivalent of drainWS (see dialConnErr
+// for why): it reads the three handshake frames the server always sends on
+// connect and applies any sync frames into doc, reporting failure via the
+// returned error rather than require/assert.
+func drainConnErr(conn *gws.Conn, doc *crdt.Doc) error {
+	for i := 0; i < 3; i++ {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := conn.ReadMessage()
+		_ = conn.SetReadDeadline(time.Time{})
+		if err != nil {
+			return fmt.Errorf("read handshake frame %d: %w", i, err)
+		}
+		dec := encoding.NewDecoder(data)
+		outer, err := dec.ReadVarUint()
+		if err != nil {
+			return fmt.Errorf("decode outer varuint: %w", err)
+		}
+		if outer == msgSync {
+			if _, err := ygsync.ApplySyncMessage(doc, dec.RemainingBytes(), nil); err != nil {
+				return fmt.Errorf("apply sync frame: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 // roomState looks up the room directly (internal test, same package) and
@@ -217,13 +252,32 @@ func TestIdleRoom_ConcurrentLeaveRejoinNoStaleStampOnOccupiedRoom(t *testing.T) 
 	// B starts dialing with the slow-join marker and blocks mid-Upgrade: past
 	// getOrCreateRoom (which, on pre-fix code, has just cleared idleSince) but
 	// not yet registered in rm.peers.
+	//
+	// The dial+handshake run on this spawned goroutine, which is NOT the
+	// goroutine running the test, so they must not call require/assert
+	// (testifylint go-require): dialConnErr/drainConnErr report failure via a
+	// returned error instead, forwarded below through bResult for the MAIN
+	// test goroutine to assert on.
+	type joinResult struct {
+		conn *gws.Conn
+		err  error
+	}
+	bResult := make(chan joinResult, 1)
 	bDone := make(chan struct{})
 	go func() {
 		defer close(bDone)
 		docB := crdt.New(crdt.WithClientID(2))
 		h := http.Header{"X-Test-Slow-Join": {"1"}}
-		connB := dialWSHeader(t, ts, "room", h)
-		drainWS(t, connB, docB)
+		connB, err := dialConnErr(ts, "room", h)
+		if err != nil {
+			bResult <- joinResult{err: err}
+			return
+		}
+		if err := drainConnErr(connB, docB); err != nil {
+			bResult <- joinResult{conn: connB, err: fmt.Errorf("drain: %w", err)}
+			return
+		}
+		bResult <- joinResult{conn: connB}
 	}()
 	<-bInUpgrade // B is now parked in the lookup→registration window.
 
@@ -243,6 +297,14 @@ func TestIdleRoom_ConcurrentLeaveRejoinNoStaleStampOnOccupiedRoom(t *testing.T) 
 	// Release B: it finishes upgrading and registers onto the stamped room.
 	close(releaseB)
 	<-bDone // B has received its handshake (sent only after registration).
+
+	// Assertions on B's dial/handshake outcome happen here, on the MAIN test
+	// goroutine — the spawned goroutine only forwarded the result.
+	res := <-bResult
+	if res.conn != nil {
+		t.Cleanup(func() { _ = res.conn.Close() })
+	}
+	require.NoError(t, res.err, "peer B dial/handshake failed")
 
 	// The room now holds a LIVE, registered peer. Its idle stamp MUST be gone.
 	rm, present, idleOccupied := roomState(s, "room")

--- a/provider/websocket/idle_test.go
+++ b/provider/websocket/idle_test.go
@@ -1,0 +1,181 @@
+package websocket
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// idleRecordAdapter records LoadDoc and StoreUpdate call counts so tests can
+// assert (a) the durable flush ran on last-peer-leave and (b) a rejoin within
+// the idle window reused the warm in-memory doc rather than reloading it.
+type idleRecordAdapter struct {
+	mu        sync.Mutex
+	loadCalls int
+	stores    [][]byte
+}
+
+func (a *idleRecordAdapter) LoadDoc(string) ([]byte, error) {
+	a.mu.Lock()
+	a.loadCalls++
+	a.mu.Unlock()
+	return nil, nil
+}
+
+func (a *idleRecordAdapter) StoreUpdate(_ string, u []byte) error {
+	a.mu.Lock()
+	a.stores = append(a.stores, append([]byte(nil), u...))
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *idleRecordAdapter) loadCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.loadCalls
+}
+
+func (a *idleRecordAdapter) storeCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.stores)
+}
+
+// roomState looks up the room directly (internal test, same package) and
+// reports whether it's present plus its idleSince stamp.
+func roomState(s *Server, name string) (r *room, present bool, idleSince time.Time) {
+	s.rmu.RLock()
+	defer s.rmu.RUnlock()
+	r, present = s.rooms[name]
+	if present {
+		r.mu.Lock()
+		idleSince = r.idleSince
+		r.mu.Unlock()
+	}
+	return r, present, idleSince
+}
+
+// newLastPeerSignal wires OnLastPeer to a buffered channel so tests can wait
+// deterministically for the teardown decision (evict vs stamp-idle) to have
+// been made, instead of sleeping. Matches the pattern used throughout
+// persistence_coalesce_test.go.
+func newLastPeerSignal(s *Server) <-chan struct{} {
+	ch := make(chan struct{}, 4)
+	s.OnLastPeer = func(_ context.Context, _ string) {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	return ch
+}
+
+// With RoomIdleTimeout > 0, the last peer leaving must still perform the
+// v1.37.0 durable flush (so data is safe) but must NOT evict: the room stays
+// discoverable in s.rooms with idleSince stamped, worker still alive.
+func TestIdleRoom_LastPeerLeaveStampsIdleKeepsRoomResident(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Minute // long enough that no sweeper (T12) matters here
+	var unloaded int32
+	s.OnUnloadDocument = func(_ context.Context, _ string) {
+		atomic.AddInt32(&unloaded, 1)
+	}
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hi", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-lastPeer // teardown decision made
+
+	rm, present, idleSince := roomState(s, "room")
+	assert.True(t, present, "room must stay resident (not evicted) when RoomIdleTimeout > 0")
+	require.NotNil(t, rm)
+	assert.False(t, idleSince.IsZero(), "idleSince must be stamped when the room goes idle")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&unloaded), "OnUnloadDocument must NOT fire for a resident idle room")
+	assert.GreaterOrEqual(t, a.storeCount(), 1, "the durable flush must still happen before stamping idle")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// A reconnect within the idle window must reuse the warm in-memory doc: no
+// second LoadDoc call, doc content intact, and idleSince cleared.
+func TestIdleRoom_RejoinReusesWarmDocNoReload(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a)
+	s.RoomIdleTimeout = time.Minute
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hello", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-lastPeer
+
+	loadsBeforeRejoin := a.loadCount()
+	assert.Equal(t, 1, loadsBeforeRejoin, "sanity: exactly one LoadDoc for the original room creation")
+
+	docB := crdt.New(crdt.WithClientID(2))
+	connB := dialWS(t, ts, "room")
+	drainWS(t, connB, docB)
+
+	assert.Equal(t, "hello", docB.GetText("t").ToString(),
+		"rejoin must see the edit from the warm in-memory doc")
+	assert.Equal(t, loadsBeforeRejoin, a.loadCount(),
+		"rejoin within the idle window must NOT call LoadDoc again")
+
+	_, present, idleSince := roomState(s, "room")
+	assert.True(t, present)
+	assert.True(t, idleSince.IsZero(), "rejoin must clear idleSince")
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+// RoomIdleTimeout == 0 (the default) must preserve exact eager-evict
+// behaviour: last peer leaving deletes the room from s.rooms and fires
+// OnUnloadDocument, unchanged from pre-#183 behaviour.
+func TestIdleRoom_ZeroTimeoutPreservesEagerEvict(t *testing.T) {
+	a := &idleRecordAdapter{}
+	s := NewServerWithPersistence(a) // RoomIdleTimeout left at zero value
+	var unloaded int32
+	s.OnUnloadDocument = func(_ context.Context, _ string) {
+		atomic.AddInt32(&unloaded, 1)
+	}
+	lastPeer := newLastPeerSignal(s)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	docA := crdt.New(crdt.WithClientID(1))
+	connA := dialWS(t, ts, "room")
+	drainWS(t, connA, docA)
+	txtA := docA.GetText("t")
+	docA.Transact(func(txn *crdt.Transaction) { txtA.Insert(txn, 0, "hi", nil) })
+	sendV1Update(t, connA, crdt.EncodeStateAsUpdateV1(docA, nil))
+
+	_ = connA.Close()
+	<-lastPeer
+
+	_, present, _ := roomState(s, "room")
+	assert.False(t, present, "RoomIdleTimeout=0 must evict the room eagerly, unchanged from prior releases")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&unloaded), "OnUnloadDocument must fire on eager eviction")
+}

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -300,6 +300,7 @@ func (s *Server) Apply(
 	if err != nil {
 		return err
 	}
+	rm.clearIdle() // #183: Apply mutates the doc immediately; no registration delay.
 
 	origin := new(struct{})
 	var (

--- a/provider/websocket/inject.go
+++ b/provider/websocket/inject.go
@@ -195,6 +195,15 @@ func (s *Server) broadcastUpdate(ctx context.Context, room string, update []byte
 	if !ok {
 		return ErrRoomNotFound
 	}
+	// Gate on the room's load barrier (#182). For the public BroadcastUpdate path
+	// this waits until the off-lock load finished; for the relay Inject path the
+	// room was already obtained via getOrCreateRoom (ready closed), so this is a
+	// no-op. A room whose load failed was removed from s.rooms and is treated as
+	// not found. The wait holds no lock, so it cannot stall other rooms.
+	<-rm.ready
+	if rm.loadErr != nil {
+		return ErrRoomNotFound
+	}
 	rm.mu.Lock()
 	targets := make([]*peer, 0, len(rm.peers))
 	for p := range rm.peers {
@@ -447,11 +456,32 @@ func (s *Server) CloseRoom(name string, force bool) error {
 		return ErrInvalidRoomName
 	}
 
+	// Find the room, waiting out any in-progress off-lock load (#182). Evicting a
+	// room whose loadRoom is still running would race the loader (which may still
+	// wire the persistence worker, or remove the placeholder on failure). A
+	// loading room has no peers yet, so waiting is safe; we release s.rmu across
+	// the wait so we neither reintroduce the global stall this fix removes nor
+	// deadlock the loader's failure-path delete (which needs s.rmu). After the
+	// wait we re-look-up: the load may have failed and removed the placeholder, or
+	// the room may have been evicted/replaced.
 	s.rmu.Lock()
-	rm, ok := s.rooms[name]
-	if !ok {
-		s.rmu.Unlock()
-		return ErrRoomNotFound
+	var rm *room
+	for {
+		r, ok := s.rooms[name]
+		if !ok {
+			s.rmu.Unlock()
+			return ErrRoomNotFound
+		}
+		select {
+		case <-r.ready:
+			rm = r
+		default:
+			s.rmu.Unlock()
+			<-r.ready
+			s.rmu.Lock()
+			continue
+		}
+		break
 	}
 
 	rm.mu.Lock()

--- a/provider/websocket/load_bench_test.go
+++ b/provider/websocket/load_bench_test.go
@@ -81,6 +81,35 @@ func BenchmarkGetOrCreateRoom_ConcurrentDistinctRoomLoads(b *testing.B) {
 	}
 }
 
+// BenchmarkReconnectReuse_WarmIdleRoom measures the #183 (G4) reconnect-reuse
+// fast path: with RoomIdleTimeout > 0 an idle room stays resident, so a
+// reconnect to it hits the warm in-memory doc and pays NONE of the adapter's
+// LoadDoc latency. Each op re-resolves the SAME already-resident room, so the
+// steady-state cost is a map lookup plus the ready-barrier receive — orders of
+// magnitude below the loadLatency a cold (evicted) room would re-incur. Compare
+// ns/op against loadLatency to confirm the reuse path avoids the reload.
+//
+// Run:
+//
+//	go test ./provider/websocket/ -bench 'ReconnectReuse' -run '^$' -benchtime=1000x
+func BenchmarkReconnectReuse_WarmIdleRoom(b *testing.B) {
+	const loadLatency = 20 * time.Millisecond
+	s := NewServerWithPersistence(fixedLatencyAdapter{latency: loadLatency})
+	s.RoomIdleTimeout = time.Hour // keep the room resident for the whole run
+	// Prime the room once (pays the one-time LoadDoc latency).
+	if _, err := s.getOrCreateRoom(context.Background(), "warm"); err != nil {
+		b.Fatalf("prime getOrCreateRoom: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.getOrCreateRoom(context.Background(), "warm"); err != nil {
+			b.Fatalf("warm getOrCreateRoom: %v", err)
+		}
+	}
+	b.StopTimer()
+	_ = s.Shutdown(context.Background())
+}
+
 // TestGetOrCreateRoom_ConcurrentDistinctRooms_LoadIsParallel is a timed-test
 // companion to the benchmark above, meant to run under plain `go test` (no
 // -bench flag) so the #182 (G3) parallelism guarantee is checked on every CI

--- a/provider/websocket/load_bench_test.go
+++ b/provider/websocket/load_bench_test.go
@@ -1,0 +1,116 @@
+// Package websocket - benchmark for issue #182 (G3): proves room load no
+// longer serializes under the global rooms lock (s.rmu). Task 9 moved
+// LoadDoc / decode / OnLoadDocument off s.rmu behind a per-room `ready`
+// barrier (see server.go's getOrCreateRoom / createRoomPlaceholder / loadRoom
+// and the correctness regressions in server_load_test.go). This file adds the
+// missing performance proof: with a fixed-latency LoadDoc, N concurrent
+// connects to N DISTINCT rooms should complete in wall-clock time close to
+// one load's latency (parallel), not N times that latency (serialized).
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedLatencyAdapter is a PersistenceAdapter whose LoadDoc sleeps a fixed
+// latency before returning empty state (no stored data), uniformly modeling
+// a slow persistence backend (network round trip, disk seek, cold cache) for
+// every room. StoreUpdate is a no-op; this benchmark never writes.
+type fixedLatencyAdapter struct {
+	latency time.Duration
+}
+
+func (a fixedLatencyAdapter) LoadDoc(string) ([]byte, error) {
+	time.Sleep(a.latency)
+	return nil, nil
+}
+
+func (a fixedLatencyAdapter) StoreUpdate(string, []byte) error { return nil }
+
+// loadNDistinctRooms starts n rooms loading concurrently against s (each name
+// unique) and blocks until every getOrCreateRoom call has returned, failing
+// tb immediately on any error. It returns the elapsed wall-clock time.
+func loadNDistinctRooms(tb testing.TB, s *Server, n int, prefix string) time.Duration {
+	tb.Helper()
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := time.Now()
+	for j := 0; j < n; j++ {
+		room := fmt.Sprintf("%s-%d", prefix, j)
+		go func() {
+			defer wg.Done()
+			if _, err := s.getOrCreateRoom(context.Background(), room); err != nil {
+				tb.Errorf("getOrCreateRoom(%s): %v", room, err)
+			}
+		}()
+	}
+	wg.Wait()
+	return time.Since(start)
+}
+
+// BenchmarkGetOrCreateRoom_ConcurrentDistinctRoomLoads is the #182 (G3)
+// headline performance benchmark. Each op loads roomCount DISTINCT rooms
+// concurrently against an adapter whose LoadDoc sleeps loadLatency; b.N (or
+// -benchtime=Nx) controls how many times that whole batch repeats.
+//
+// Pre-fix (load under s.rmu): a batch takes ~roomCount*loadLatency, because
+// every room's LoadDoc serializes behind the single global lock.
+// Post-fix (Task 9's per-room ready barrier, load off s.rmu): a batch takes
+// ~loadLatency, because distinct rooms load in parallel.
+//
+// Run:
+//
+//	go test ./provider/websocket/ -bench 'Load|RoomCreate' -run '^$' -benchtime=5x
+//
+// Read ns/op against roomCount*loadLatency (serialized) vs loadLatency
+// (parallel) to judge which regime the code is in.
+func BenchmarkGetOrCreateRoom_ConcurrentDistinctRoomLoads(b *testing.B) {
+	const (
+		roomCount   = 20
+		loadLatency = 20 * time.Millisecond
+	)
+	adapter := fixedLatencyAdapter{latency: loadLatency}
+
+	for i := 0; i < b.N; i++ {
+		s := NewServerWithPersistence(adapter)
+		loadNDistinctRooms(b, s, roomCount, fmt.Sprintf("room-%d", i))
+	}
+}
+
+// TestGetOrCreateRoom_ConcurrentDistinctRooms_LoadIsParallel is a timed-test
+// companion to the benchmark above, meant to run under plain `go test` (no
+// -bench flag) so the #182 (G3) parallelism guarantee is checked on every CI
+// run, not just when someone remembers to pass -bench.
+//
+// It loads roomCount distinct rooms concurrently against a fixed-latency
+// LoadDoc and asserts the whole batch finishes well under
+// serializedBound (< roomCount*loadLatency): serialized loading (the pre-fix
+// behavior, room load running under s.rmu) would take roughly
+// roomCount*loadLatency = 300ms here; parallel loading (post-fix, Task 9's
+// per-room ready barrier) takes roughly loadLatency = 30ms. The bound is set
+// generously (3x a single load's latency) to absorb scheduler/CI jitter while
+// remaining decisively below the serialized total, so this fails loudly on a
+// regression back to lock-held loads without flaking on a merely slow CI box.
+func TestGetOrCreateRoom_ConcurrentDistinctRooms_LoadIsParallel(t *testing.T) {
+	const (
+		roomCount       = 10
+		loadLatency     = 30 * time.Millisecond
+		serializedBound = 3 * loadLatency // generous: well below roomCount*loadLatency (300ms), well above one load (30ms)
+	)
+	adapter := fixedLatencyAdapter{latency: loadLatency}
+	s := NewServerWithPersistence(adapter)
+
+	elapsed := loadNDistinctRooms(t, s, roomCount, "room")
+
+	t.Logf("%d distinct rooms x %s LoadDoc: %s wall-clock (serialized would be ~%s)",
+		roomCount, loadLatency, elapsed, roomCount*loadLatency)
+
+	if elapsed >= serializedBound {
+		t.Fatalf("loading %d distinct rooms took %s, want < %s (roughly one load's latency, not %d x latency = %s) — room load may be serializing under the global lock again (#182)",
+			roomCount, elapsed, serializedBound, roomCount, roomCount*loadLatency)
+	}
+}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -448,13 +448,31 @@ func (p *peer) handleDisconnect() {
 		// persistStop close and the persistDone wait so they stay consistent —
 		// when we abort (flush failed) the worker stays alive and we must NOT wait
 		// on persistDone (it would block forever).
+		//
+		// IDLE RESIDENCY (#183). When Server.RoomIdleTimeout > 0, a still-empty
+		// room whose flush succeeded is NOT evicted: instead we stamp
+		// rm.idleSince and leave it resident (persistStop stays open, worker
+		// stays alive) so a rejoin reuses the warm in-memory doc with no
+		// reload. This only changes what happens on the safe (flushOK) path;
+		// a flush failure still leaves the room alive exactly as before
+		// (evict stays false), matching pre-#183 behaviour, and does NOT stamp
+		// idleSince — an unflushed room isn't safely idle. RoomIdleTimeout==0
+		// takes the exact pre-#183 branch (evict = stillEmpty && flushOK), so
+		// behaviour for existing callers is byte-identical.
 		stillEmpty := false
 		evict := false
 		if empty {
+			idleTimeout := p.server.RoomIdleTimeout
 			p.server.rmu.Lock()
 			rm.mu.Lock()
 			stillEmpty = len(rm.peers) == 0
-			evict = stillEmpty && flushOK
+			if stillEmpty && flushOK {
+				if idleTimeout > 0 {
+					rm.idleSince = time.Now()
+				} else {
+					evict = true
+				}
+			}
 			if evict {
 				if current, stillIn := p.server.rooms[p.roomName]; stillIn && current == rm {
 					delete(p.server.rooms, p.roomName)

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -873,6 +873,23 @@ func NewServer() *Server {
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.shutdownOnce.Do(func() { close(s.shutdownCh) })
 
+	// Join the idle-room sweeper (#183, G4) before doing anything else. Closing
+	// shutdownCh above only asks idleSweepLoop to exit on its next select; a
+	// sweep pass already in flight (including an evictIdleRoom flush) keeps
+	// running and can still fire OnUnloadDocument after Shutdown would
+	// otherwise have returned, which a caller reasonably assumes means "no more
+	// hooks will fire". Waiting here also keeps the sweeper from concurrently
+	// mutating s.rooms while Shutdown enumerates it below. Only wait if the
+	// sweeper was ever started (RoomIdleTimeout > 0 at some point); bounded by
+	// ctx, like the persistDone wait further down, so a stuck sweep can't hang
+	// Shutdown forever.
+	if s.sweeperStarted.Load() {
+		select {
+		case <-s.sweeperDone:
+		case <-ctx.Done():
+		}
+	}
+
 	// Stop THIS server's relay delivery by cancelling the relay context: this
 	// winds down the relay worker and the relay's per-node delivery goroutine
 	// (started under relayCtx). It does NOT Close the relay — the caller owns

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -316,9 +316,12 @@ type room struct {
 	// handleDisconnect's teardown path when the room goes empty and the
 	// durable flush succeeds; cleared at peer REGISTRATION (ServeHTTP) — not at
 	// room lookup — so it tracks true occupancy, and by the immediate-mutation
-	// relay/admin callers via clearIdle. Guarded by mu. The background sweeper
-	// that evicts rooms whose idleSince has aged past RoomIdleTimeout is a
-	// separate piece of work (#183 follow-up); this field only records the stamp.
+	// relay/admin callers via clearIdle. Guarded by mu. Rooms stamped idle here
+	// are reclaimed by the background sweeper (idle_sweep.go, started lazily via
+	// ensureIdleSweeper when RoomIdleTimeout > 0): it evicts any room idle longer
+	// than RoomIdleTimeout and, when MaxResidentRooms > 0, the least-recently-idle
+	// rooms in excess of that bound (LRU). This field only records the stamp; the
+	// sweeper acts on it.
 	idleSince time.Time
 }
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -994,19 +994,16 @@ func (s *Server) createRoomPlaceholder(name string) (*room, bool, error) {
 // (re-acquiring s.rmu for the O(1) delete) and stops the awareness sweep, then
 // closes r.ready to wake every waiter with the error. r.ready is always closed
 // exactly once, on both paths.
+//
+// A panic raised by the adapter's LoadDoc or by the state decode (a buggy or
+// malicious adapter, or malformed persisted bytes) is recovered by
+// loadRoomDoc and funneled into loadErr rather than propagating: without this,
+// the placeholder is already published in s.rooms but r.ready is never
+// closed, so every future getOrCreateRoom/BroadcastUpdate/CloseRoom for this
+// room parks on <-r.ready forever — a permanent goroutine/connection/MaxRooms
+// leak that administrative CloseRoom cannot even clear (#182 follow-up).
 func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
-	var loadErr error
-	if s.persistence != nil {
-		data, err := s.persistence.LoadDoc(name)
-		switch {
-		case err != nil:
-			loadErr = fmt.Errorf("loading room %q: %w", name, err)
-		case len(data) > 0:
-			if err := crdt.ApplyUpdateV1(r.doc, data, nil); err != nil {
-				loadErr = fmt.Errorf("bootstrapping room %q: %w", name, err)
-			}
-		}
-	}
+	loadErr := s.loadRoomDoc(r, name)
 	// #60 — fire OnLoadDocument AFTER persistence bootstrap but BEFORE the
 	// persistence worker starts, so a hook returning an error fails room creation
 	// cleanly. Runs off-lock now (#182), so a slow hook no longer stalls other
@@ -1025,16 +1022,7 @@ func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
 	}
 
 	if loadErr != nil {
-		// Remove the placeholder under s.rmu (O(1) delete) and stop the awareness
-		// sweep so a failed load leaves no room in s.rooms and no goroutine leak.
-		s.rmu.Lock()
-		if cur, ok := s.rooms[name]; ok && cur == r {
-			delete(s.rooms, name)
-		}
-		s.rmu.Unlock()
-		r.awareness.Destroy()
-		r.loadErr = loadErr
-		close(r.ready)
+		s.failRoomLoad(r, name, loadErr)
 		return
 	}
 
@@ -1064,6 +1052,53 @@ func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
 	if s.relay != nil {
 		s.registerRelayObservers(r, name)
 	}
+	close(r.ready)
+}
+
+// loadRoomDoc performs the persistence LoadDoc call and, if data was returned,
+// the full-state V1 decode into r.doc. A panic raised by either — a
+// buggy/malicious PersistenceAdapter, or a decode panic on malformed/corrupt
+// persisted bytes — is recovered and converted into the returned error rather
+// than propagating up through loadRoom. This must NOT re-panic: the caller
+// (the goroutine that published the placeholder into s.rooms) has to reach
+// failRoomLoad/close(r.ready) so waiters wake with an error instead of
+// parking on r.ready forever (#182 follow-up).
+func (s *Server) loadRoomDoc(r *room, name string) (loadErr error) {
+	if s.persistence == nil {
+		return nil
+	}
+	defer func() {
+		if rv := recover(); rv != nil {
+			loadErr = fmt.Errorf("LoadDoc panic for room %q: %v", name, rv)
+		}
+	}()
+	data, err := s.persistence.LoadDoc(name)
+	switch {
+	case err != nil:
+		return fmt.Errorf("loading room %q: %w", name, err)
+	case len(data) > 0:
+		if err := crdt.ApplyUpdateV1(r.doc, data, nil); err != nil {
+			return fmt.Errorf("bootstrapping room %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// failRoomLoad is the single failure path shared by every loadRoom failure
+// mode (LoadDoc error, decode error, OnLoadDocument hook error, or a
+// recovered LoadDoc/decode panic via loadRoomDoc): remove the placeholder
+// from s.rooms under s.rmu (O(1) delete, guarded by pointer identity in case
+// it was already replaced), stop the awareness auto-expiry sweep, record
+// loadErr, then close r.ready so every waiter — including the caller that
+// created the placeholder — wakes with the error instead of blocking.
+func (s *Server) failRoomLoad(r *room, name string, loadErr error) {
+	s.rmu.Lock()
+	if cur, ok := s.rooms[name]; ok && cur == r {
+		delete(s.rooms, name)
+	}
+	s.rmu.Unlock()
+	r.awareness.Destroy()
+	r.loadErr = loadErr
 	close(r.ready)
 }
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -588,6 +588,25 @@ type Server struct {
 	// mutated while the server is handling connections.
 	RoomIdleTimeout time.Duration
 
+	// MaxResidentRooms, when > 0, bounds how many IDLE-resident rooms the
+	// server keeps warm at once (#183, G4). When RoomIdleTimeout > 0 an empty
+	// room is not evicted immediately but stamped idle and left resident so a
+	// rejoin reuses the warm doc; without a bound, a workload that touches many
+	// distinct rooms would accumulate them until each individually ages past
+	// RoomIdleTimeout. This cap makes the idle set an LRU: whenever the count of
+	// idle-resident rooms exceeds MaxResidentRooms, the background sweeper evicts
+	// the least-recently-idle rooms first (smallest idleSince) — durably flushing
+	// each before eviction — until the count is back within the bound, even for
+	// rooms that have not yet reached RoomIdleTimeout. Active rooms (with peers)
+	// are never counted or evicted.
+	//
+	// Only meaningful together with RoomIdleTimeout > 0 (only then are rooms
+	// stamped idle and a sweeper started); it is ignored in eager-evict mode.
+	// Zero (the default) means unlimited idle residency. Like the other config
+	// fields, set it before serving; it is read without synchronisation and must
+	// not be mutated while the server is handling connections.
+	MaxResidentRooms int
+
 	// PersistCoalesceWindow controls debounced coalescing of persistence
 	// writes. Buffered updates are merged into a single StoreUpdate rather than
 	// written one-per-update. The window is a debounce: each new update resets
@@ -691,6 +710,19 @@ type Server struct {
 	// first ServeHTTP. nil when MaxConnections == 0 (unlimited).
 	connSem     *semaphore.Weighted
 	connSemOnce sync.Once
+
+	// Idle-room sweeper (#183, G4). A single background goroutine per Server,
+	// started lazily by ensureIdleSweeper the first time a room is created while
+	// RoomIdleTimeout > 0, that periodically evicts rooms idle longer than
+	// RoomIdleTimeout and enforces the MaxResidentRooms LRU bound. sweeperDone is
+	// closed when the loop exits (on Shutdown), letting tests observe a clean
+	// stop. sweeperStarted records whether the loop was ever launched.
+	// idleSweepInterval overrides the poll cadence in tests; production derives
+	// it from RoomIdleTimeout.
+	sweeperOnce       sync.Once
+	sweeperStarted    atomic.Bool
+	sweeperDone       chan struct{}
+	idleSweepInterval time.Duration
 }
 
 // connSemaphore lazily initialises and returns the server-wide connection
@@ -827,8 +859,9 @@ func (s *Server) newPeerLimiter() *rate.Limiter {
 // NewServer returns a new Server with an empty room store and no persistence.
 func NewServer() *Server {
 	s := &Server{
-		rooms:      make(map[string]*room),
-		shutdownCh: make(chan struct{}),
+		rooms:       make(map[string]*room),
+		shutdownCh:  make(chan struct{}),
+		sweeperDone: make(chan struct{}),
 	}
 	s.upgrader = gws.Upgrader{CheckOrigin: s.checkOrigin}
 	return s
@@ -976,6 +1009,13 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 	if r.loadErr != nil {
 		return nil, r.loadErr
 	}
+
+	// #183 (G4): start the idle-room sweeper lazily on first room creation when
+	// RoomIdleTimeout > 0. getOrCreateRoom is the single funnel for every room
+	// creation (peer upgrade, Apply, BroadcastUpdate, relay Inject), so this
+	// covers all of them; the sync.Once makes it a cheap no-op afterwards and a
+	// no-op entirely in eager-evict mode (RoomIdleTimeout == 0).
+	s.ensureIdleSweeper()
 
 	// NOTE (#183): idleSince is deliberately NOT cleared here. Looking a room up
 	// is not the same causal event as a peer becoming present: for the WS join

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -308,6 +308,17 @@ type room struct {
 	// once when the room is evicted so the relay observers don't leak. Guarded
 	// by the room's mu via registerRelayObservers / unregisterRelayObservers.
 	relayUnsub []func()
+
+	// idleSince records when this room last went empty while
+	// Server.RoomIdleTimeout > 0 (#183). Zero value means "not idle" — either
+	// the room has peers, or RoomIdleTimeout is 0 (eager-evict mode, in which
+	// case an empty room is deleted from s.rooms rather than stamped). Set by
+	// handleDisconnect's teardown path when the room goes empty and the
+	// durable flush succeeds; cleared by getOrCreateRoom when a rejoin finds
+	// this resident room. Guarded by mu. The background sweeper that evicts
+	// rooms whose idleSince has aged past RoomIdleTimeout is a separate piece
+	// of work (#183 follow-up); this field only records the stamp.
+	idleSince time.Time
 }
 
 // ConnectionConfig describes an accepted WebSocket connection. It is returned by
@@ -544,6 +555,25 @@ type Server struct {
 	// synchronisation and must not be mutated while the server is handling
 	// connections.
 	SlowPeerPolicy SlowPeerPolicy
+
+	// RoomIdleTimeout, when > 0, switches room eviction from eager to lazy
+	// (#183): when the last peer leaves a room, the v1.37.0 durable
+	// flush-before-evict still runs (so pending writes are never lost), but
+	// the room is NOT deleted from the server map — it is stamped idle
+	// (its idleSince timestamp is set) and stays resident, worker and
+	// in-memory doc alive. A rejoin before eviction reuses the warm doc with
+	// no LoadDoc / reload. Actually evicting rooms whose idle time exceeds
+	// this timeout is done by a separate background sweeper; setting this
+	// field alone only stops eager eviction and marks rooms idle — without a
+	// sweeper an idle room simply stays resident indefinitely, which is safe
+	// (just extra memory) but never reclaims it on its own.
+	//
+	// Zero (the default) preserves the original eager-evict behaviour: the
+	// room is deleted from the server map and OnUnloadDocument fires the
+	// instant the last peer disconnects. Like the other config fields, set
+	// this before serving; it is read without synchronisation and must not be
+	// mutated while the server is handling connections.
+	RoomIdleTimeout time.Duration
 
 	// PersistCoalesceWindow controls debounced coalescing of persistence
 	// writes. Buffered updates are merged into a single StoreUpdate rather than
@@ -933,6 +963,17 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 	if r.loadErr != nil {
 		return nil, r.loadErr
 	}
+
+	// Rejoin-cancels-idle (#183): any caller that reaches a resident room —
+	// fresh or previously idle-stamped — clears idleSince under the room's
+	// own lock. A no-op (already zero) for a room that was never idle or was
+	// just created; race-free against the teardown stamp in handleDisconnect
+	// because both paths serialise through s.rmu (the stamp is written inside
+	// an s.rmu.Lock()+rm.mu section, and createRoomPlaceholder above already
+	// took/released s.rmu.Lock() to find this room before we get here).
+	r.mu.Lock()
+	r.idleSince = time.Time{}
+	r.mu.Unlock()
 	return r, nil
 }
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -268,6 +268,22 @@ type room struct {
 	awareness *awareness.Awareness
 	peers     map[*peer]struct{}
 
+	// ready is closed exactly once, by the goroutine that created the room, when
+	// the off-lock load (LoadDoc + decode + OnLoadDocument) has finished — whether
+	// it succeeded or failed. It is the barrier that lets room load run OFF the
+	// global rooms lock (s.rmu): the placeholder room is published into s.rooms
+	// under s.rmu (an O(1) map write), s.rmu is released, and the actual load runs
+	// unlocked. Every consumer that touches r.doc must first receive on ready.
+	// #182 (G3).
+	ready chan struct{}
+
+	// loadErr holds the load failure, if any. Written exactly once by the creating
+	// goroutine BEFORE close(ready), and read only AFTER a receive on ready — the
+	// channel close is the happens-before that publishes it, so no mutex is
+	// needed. When non-nil the placeholder has already been removed from s.rooms
+	// and r.doc must NOT be used.
+	loadErr error
+
 	// peerSem enforces MaxPeersPerRoom as a hard cap. Initialised at room
 	// creation time. nil when MaxPeersPerRoom == 0 (unlimited).
 	peerSem *semaphore.Weighted
@@ -431,11 +447,14 @@ type Server struct {
 	// in a custom resolver, decrypt-at-rest, schema-migration check, or
 	// any other one-time per-room setup. (#60)
 	//
-	// The hook runs while the server room-map lock is held, so
-	// implementations must return promptly; defer heavy I/O to a
-	// goroutine if needed. The doc passed in is owned by the server —
-	// retaining a reference past the hook return is safe as long as the
-	// caller serialises access through Transact / public APIs.
+	// As of #182 the hook runs OFF the global room-map lock (s.rmu): the
+	// room is published as a not-yet-ready placeholder under s.rmu, then
+	// LoadDoc + decode + this hook run with s.rmu released. A slow hook
+	// therefore no longer stalls create / lookup / evict for other rooms —
+	// it only delays callers waiting on THIS room's ready barrier. The doc
+	// passed in is owned by the server — retaining a reference past the hook
+	// return is safe as long as the caller serialises access through Transact
+	// / public APIs.
 	OnLoadDocument func(ctx context.Context, room string, doc *crdt.Doc) error
 
 	// OnUnloadDocument, if non-nil, is called once per room immediately
@@ -799,8 +818,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 			conns = append(conns, p.conn)
 		}
 		r.mu.Unlock()
-		if r.persistDone != nil {
-			persistDones = append(persistDones, r.persistDone)
+		// Only read the persistence fields once the room's load has completed:
+		// loadRoom sets r.persistDone off-lock, then closes r.ready, so observing
+		// a closed ready is the happens-before that publishes the write (#182). A
+		// still-loading room has no peers and no worker yet — nothing to drain.
+		select {
+		case <-r.ready:
+			if r.persistDone != nil {
+				persistDones = append(persistDones, r.persistDone)
+			}
+		default:
 		}
 	}
 	s.rmu.RUnlock()
@@ -841,40 +868,82 @@ func NewServerWithPersistence(p PersistenceAdapter) *Server {
 
 // GetDoc returns the document for the given room, or nil if no peer has
 // connected to that room yet.
+//
+// A room that is still loading (its off-lock LoadDoc + decode + OnLoadDocument
+// has not finished; #182) is reported as not-yet-present — GetDoc returns nil
+// rather than block or expose a doc that is being mutated by the loader. This
+// matches the documented "no room yet" contract: the result is an
+// immediately-stale snapshot. Once the load completes, GetDoc returns the doc;
+// if the load failed, the room was removed and GetDoc returns nil.
 func (s *Server) GetDoc(name string) *crdt.Doc {
 	s.rmu.RLock()
-	defer s.rmu.RUnlock()
-	if r, ok := s.rooms[name]; ok {
-		return r.doc
+	r, ok := s.rooms[name]
+	s.rmu.RUnlock()
+	if !ok {
+		return nil
 	}
-	return nil
+	select {
+	case <-r.ready:
+		if r.loadErr != nil {
+			return nil
+		}
+		return r.doc
+	default:
+		return nil // still loading; do not expose a doc under construction
+	}
 }
 
-// getOrCreateRoom returns the room for name, creating it on first use. When a
-// new room is created and a relay is attached, the relay's RoomActivated
-// callback fires AFTER s.rmu is released (#133): RoomActivated may synchronously
-// replay stream history via Sink.Inject, which re-enters getOrCreateRoom — under
-// s.rmu the non-reentrant mutex would self-deadlock and wedge the whole instance.
-// This mirrors teardownRelayRoom, which already fires RoomDeactivated off-lock.
+// getOrCreateRoom returns the room for name, creating it on first use.
+//
+// Room load — LoadDoc (I/O), full-state decode, and the OnLoadDocument hook —
+// runs OFF the global rooms lock (#182, G3). s.rmu is held only for the O(1)
+// map operations of createRoomPlaceholder; the load itself happens in loadRoom
+// with s.rmu released, so one slow or large load never stalls create / lookup /
+// evict for every other room process-wide.
+//
+// The creating goroutine (created==true) performs the load and closes r.ready;
+// every other caller — including a caller for the same still-loading room —
+// waits on r.ready rather than on s.rmu. On load failure the placeholder has
+// already been removed from s.rooms and r.loadErr is returned to all waiters.
+//
+// When a new room is loaded and a relay is attached, the relay's RoomActivated
+// callback fires AFTER r.ready is closed (#133): RoomActivated may synchronously
+// replay stream history via Sink.Inject, which re-enters getOrCreateRoom. By
+// that point the placeholder is published AND ready is closed, so the re-entrant
+// call finds the room and returns off an already-closed barrier instead of
+// self-deadlocking on the non-reentrant s.rmu.
 func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error) {
-	r, created, err := s.getOrCreateRoomLocked(ctx, name)
+	r, created, err := s.createRoomPlaceholder(name)
 	if err != nil {
 		return nil, err
 	}
-	if created && s.relay != nil {
-		// Off-lock: the room is already published into s.rooms, so a re-entrant
-		// Sink.Inject finds it and returns instead of blocking on s.rmu.
-		s.relay.RoomActivated(name)
+	if created {
+		// This goroutine owns the load. It runs with s.rmu released; other
+		// callers (same or different room) never block on it via s.rmu.
+		s.loadRoom(ctx, r, name)
+		if r.loadErr == nil && s.relay != nil {
+			// Off-lock and post-ready: a re-entrant Sink.Inject from RoomActivated
+			// finds the published room and waits on the already-closed ready.
+			s.relay.RoomActivated(name)
+		}
+	} else {
+		// Someone else is (or was) loading this room; wait for the barrier.
+		<-r.ready
+	}
+	if r.loadErr != nil {
+		return nil, r.loadErr
 	}
 	return r, nil
 }
 
-// getOrCreateRoomLocked is the locked portion of getOrCreateRoom. It returns the
-// room, whether it was newly created (so the caller fires RoomActivated exactly
-// once off-lock), and any creation error. Relay observers are registered here,
-// before the room is published into s.rooms, so no local change is missed — only
-// the RoomActivated notification is deferred until after s.rmu is released.
-func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room, bool, error) {
+// createRoomPlaceholder returns the room for name. If it already exists the
+// existing room is returned with created=false; otherwise a PLACEHOLDER room —
+// doc/awareness/peer map allocated but NOT yet bootstrapped from persistence — is
+// published into s.rooms with an open ready barrier and returned with
+// created=true so the caller performs the off-lock load. s.rmu is held only for
+// the duration of these O(1) allocations and the single map write; no I/O and no
+// O(doc) work happens under the lock (#182).
+func (s *Server) createRoomPlaceholder(name string) (*room, bool, error) {
 	s.rmu.Lock()
 	defer s.rmu.Unlock()
 	if r, ok := s.rooms[name]; ok {
@@ -895,48 +964,85 @@ func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room,
 		aw.SetMaxClients(s.MaxAwarenessClientsPerRoom)
 	}
 	if s.AwarenessExpiry > 0 {
-		// Background sweep; stopped via aw.Destroy() when the room is evicted.
+		// Background sweep; stopped via aw.Destroy() when the room is evicted, or
+		// when the off-lock load fails (loadRoom removes the placeholder).
 		aw.StartAutoExpiry(s.AwarenessExpiry)
 	}
 	r := &room{
 		doc:       crdt.New(docOpts...),
 		awareness: aw,
 		peers:     make(map[*peer]struct{}),
+		ready:     make(chan struct{}),
 	}
 	if s.MaxPeersPerRoom > 0 {
 		r.peerSem = semaphore.NewWeighted(int64(s.MaxPeersPerRoom))
 	}
+	s.rooms[name] = r
+	return r, true, nil
+}
+
+// loadRoom performs the off-lock room load for a freshly created placeholder:
+// LoadDoc + full-state decode + the OnLoadDocument hook. s.rmu is NOT held here.
+//
+// On success it wires the persistence worker and relay observers (AFTER the
+// bootstrap decode, so the loaded state is not re-persisted or re-relayed —
+// preserving the pre-#182 registration timing) and closes r.ready. Because no
+// other goroutine may touch r.doc until ready closes (all consumers gate on it),
+// registering observers just before close(ready) still misses no update.
+//
+// On failure it records r.loadErr, removes the placeholder from s.rooms
+// (re-acquiring s.rmu for the O(1) delete) and stops the awareness sweep, then
+// closes r.ready to wake every waiter with the error. r.ready is always closed
+// exactly once, on both paths.
+func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
+	var loadErr error
 	if s.persistence != nil {
 		data, err := s.persistence.LoadDoc(name)
-		if err != nil {
-			return nil, false, fmt.Errorf("loading room %q: %w", name, err)
-		}
-		if len(data) > 0 {
+		switch {
+		case err != nil:
+			loadErr = fmt.Errorf("loading room %q: %w", name, err)
+		case len(data) > 0:
 			if err := crdt.ApplyUpdateV1(r.doc, data, nil); err != nil {
-				return nil, false, fmt.Errorf("bootstrapping room %q: %w", name, err)
+				loadErr = fmt.Errorf("bootstrapping room %q: %w", name, err)
 			}
 		}
 	}
 	// #60 — fire OnLoadDocument AFTER persistence bootstrap but BEFORE the
-	// persistence worker starts and the room is registered, so a hook
-	// returning an error fails room creation cleanly with nothing left to
-	// clean up. Hook runs under s.rmu.Lock; implementations must be fast.
-	// A panic in the hook is recovered (logged at Error with the stack)
-	// and treated as a hook-failure error so room creation is not silently
-	// committed in an inconsistent state.
-	if hook := s.OnLoadDocument; hook != nil {
-		var hookErr error
-		s.safeHook("OnLoadDocument", func() {
-			hookErr = hook(ctx, name, r.doc)
-		})
-		if hookErr != nil {
-			return nil, false, fmt.Errorf("OnLoadDocument for room %q: %w", name, hookErr)
+	// persistence worker starts, so a hook returning an error fails room creation
+	// cleanly. Runs off-lock now (#182), so a slow hook no longer stalls other
+	// rooms. A panic in the hook is recovered (logged at Error with the stack)
+	// and treated as a hook-failure error.
+	if loadErr == nil {
+		if hook := s.OnLoadDocument; hook != nil {
+			var hookErr error
+			s.safeHook("OnLoadDocument", func() {
+				hookErr = hook(ctx, name, r.doc)
+			})
+			if hookErr != nil {
+				loadErr = fmt.Errorf("OnLoadDocument for room %q: %w", name, hookErr)
+			}
 		}
 	}
+
+	if loadErr != nil {
+		// Remove the placeholder under s.rmu (O(1) delete) and stop the awareness
+		// sweep so a failed load leaves no room in s.rooms and no goroutine leak.
+		s.rmu.Lock()
+		if cur, ok := s.rooms[name]; ok && cur == r {
+			delete(s.rooms, name)
+		}
+		s.rmu.Unlock()
+		r.awareness.Destroy()
+		r.loadErr = loadErr
+		close(r.ready)
+		return
+	}
+
 	if s.persistence != nil {
 		// Serialise persistence writes through a buffered channel so that a
 		// slow storage backend does not block the Transact caller (N-H7) and
-		// writes arrive in order.
+		// writes arrive in order. Registered AFTER the bootstrap decode so the
+		// loaded state is not re-persisted.
 		r.persistCh = make(chan []byte, 256)
 		r.persistStop = make(chan struct{})
 		r.persistDone = make(chan struct{})
@@ -949,16 +1055,16 @@ func (s *Server) getOrCreateRoomLocked(ctx context.Context, name string) (*room,
 			}
 		})
 	}
-	// Wire relay observers (doc.OnUpdate + awareness.OnChange) so local changes
-	// are published to other nodes. Registered under s.rmu.Lock before the room
-	// is published into s.rooms, so no change is missed. No-op when no relay is
-	// attached. RoomActivated is NOT fired here — the caller fires it off-lock
-	// once getOrCreateRoomLocked returns created=true (#133).
+	// Wire relay observers (doc.OnUpdate + awareness.OnUpdate) so local changes
+	// are published to other nodes. Registered AFTER the bootstrap decode (so the
+	// loaded state is not re-relayed) but BEFORE close(ready) — since no consumer
+	// may mutate r.doc until ready closes, no local change is missed. No-op when
+	// no relay is attached. RoomActivated is fired by getOrCreateRoom off-lock
+	// after ready closes (#133).
 	if s.relay != nil {
 		s.registerRelayObservers(r, name)
 	}
-	s.rooms[name] = r
-	return r, true, nil
+	close(r.ready)
 }
 
 // ServeHTTP upgrades the request to WebSocket and runs the peer sync loop.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -314,11 +314,24 @@ type room struct {
 	// the room has peers, or RoomIdleTimeout is 0 (eager-evict mode, in which
 	// case an empty room is deleted from s.rooms rather than stamped). Set by
 	// handleDisconnect's teardown path when the room goes empty and the
-	// durable flush succeeds; cleared by getOrCreateRoom when a rejoin finds
-	// this resident room. Guarded by mu. The background sweeper that evicts
-	// rooms whose idleSince has aged past RoomIdleTimeout is a separate piece
-	// of work (#183 follow-up); this field only records the stamp.
+	// durable flush succeeds; cleared at peer REGISTRATION (ServeHTTP) — not at
+	// room lookup — so it tracks true occupancy, and by the immediate-mutation
+	// relay/admin callers via clearIdle. Guarded by mu. The background sweeper
+	// that evicts rooms whose idleSince has aged past RoomIdleTimeout is a
+	// separate piece of work (#183 follow-up); this field only records the stamp.
 	idleSince time.Time
+}
+
+// clearIdle marks the room as non-idle. Used by the immediate-mutation callers
+// (relay Inject, admin Apply) that make the room active without registering a
+// peer, so there is no lookup→registration window to worry about. Takes rm.mu
+// itself; must NOT be called while already holding rm.mu. The WS join path does
+// NOT use this — it clears idleSince inside the same rm.mu section that adds the
+// peer (see ServeHTTP) so the clear is ordered against handleDisconnect's stamp.
+func (r *room) clearIdle() {
+	r.mu.Lock()
+	r.idleSince = time.Time{}
+	r.mu.Unlock()
 }
 
 // ConnectionConfig describes an accepted WebSocket connection. It is returned by
@@ -964,16 +977,23 @@ func (s *Server) getOrCreateRoom(ctx context.Context, name string) (*room, error
 		return nil, r.loadErr
 	}
 
-	// Rejoin-cancels-idle (#183): any caller that reaches a resident room —
-	// fresh or previously idle-stamped — clears idleSince under the room's
-	// own lock. A no-op (already zero) for a room that was never idle or was
-	// just created; race-free against the teardown stamp in handleDisconnect
-	// because both paths serialise through s.rmu (the stamp is written inside
-	// an s.rmu.Lock()+rm.mu section, and createRoomPlaceholder above already
-	// took/released s.rmu.Lock() to find this room before we get here).
-	r.mu.Lock()
-	r.idleSince = time.Time{}
-	r.mu.Unlock()
+	// NOTE (#183): idleSince is deliberately NOT cleared here. Looking a room up
+	// is not the same causal event as a peer becoming present: for the WS join
+	// path (ServeHTTP) there is a wide window — a semaphore acquire plus the full
+	// Upgrade handshake — between this return and the peer actually registering
+	// in rm.peers. Clearing at lookup time desynced idleSince from true room
+	// occupancy two ways:
+	//   1. peer A (sole occupant) leaves inside that window: handleDisconnect saw
+	//      len(peers)==0 (the joining peer B not yet registered), stamped idle,
+	//      and B then registered onto an occupied room whose stale stamp nothing
+	//      cleared — a room with a LIVE peer eligible for idle eviction; and
+	//   2. the request failing after this lookup (semaphore denial / Upgrade
+	//      error) left a genuinely-empty, previously-idle room with its stamp
+	//      wiped and no disconnect to re-stamp it — never reaped.
+	// So the JOIN path clears idleSince in the SAME rm.mu section that mutates
+	// rm.peers (see ServeHTTP), tying "not idle" to "a peer is present." The
+	// immediate-mutation callers (relay Inject, admin Apply) that mutate the doc
+	// with no registration delay clear it themselves right after this returns.
 	return r, nil
 }
 
@@ -1252,6 +1272,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rm.mu.Lock()
 	rm.peers[p] = struct{}{}
 	firstPeer := len(rm.peers) == 1 // #60: 0→1 transition
+	// #183: clear idleSince in the SAME rm.mu section that adds the peer, so
+	// "not idle" is tied to true occupancy. handleDisconnect stamps idleSince
+	// under this same rm.mu (after re-checking len(rm.peers)==0), so a
+	// concurrent last-peer-leave / rejoin can only interleave as one of:
+	//   - stamp then register: this clear wins, occupied room ends non-idle;
+	//   - register then stamp: handleDisconnect sees len(peers)>=1 and does not
+	//     stamp at all.
+	// Either way an occupied room never keeps a stale idle stamp.
+	rm.idleSince = time.Time{}
 	rm.mu.Unlock()
 	s.rmu.RUnlock()
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -911,6 +911,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 			conns = append(conns, p.conn)
 		}
 		r.mu.Unlock()
+		// Stop this room's awareness auto-expiry sweep (if AwarenessExpiry>0
+		// started one). Pre-#183, every empty room was evicted on last-peer-leave,
+		// which already called awareness.Destroy(); with idle-resident rooms
+		// (RoomIdleTimeout>0) a room can now sit in s.rooms with no peers and
+		// never get evicted before Shutdown, leaking its sweep goroutine forever.
+		// Safe to call unconditionally here: awareness is allocated synchronously
+		// in createRoomPlaceholder (even for a still-loading room), and Destroy is
+		// idempotent/concurrency-safe, so this cannot double-stop or race the
+		// eviction/CloseRoom/handleDisconnect paths that may also call it.
+		r.awareness.Destroy()
 		// Only read the persistence fields once the room's load has completed:
 		// loadRoom sets r.persistDone off-lock, then closes r.ready, so observing
 		// a closed ready is the happens-before that publishes the write (#182). A

--- a/provider/websocket/server_internal_test.go
+++ b/provider/websocket/server_internal_test.go
@@ -209,3 +209,53 @@ func TestServer_AwarenessExpiry_GoroutineStoppedOnEvict(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// TestServer_Shutdown_DestroysAwarenessOfResidentRooms verifies that Shutdown
+// stops the auto-expiry goroutine of a room that is still RESIDENT (never
+// evicted) at shutdown time — the #183 gap where an idle-resident room
+// (RoomIdleTimeout>0) sat in s.rooms with no peers, so neither eviction path
+// (which calls awareness.Destroy) ever ran for it. The room here is created
+// via getOrCreateRoom and never joined/left by a peer, so its idleSince stays
+// zero and the idle sweeper's candidate scan never picks it up — any Destroy
+// of its awareness must come from Shutdown itself.
+func TestServer_Shutdown_DestroysAwarenessOfResidentRooms(t *testing.T) {
+	s := NewServer()
+	s.AwarenessExpiry = 50 * time.Millisecond
+	s.RoomIdleTimeout = time.Hour // large enough that the sweeper (if started) never evicts
+
+	before := runtime.NumGoroutine()
+	rm, err := s.getOrCreateRoom(context.Background(), "room")
+	if err != nil {
+		t.Fatalf("getOrCreateRoom: %v", err)
+	}
+	if rm.awareness == nil {
+		t.Fatal("room has no awareness")
+	}
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	// Room must still be resident (Shutdown must not evict) — only its
+	// awareness sweep should have stopped.
+	s.rmu.RLock()
+	_, present := s.rooms["room"]
+	s.rmu.RUnlock()
+	if !present {
+		t.Fatal("Shutdown must not remove a resident room from s.rooms")
+	}
+
+	// Poll until the goroutine count returns to baseline (the expiry goroutine
+	// exits when Destroy stops it). Condition-based wait avoids flakiness.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		runtime.Gosched()
+		if runtime.NumGoroutine() <= before+1 { // +1 tolerance for scheduler noise
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expiry goroutine of a resident room leaked past Shutdown: before=%d after=%d", before, runtime.NumGoroutine())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/provider/websocket/server_load_test.go
+++ b/provider/websocket/server_load_test.go
@@ -1,0 +1,265 @@
+// Package websocket - internal regression tests for issue #182 (G3): room load
+// (LoadDoc / decode / OnLoadDocument) must run OFF the global rooms lock
+// (s.rmu). A slow or large load of one room must not stall create / lookup /
+// evict for every other room. The mechanism is a placeholder room published
+// under s.rmu with a `ready chan struct{}`; the load happens off-lock and every
+// consumer that touches r.doc first waits on ready.
+package websocket
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
+)
+
+// blockingLoadAdapter is a PersistenceAdapter whose LoadDoc blocks on a per-room
+// gate so a test can hold one room's load open while driving other rooms. It
+// also records when each room's LoadDoc is entered and can be told to fail a
+// room's load with a specific error.
+type blockingLoadAdapter struct {
+	mu      sync.Mutex
+	gate    map[string]chan struct{} // room → closed to release LoadDoc
+	entered map[string]chan struct{} // room → closed when LoadDoc is entered
+	loadErr map[string]error         // room → error LoadDoc returns
+}
+
+func newBlockingLoadAdapter() *blockingLoadAdapter {
+	return &blockingLoadAdapter{
+		gate:    map[string]chan struct{}{},
+		entered: map[string]chan struct{}{},
+		loadErr: map[string]error{},
+	}
+}
+
+// block marks room so its LoadDoc parks until release(room) is called.
+func (a *blockingLoadAdapter) block(room string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.gate[room] = make(chan struct{})
+	a.entered[room] = make(chan struct{})
+}
+
+// setErr makes room's LoadDoc return err (after the gate, if any, releases).
+func (a *blockingLoadAdapter) setErr(room string, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.loadErr[room] = err
+}
+
+// release unblocks a previously blocked room's LoadDoc.
+func (a *blockingLoadAdapter) release(room string) {
+	a.mu.Lock()
+	g := a.gate[room]
+	a.mu.Unlock()
+	if g != nil {
+		close(g)
+	}
+}
+
+// enteredCh returns a channel that closes when room's LoadDoc has been entered.
+func (a *blockingLoadAdapter) enteredCh(room string) <-chan struct{} {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.entered[room]
+}
+
+func (a *blockingLoadAdapter) LoadDoc(room string) ([]byte, error) {
+	a.mu.Lock()
+	entered := a.entered[room]
+	gate := a.gate[room]
+	err := a.loadErr[room]
+	a.mu.Unlock()
+	if entered != nil {
+		select {
+		case <-entered:
+		default:
+			close(entered)
+		}
+	}
+	if gate != nil {
+		<-gate
+	}
+	return nil, err
+}
+
+func (a *blockingLoadAdapter) StoreUpdate(string, []byte) error { return nil }
+
+// TestGetOrCreateRoom_ConcurrentDistinctRooms_DoNotSerialize is the headline G3
+// regression: a blocked load of room A must not stall a create of room B. On the
+// pre-fix code the load ran under s.rmu, so B parked on the global lock until A
+// unblocked — this test times out there (RED).
+func TestGetOrCreateRoom_ConcurrentDistinctRooms_DoNotSerialize(t *testing.T) {
+	a := newBlockingLoadAdapter()
+	a.block("A") // A's LoadDoc parks until released; B is not gated.
+	s := NewServerWithPersistence(a)
+
+	aDone := make(chan struct{})
+	go func() {
+		_, _ = s.getOrCreateRoom(context.Background(), "A")
+		close(aDone)
+	}()
+
+	// Wait until A's load is actually in progress so the placeholder is
+	// published and (post-fix) s.rmu released.
+	select {
+	case <-a.enteredCh("A"):
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's LoadDoc was never entered")
+	}
+
+	// B must complete while A is still blocked in LoadDoc.
+	bDone := make(chan struct{})
+	go func() {
+		if _, err := s.getOrCreateRoom(context.Background(), "B"); err != nil {
+			t.Errorf("B getOrCreateRoom: %v", err)
+		}
+		close(bDone)
+	}()
+	select {
+	case <-bDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("B serialized behind A's blocked load — room load is still under the global lock (#182)")
+	}
+
+	// A must still be parked (sanity: we really did block it).
+	select {
+	case <-aDone:
+		t.Fatal("A returned before it was released")
+	default:
+	}
+	a.release("A")
+	<-aDone
+}
+
+// TestGetOrCreateRoom_SecondJoinerWaitsOnReady asserts a second caller for the
+// same still-loading room parks on the room's ready barrier, not on s.rmu — a
+// third caller for a different room proceeds meanwhile. Both same-room callers
+// then observe the identical room instance.
+func TestGetOrCreateRoom_SecondJoinerWaitsOnReady(t *testing.T) {
+	a := newBlockingLoadAdapter()
+	a.block("A")
+	s := NewServerWithPersistence(a)
+
+	r1done := make(chan *room, 1)
+	go func() {
+		r, _ := s.getOrCreateRoom(context.Background(), "A")
+		r1done <- r
+	}()
+	select {
+	case <-a.enteredCh("A"):
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's LoadDoc was never entered")
+	}
+
+	r2done := make(chan *room, 1)
+	go func() {
+		r, _ := s.getOrCreateRoom(context.Background(), "A")
+		r2done <- r
+	}()
+
+	// A different room must still be creatable while the second A joiner waits,
+	// proving the joiner does not hold s.rmu.
+	if _, err := s.getOrCreateRoom(context.Background(), "C"); err != nil {
+		t.Fatalf("C getOrCreateRoom blocked while a joiner waited on ready: %v", err)
+	}
+
+	select {
+	case <-r1done:
+		t.Fatal("first A caller returned before release")
+	case <-r2done:
+		t.Fatal("second A caller returned before release")
+	default:
+	}
+
+	a.release("A")
+	r1 := <-r1done
+	r2 := <-r2done
+	if r1 == nil || r1 != r2 {
+		t.Fatalf("same-room joiners got different/nil rooms: r1=%p r2=%p", r1, r2)
+	}
+}
+
+// TestGetOrCreateRoom_LoadErrorWakesWaitersNoPlaceholder asserts a LoadDoc error
+// propagates (wrapped) to every waiter and leaves NO placeholder behind in
+// s.rooms.
+func TestGetOrCreateRoom_LoadErrorWakesWaitersNoPlaceholder(t *testing.T) {
+	a := newBlockingLoadAdapter()
+	a.block("A")
+	wantErr := errors.New("boom-load-failure")
+	a.setErr("A", wantErr)
+	s := NewServerWithPersistence(a)
+
+	const n = 3
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			_, err := s.getOrCreateRoom(context.Background(), "A")
+			errs <- err
+		}()
+	}
+
+	select {
+	case <-a.enteredCh("A"):
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's LoadDoc was never entered")
+	}
+	a.release("A")
+
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-errs:
+			if err == nil || !errors.Is(err, wantErr) {
+				t.Fatalf("waiter got err=%v, want a wrap of %v", err, wantErr)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("a waiter was not woken on load error")
+		}
+	}
+
+	s.rmu.RLock()
+	_, ok := s.rooms["A"]
+	s.rmu.RUnlock()
+	if ok {
+		t.Fatal("failed-load placeholder was left in s.rooms")
+	}
+	if d := s.GetDoc("A"); d != nil {
+		t.Fatal("GetDoc returned non-nil for a failed-load room")
+	}
+}
+
+// TestGetOrCreateRoom_RelayReentrancyWithPersistence_NoDeadlock exercises the
+// hazardous interaction: a relay whose RoomActivated synchronously re-enters
+// Sink.Inject (which calls getOrCreateRoom) on a server that also has a
+// PersistenceAdapter. RoomActivated must fire only AFTER ready closes, so the
+// re-entrant getOrCreateRoom finds the published placeholder and waits on an
+// already-closed ready — no deadlock, and the injected update lands.
+func TestGetOrCreateRoom_RelayReentrancyWithPersistence_NoDeadlock(t *testing.T) {
+	src := crdt.New()
+	txt := src.GetText("t")
+	src.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
+
+	a := newBlockingLoadAdapter() // no room gated → loads return immediately
+	s := NewServerWithPersistence(a)
+	relay := &reentrantActivationRelay{kind: cluster.KindSync, data: crdt.EncodeStateAsUpdateV1(src, nil)}
+	if err := s.AttachRelay(relay); err != nil {
+		t.Fatalf("AttachRelay: %v", err)
+	}
+
+	runWithDeadlockGuard(t, func() { _, _ = s.getOrCreateRoom(context.Background(), "doc1") })
+
+	if relay.injectErr != nil {
+		t.Fatalf("re-entrant Inject returned error: %v", relay.injectErr)
+	}
+	d := s.GetDoc("doc1")
+	if d == nil {
+		t.Fatal("room doc1 was not created")
+	}
+	if got := d.GetText("t").ToString(); got != "hi" {
+		t.Fatalf("injected update not applied: GetText = %q, want %q", got, "hi")
+	}
+}

--- a/provider/websocket/server_load_test.go
+++ b/provider/websocket/server_load_test.go
@@ -9,6 +9,7 @@ package websocket
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -22,18 +23,30 @@ import (
 // also records when each room's LoadDoc is entered and can be told to fail a
 // room's load with a specific error.
 type blockingLoadAdapter struct {
-	mu      sync.Mutex
-	gate    map[string]chan struct{} // room → closed to release LoadDoc
-	entered map[string]chan struct{} // room → closed when LoadDoc is entered
-	loadErr map[string]error         // room → error LoadDoc returns
+	mu       sync.Mutex
+	gate     map[string]chan struct{} // room → closed to release LoadDoc
+	entered  map[string]chan struct{} // room → closed when LoadDoc is entered
+	loadErr  map[string]error         // room → error LoadDoc returns
+	panicked map[string]bool          // room → LoadDoc panics instead of returning
 }
 
 func newBlockingLoadAdapter() *blockingLoadAdapter {
 	return &blockingLoadAdapter{
-		gate:    map[string]chan struct{}{},
-		entered: map[string]chan struct{}{},
-		loadErr: map[string]error{},
+		gate:     map[string]chan struct{}{},
+		entered:  map[string]chan struct{}{},
+		loadErr:  map[string]error{},
+		panicked: map[string]bool{},
 	}
+}
+
+// setPanic makes room's LoadDoc panic (after the gate, if any, releases)
+// instead of returning normally. Used to test the #182-follow-up recover:
+// a panic must funnel into the same failure path as an ordinary LoadDoc
+// error, not leave the placeholder parked forever.
+func (a *blockingLoadAdapter) setPanic(room string, v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.panicked[room] = v
 }
 
 // block marks room so its LoadDoc parks until release(room) is called.
@@ -73,6 +86,7 @@ func (a *blockingLoadAdapter) LoadDoc(room string) ([]byte, error) {
 	entered := a.entered[room]
 	gate := a.gate[room]
 	err := a.loadErr[room]
+	doPanic := a.panicked[room]
 	a.mu.Unlock()
 	if entered != nil {
 		select {
@@ -83,6 +97,9 @@ func (a *blockingLoadAdapter) LoadDoc(room string) ([]byte, error) {
 	}
 	if gate != nil {
 		<-gate
+	}
+	if doPanic {
+		panic("simulated LoadDoc panic for room " + room)
 	}
 	return nil, err
 }
@@ -261,5 +278,106 @@ func TestGetOrCreateRoom_RelayReentrancyWithPersistence_NoDeadlock(t *testing.T)
 	}
 	if got := d.GetText("t").ToString(); got != "hi" {
 		t.Fatalf("injected update not applied: GetText = %q, want %q", got, "hi")
+	}
+}
+
+// TestGetOrCreateRoom_LoadDocPanicWakesWaitersNoPlaceholder is the #182
+// follow-up regression: a panic inside LoadDoc (buggy/malicious adapter, or a
+// decode panic on malformed persisted state) must NOT leave the already-
+// published placeholder parked forever with r.ready never closed. Pre-fix,
+// this test hangs (both callers block on <-r.ready indefinitely) — the test
+// enforces a hard timeout so that hang fails fast (RED) instead of wedging
+// the test run. Post-fix, loadRoomDoc recovers the panic into r.loadErr and
+// failRoomLoad removes the placeholder and closes ready, so both callers wake
+// with an error, the MaxRooms slot is released, and a subsequent load with a
+// healthy adapter succeeds.
+func TestGetOrCreateRoom_LoadDocPanicWakesWaitersNoPlaceholder(t *testing.T) {
+	a := newBlockingLoadAdapter()
+	a.block("A")
+	a.setPanic("A", true)
+	s := NewServerWithPersistence(a)
+	s.MaxRooms = 1 // (d) the room's placeholder must fully release its slot
+
+	// First (creating) caller: runs loadRoom synchronously inside
+	// getOrCreateRoom, so on unfixed code the panic unwinds this exact
+	// goroutine's stack uncaught (nothing in getOrCreateRoom/loadRoom recovers
+	// it). In production that goroutine is normally net/http's per-connection
+	// handler goroutine, which recovers a handler panic itself (logs it,
+	// closes the connection) rather than crashing the whole process — so we
+	// add the same kind of outer recover here purely as a test-harness
+	// safety net, to observe the resulting *state* (parked waiters, leaked
+	// placeholder) instead of taking down the entire test binary. Post-fix,
+	// loadRoomDoc recovers the panic itself and getOrCreateRoom returns a
+	// normal error, so this recover never fires.
+	err1ch := make(chan error, 1)
+	go func() {
+		defer func() {
+			if rv := recover(); rv != nil {
+				err1ch <- fmt.Errorf("panic escaped getOrCreateRoom uncaught (not recovered into loadErr): %v", rv)
+			}
+		}()
+		_, err := s.getOrCreateRoom(context.Background(), "A")
+		err1ch <- err
+	}()
+
+	select {
+	case <-a.enteredCh("A"):
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's LoadDoc was never entered")
+	}
+
+	// Second (joining) caller for the SAME room: must wait on r.ready, not on
+	// s.rmu, and must also wake with an error once the panic is recovered.
+	err2ch := make(chan error, 1)
+	go func() {
+		_, err := s.getOrCreateRoom(context.Background(), "A")
+		err2ch <- err
+	}()
+
+	// Give the second caller a moment to actually park on <-r.ready before
+	// releasing the panic, so this exercises the concurrent-waiter path.
+	time.Sleep(50 * time.Millisecond)
+	a.release("A") // LoadDoc now panics.
+
+	// (a) creating caller wakes with an error, not a hang.
+	select {
+	case err := <-err1ch:
+		if err == nil {
+			t.Fatal("creating caller returned nil error after a LoadDoc panic")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("creating caller parked forever after a LoadDoc panic — panic was not recovered into the failure path")
+	}
+
+	// (b) second concurrent same-room caller also wakes with an error.
+	select {
+	case err := <-err2ch:
+		if err == nil {
+			t.Fatal("second concurrent caller returned nil error after a LoadDoc panic")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second concurrent caller parked forever after a LoadDoc panic")
+	}
+
+	// (c) no placeholder remains in s.rooms.
+	s.rmu.RLock()
+	_, ok := s.rooms["A"]
+	s.rmu.RUnlock()
+	if ok {
+		t.Fatal("panicked-load placeholder was left in s.rooms")
+	}
+	if d := s.GetDoc("A"); d != nil {
+		t.Fatal("GetDoc returned non-nil for a panicked-load room")
+	}
+
+	// (c/d) a subsequent getOrCreateRoom with a now-healthy adapter succeeds,
+	// proving the MaxRooms slot was released and the room is retryable.
+	a.setPanic("A", false)
+	r, err := s.getOrCreateRoom(context.Background(), "A")
+	if err != nil {
+		t.Fatalf("retry after panicked load failed: %v", err)
+	}
+	if r == nil {
+		t.Fatal("retry after panicked load returned a nil room")
 	}
 }


### PR DESCRIPTION
## Summary

The P0 "biggest wins" from the adversarial performance & scalability review (epic #189), in one PR — closes **#181**, **#182**, **#183**. Target **v1.39.0** (minor; two additive `Server` fields, no breaking change).

## #181 — O(1) positional access (search marker)

Replaced the forward-only position cache with a faithful **Yjs-style bidirectional, move-aware `ArraySearchMarker`** (`crdt/search_marker.go`): ~80 markers, nearest-selection, walk left *or* right, relocate-on-merge, index-shift-on-edit; invalidation wired into the structural mutation sites (not the unreliable `txn.Local` signal — this avoids the v1.31.6 stale-cache class). Split into a read-only `findMarkerRO` (read path, under `RLock`) and a mutating `findMarkerMut` (write path, under the doc write lock), so concurrent readers never race the marker set. Routed `Get`/`Slice`/`deleteRange`/`Format`/`currentAttributesAt` and a single-cursor `ApplyDelta` through it; `deleteRange` is move-aware so `Get`/`Slice`/`Delete` stay coherent on arrays with active `ContentMove`.

**Measured (100k-node doc, ns/op):** random insert **~101×** (632µs→6.3µs), reverse insert **~916×** (1.15ms→1.26µs), random `Get` **~114×** (481µs→4.2µs), deleteRange 5–7×. yrs has *no* marker, so this is the axis where ygo now beats it on random access. Internal change — **no public API**.

## #182 — room load off the global lock

Room load (`LoadDoc`/decode/`OnLoadDocument`) no longer runs under the single global `s.rmu`. `getOrCreateRoomLocked` publishes a placeholder room with a per-room `ready` barrier and releases `s.rmu` before any I/O; every consumer (`getOrCreateRoom`, `GetDoc`, broadcast, peer initial-sync, relay `Inject`) gates on `ready`. Concurrent connects to distinct rooms now load in **parallel** instead of serializing behind one slow `LoadDoc` (benchmark: 20 rooms × 20ms = ~21ms, not ~400ms). A `LoadDoc`/decode **panic** is recovered and funnelled into the shared failure path (previously a panic could park all waiters forever / crash the process).

## #183 — idle-room residency

New `Server.RoomIdleTimeout time.Duration` (keep a room warm this long after the last peer leaves so a quick reconnect reuses the in-memory doc instead of re-decoding; **0 = evict immediately, the prior behaviour**) and `Server.MaxResidentRooms int` (LRU bound on idle-resident rooms; 0 = unbounded). A single lazy sweeper evicts expired idle rooms via the v1.37.0 flush-before-evict teardown, rechecking `len(peers)==0` under `rm.mu` before every eviction (never on `idleSince` alone). Reconnect within the window: **43ns** warm vs ~20ms cold reload.

## Behaviour fix

`YText.ApplyDelta` no longer bleeds a preceding `{retain, attributes}`'s formatting into a following `insert` (now **Yjs/Quill-aligned** — an insert carries only its own attributes), and consecutive attribute-less inserts no longer integrate out of order. Downstreams relying on the old format-bleed should note this.

## Correctness / testing

Markers are a pure lookup accelerator — they never affect integration order, convergence, GC, or wire output. Every engine change is gated on the **convergence fuzzer**, the full `crdt` suite, JS conformance (non-move), `-race`, and marker-vs-cold byte-equality tests (via a force-cold seam). The v1.31.6 stale-cache scenario, move+delete coherence, GC marker migration, and concurrent-reader safety each have dedicated tests. Full `go test -race ./...` green across all 16 packages; `golangci-lint` 0 issues.

Built task-by-task with a review gate after each (high-risk tasks — marker mutation/invalidation/move-awareness, the room-load barrier, the idle sweeper — reviewed on the strongest model) plus a final whole-branch review.

## Known follow-ups (not blocking; tracked separately)

- The convergence fuzzer has **no move op**, so move+delete parity rests on ygo-internal coherence + 2-peer convergence tests, **not** a live-Yjs cross-check. (Follow-up: add move ops to the fuzzer + JS oracle.)
- An orphan room (created, request fails before any peer registers) sits at `idleSince=0` and isn't reaped by the sweeper (pre-existing lifecycle gap).
- `MaxResidentRooms` bounds only idle-resident rooms (documented on the field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
