### PR TITLE
test(bench): honest performance + scalability benchmark suite (#180)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,10 +64,14 @@ jobs:
         run: benchstat /tmp/old.txt /tmp/new.txt
       - name: Heavy-tier benchmarks (nightly + manual)
         if: github.event_name != 'pull_request'
-        run: go test -tags benchheavy -bench=. -benchmem -count=6 ./... | tee /tmp/heavy.txt
+        run: |
+          set -o pipefail
+          go test -tags benchheavy -bench=. -benchmem -count=6 ./... | tee /tmp/heavy.txt
       - name: Scaling probe (nightly + manual)
         if: github.event_name != 'pull_request'
-        run: go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/ | tee /tmp/scaleprobe.txt
+        run: |
+          set -o pipefail
+          go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/ | tee /tmp/scaleprobe.txt
       - name: Upload nightly/dispatch output
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,13 +9,16 @@ name: Benchmark
 #
 #   2. Nightly on a cron schedule. Runs the suite on whatever main currently is
 #      and uploads the raw output as a 30-day artifact. Lets us spot slow drift
-#      that no single PR introduces. The nightly run additionally exercises the
-#      benchheavy-tagged heavy tier (100k-scale + conflict benches, see #180)
-#      and the websocket scaling probe (TestScaleProbe) — both too slow for
-#      the PR gate — and uploads their output alongside the light-tier run.
+#      that no single PR introduces. Nightly AND manual runs additionally
+#      exercise the benchheavy-tagged heavy tier (100k-scale + conflict
+#      benches, see #180) and the websocket scaling probe (TestScaleProbe) —
+#      both too slow for the PR gate — and upload their output alongside the
+#      light-tier run.
 #
 #   3. Manually via workflow_dispatch. Use this when a non-hot-path PR genuinely
-#      needs measurement, or to spot-check main on demand.
+#      needs measurement, or to spot-check main on demand — this also runs the
+#      heavy tier and scaling probe (see #2), so a manual dispatch gets the
+#      full picture, not just the light tier.
 #
 # Rationale: previously this ran on every PR (~20 min per run). Most PRs don't
 # touch the hot paths, so the comparison was noise. See PR #80.
@@ -59,11 +62,11 @@ jobs:
       - name: Compare PR vs base
         if: github.event_name == 'pull_request'
         run: benchstat /tmp/old.txt /tmp/new.txt
-      - name: Heavy-tier benchmarks (nightly)
-        if: github.event_name == 'schedule'
+      - name: Heavy-tier benchmarks (nightly + manual)
+        if: github.event_name != 'pull_request'
         run: go test -tags benchheavy -bench=. -benchmem -count=6 ./... | tee /tmp/heavy.txt
-      - name: Scaling probe (nightly)
-        if: github.event_name == 'schedule'
+      - name: Scaling probe (nightly + manual)
+        if: github.event_name != 'pull_request'
         run: go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/ | tee /tmp/scaleprobe.txt
       - name: Upload nightly/dispatch output
         if: github.event_name != 'pull_request'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,10 @@ name: Benchmark
 #
 #   2. Nightly on a cron schedule. Runs the suite on whatever main currently is
 #      and uploads the raw output as a 30-day artifact. Lets us spot slow drift
-#      that no single PR introduces.
+#      that no single PR introduces. The nightly run additionally exercises the
+#      benchheavy-tagged heavy tier (100k-scale + conflict benches, see #180)
+#      and the websocket scaling probe (TestScaleProbe) — both too slow for
+#      the PR gate — and uploads their output alongside the light-tier run.
 #
 #   3. Manually via workflow_dispatch. Use this when a non-hot-path PR genuinely
 #      needs measurement, or to spot-check main on demand.
@@ -56,10 +59,19 @@ jobs:
       - name: Compare PR vs base
         if: github.event_name == 'pull_request'
         run: benchstat /tmp/old.txt /tmp/new.txt
+      - name: Heavy-tier benchmarks (nightly)
+        if: github.event_name == 'schedule'
+        run: go test -tags benchheavy -bench=. -benchmem -count=6 ./... | tee /tmp/heavy.txt
+      - name: Scaling probe (nightly)
+        if: github.event_name == 'schedule'
+        run: go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/ | tee /tmp/scaleprobe.txt
       - name: Upload nightly/dispatch output
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-${{ github.run_id }}
-          path: /tmp/new.txt
+          path: |
+            /tmp/new.txt
+            /tmp/heavy.txt
+            /tmp/scaleprobe.txt
           retention-days: 30

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -32,9 +32,9 @@ go version go1.26.5 darwin/arm64
 - CI (`.github/workflows/benchmark.yml`) uses `-count=5` (PR gate) / `-count=6`
   (nightly heavy tier) so `benchstat` has enough samples to report a
   meaningful confidence interval. This document's numbers use `-count=3`
-  (light tier) and `-count=1` (`-benchtime=10x`, heavy tier) — enough to sanity
-  -check the shape of the numbers, not a substitute for `benchstat old.txt
-  new.txt` when evaluating a real performance change.
+  (light tier) and `-count=1` (`-benchtime=10x`, heavy tier) — enough to
+  sanity-check the shape of the numbers, not a substitute for `benchstat
+  old.txt new.txt` when evaluating a real performance change.
 - **Determinism:** every randomized scenario in this suite seeds its PRNG
   from a fixed constant (`rand.New(rand.NewSource(<const>))`) — never
   unseeded `math/rand` or a wall-clock seed. Re-running any benchmark here
@@ -76,12 +76,13 @@ that room count, to spot `O(rooms)` growth in server-side resource usage.
 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
 ```
 
-Override the room count with `SCALE_PROBE_N` (default is a smaller
-built-in value suitable for a laptop; set it higher to approximate
-production room counts):
+By default `TestScaleProbe` runs at both 1,000 and 10,000 rooms. Override
+with `SCALE_PROBE_N` to run a single size instead — set it lower (e.g.
+`200`) for a quick laptop smoke run, or higher to approximate production
+room counts:
 
 ```
-SCALE_PROBE_N=1000 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
+SCALE_PROBE_N=200 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
 ```
 
 ## Results
@@ -270,10 +271,10 @@ The engine-scenario benchmarks in this suite (`crdt/bench_test.go`'s
 B1-style Prepend/RandomInsert/InsertThenDelete/WordInsert/MixedEdits, and
 `crdt/bench_heavy_test.go`'s B2/B3 conflict scenarios, plus the pre-existing
 B4 editing-trace suite in `benchmarks/`) are deliberately named and shaped
-to mirror
-[`dmonad/crdt-benchmarks`](https://github.com/dmonad/crdt-benchmarks)'
-operation definitions, so that a future native yjs (JS)/yrs (Rust) run on
-the same hardware is a drop-in comparison rather than a re-design.
+to mirror the operation definitions from
+[`dmonad/crdt-benchmarks`](https://github.com/dmonad/crdt-benchmarks), so
+that a future native yjs (JS)/yrs (Rust) run on the same hardware is a
+drop-in comparison rather than a re-design.
 
 That native re-run has **not** been done as part of this task — it is
 explicitly out of scope here and tracked as a follow-up (see "Draft

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,298 @@
+# Benchmarks
+
+This document explains how to run ygo's benchmark suite, what each tier
+measures, and reports real numbers from a local run. It complements the
+per-file benchmark docs (`crdt/bench_test.go`, `crdt/bench_heavy_test.go`,
+`provider/websocket/scale_bench_test.go`, `provider/websocket/scale_probe_test.go`,
+`persistence/scale_bench_test.go`, `cluster/relay_bench_test.go`,
+`benchmarks/b4_test.go`), which document individual scenarios in detail.
+
+## Methodology
+
+**Reference machine** (all numbers in this document, unless noted otherwise):
+
+```
+$ uname -a
+Darwin Nimits-MacBook-Pro.local 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:28:34 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T6041 arm64
+$ sysctl -n machdep.cpu.brand_string hw.ncpu hw.memsize
+Apple M4 Max
+16
+51539607552   # 48 GiB
+$ go version
+go version go1.26.5 darwin/arm64
+```
+
+- **Apple M4 Max, 16 cores, 48 GiB RAM, macOS (Darwin 25.5.0), go1.26.5 darwin/arm64.**
+- Every table below is labeled with this machine. Numbers from a different
+  machine (CI's `ubuntu-latest` runners, a teammate's laptop, target
+  production hardware) will differ — do not treat these as portable SLAs,
+  treat them as a baseline for `benchstat` regression comparison on *this*
+  machine, and re-run locally before trusting an absolute number for
+  capacity planning.
+- CI (`.github/workflows/benchmark.yml`) uses `-count=5` (PR gate) / `-count=6`
+  (nightly heavy tier) so `benchstat` has enough samples to report a
+  meaningful confidence interval. This document's numbers use `-count=3`
+  (light tier) and `-count=1` (`-benchtime=10x`, heavy tier) — enough to sanity
+  -check the shape of the numbers, not a substitute for `benchstat old.txt
+  new.txt` when evaluating a real performance change.
+- **Determinism:** every randomized scenario in this suite seeds its PRNG
+  from a fixed constant (`rand.New(rand.NewSource(<const>))`) — never
+  unseeded `math/rand` or a wall-clock seed. Re-running any benchmark here
+  exercises the exact same operation sequence every time; only timing
+  varies.
+
+## Run tiers
+
+### Light (PR gate)
+
+Runs on every PR touching `crdt/`, `encoding/`, `benchmarks/`, or the
+workflow file itself (see `.github/workflows/benchmark.yml`). Sizes are
+bounded (≤ ~2000 ops) so this stays fast enough for the PR gate.
+
+```
+go test -bench=. -benchmem ./...
+```
+
+### Heavy (nightly + manual)
+
+Gated behind the `benchheavy` build tag. 100k-scale engine benchmarks,
+concurrent-conflict scenarios (B2/B3), persistence flush-cost scaling,
+relay fan-out/backpressure, and websocket broadcast fan-out. Too slow for
+the PR gate; runs nightly on a cron schedule and on demand
+(`workflow_dispatch`).
+
+```
+go test -tags benchheavy -bench=. -benchmem -count=6 ./...
+```
+
+### Scaling probe (nightly + manual)
+
+Not a benchmark — a measurement harness (`TestScaleProbe`) that creates N
+rooms directly (bypassing real peer connections) and reports heap/sys
+memory, goroutine count, and RSS (Linux only, via `/proc/self/status`) at
+that room count, to spot `O(rooms)` growth in server-side resource usage.
+
+```
+go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
+```
+
+Override the room count with `SCALE_PROBE_N` (default is a smaller
+built-in value suitable for a laptop; set it higher to approximate
+production room counts):
+
+```
+SCALE_PROBE_N=1000 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
+```
+
+## Results
+
+All numbers below are from the reference machine described in
+**Methodology**, `go1.26.5 darwin/arm64`. `ns/op`, `B/op`, `allocs/op` are
+per Go's `testing.B` convention (per-iteration, amortized over `b.N`).
+
+### Light tier
+
+`go test -bench=. -benchmem -count=3 ./crdt/ ./encoding/ ./sync/ ./awareness/`
+completed in full (`crdt` 963s — dominated by the pre-existing
+`BenchmarkSearchMarker_*_100k_*` scenarios re-run 3x, not by anything added
+in this task; `encoding` 70s, `sync` 16s, `awareness` 92s — all `PASS`).
+Representative results below (one of the 3 samples per benchmark; given the
+fixed-seed scenarios the 3 samples cluster tightly except where noted):
+
+**`crdt` — B1-style engine benches (mirrors `dmonad/crdt-benchmarks` shapes) + wire encode/decode:**
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `YText_Insert` | 1,325 | 1,256 | 16 |
+| `YText_InsertBulk` | 2,287 | 1,352 | 16 |
+| `YText_Delete` | 1,544,071† | 1,360,004 | 14,000 |
+| `YText_Prepend` | 214,750 | 467,681 | 8,068 |
+| `YText_RandomInsert` | 763,029 | 508,121 | 10,053 |
+| `YText_InsertThenDelete` | 28,339,417 | 3,230,249 | 38,059 |
+| `YText_WordInsert` | 20,594,592 | 2,483,694 | 32,034 |
+| `YText_MixedEdits` | 1,837,221 | 361,064 | 7,001 |
+| `YText_Format` | 2,742 | 2,535 | 32 |
+| `YText_ApplyDelta` | 4,396 | 2,592 | 37 |
+| `EncodeStateAsUpdateV1` | 41,873 | 23,899 | 16 |
+| `ApplyUpdateV1` | 121,962 | 228,478 | 3,087 |
+| `EncodeStateAsUpdateV2` | 52,267 | 56,328 | 40 |
+| `ApplyUpdateV2` | 123,423 | 231,239 | 3,114 |
+| `MergeUpdatesV1` | 138,561 | 273,811 | 3,258 |
+| `YMap_Set` | 22,119 | 33,760 | 438 |
+| `YArray_Push` | 102,039 | 123,920 | 1,508 |
+| `TwoPeerConvergence` | 20,063 | 29,737 | 406 |
+| `ConcurrentSamePositionInsert/peers=400` | 7,579,318 | 12,314,931 | 14,659 |
+| `ObservedTxn_Apply` | 1,750 | 1,738 | 22 |
+| `ObservedTxn_ApplyBaseline` | 858.3 | 1,242 | 16 |
+
+† `YText_Delete` benchmarks a ~2,000-element delete, hence the disproportionate `ns/op` vs. `YText_Insert` above — this is deliberate benchmark shape (single-op vs. bulk-delete cost), not a light/heavy tier inconsistency.
+
+Pre-existing `BenchmarkSearchMarker_*` (search-marker positional-access;
+not part of this task, included here only because they live in the same
+file and package): 1k/100k warm-marker and cold-cache variants across
+Insert/Get/DeleteRange/ApplyDelta all completed, ranging from ~90 ns/op
+(warm `ArrayGetRandom_1k`) to ~5 ms/op (cold `DeleteRangeTail_100k`). See
+`crdt/bench_test.go` for the full scenario list; not reproduced in full
+here to keep this table scoped to Task 1–6's additions.
+
+**`encoding` — varint/varstring/varbytes wire encode/decode:**
+
+| Benchmark | ns/op | MB/s | allocs/op |
+|---|---|---|---|
+| `WriteVarUint_Small` | 1.768 | 565.6 | 0 |
+| `WriteVarUint_Large` | 8.665 | 577.0 | 0 |
+| `ReadVarUint_Small` | 1.013 | 987.5 | 0 |
+| `ReadVarUint_Large` | 3.219 | 1,553.5 | 0 |
+| `WriteVarString_Short` | 3.846 | 2,600.0 | 0 |
+| `WriteVarString_Long` | 15.31 | 65,308.2 | 0 |
+
+**`sync` — sync-protocol step1/update/handshake:**
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `EncodeSyncStep1` | 164.8 | 296 | 6 |
+| `ApplySyncMessage_Update` | 1,729 | 3,658 | 37 |
+| `FullHandshake` | 1,540 | 3,253 | 46 |
+
+**`awareness` — presence state + update encode/apply:**
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `SetLocalState` | 104.4 | 15 | 1 |
+| `EncodeUpdate_Single` | 234.4 | 240 | 7 |
+| `EncodeUpdate_Many` | 13,494 | 16,747 | 348 |
+| `ApplyUpdate_Single` | 775.6 | 2,008 | 26 |
+| `ApplyUpdate_Many` | 23,463 | 46,312 | 586 |
+| `RemoveExpired` | 5,462 | 5,448 | 15 |
+
+### Heavy tier
+
+`go test -tags benchheavy -bench=. -benchtime=10x -benchmem ./crdt/ ./persistence/ ./cluster/ ./provider/websocket/`
+— this completed in full on the reference machine (no OOM, no size
+reduction needed):
+
+**`crdt` — 100k-scale random access + conflict (B2/B3):**
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `YArray_RandomGet_100k` | 184,038 | 0 | 0 |
+| `YArray_RandomInsert_100k` | 208,079 | 1,265 | 16 |
+| `YText_RandomInsert_100k` | 10,829 | 1,392 | 21 |
+| `YText_RandomDelete_100k` | 11,125 | 1,688 | 22 |
+| `Conflict_B2_TwoUsers` (2×500 ops) | 12,194,792 | 19,634,680 | 21,869 |
+| `Conflict_B3_ManyUsers` (10×150 ops) | 432,413,896 | 595,506,409 | 273,836 |
+
+**`persistence` — `MemoryPersistence` flush cost vs. doc size, coalescing throughput:**
+
+| Benchmark | ns/op | B/op | allocs/op | other |
+|---|---|---|---|---|
+| `MemoryPersistence_FlushVsDocSize/N=1000` | 345,283 | 662,261 | 7,056 | |
+| `MemoryPersistence_FlushVsDocSize/N=10000` | 3,473,975 | 7,331,690 | 70,094 | |
+| `MemoryPersistence_FlushVsDocSize/N=100000` | 34,912,188 | 78,205,744 | 700,123 | |
+| `PersistThroughput_Coalescing/M=1000` | 15,098,808 | 5,540,300 | 73,501 | 71,042 updates/s, 0.999 coalesce-hit-rate |
+
+`FlushVsDocSize` measures `LoadDoc`'s cost as the number of stored
+single-op V1 updates grows — i.e. the `MergeUpdatesV1`-over-all-blobs cost
+a `LegacyAdapter`-backed `VersionedPersistence` pays on every load when no
+compaction has run. On this run the three sampled sizes (1k/10k/100k) each
+scaled close to 10x latency per 10x N, which reads as roughly linear at
+these specific points — but per Task 5's more granular sweep (see
+`persistence/scale_bench_test.go` and the Task 5 report) the underlying
+cost is a **superlinear merge-per-flush cost, not strict O(doc²)**:
+`MergeUpdatesV1` does struct-level dedup rather than pairwise-quadratic
+merging, so it degrades worse than linear but well short of quadratic.
+Treat "superlinear, sub-quadratic" as the accurate characterization rather
+than either "linear" (an artifact of these three sample points) or
+"O(doc²)" (not supported by the measurements).
+
+**`cluster` — `MemRelay` fan-out and backpressure:**
+
+| Benchmark | ns/op | B/op | allocs/op | other |
+|---|---|---|---|---|
+| `MemRelay_Fanout/Fanout` (8 subscribers) | 416.7 | 64 | 1 | |
+| `MemRelay_Fanout/Backpressure` | 469,654,317 | 77,553 | 1,209 | 177.0 publish-timeouts, 200.0 published |
+
+The `Backpressure` sub-benchmark's `publish-timeouts` metric is a
+**caller-side publish-timeout count, not a relay-internal drop count**:
+`MemRelay.Publish` intentionally blocks rather than drops when a
+subscriber's channel is full (see the doc comment on `Publish` in
+`cluster/mem_relay.go` and the benchmark's own doc comment in
+`cluster/relay_bench_test.go`). This benchmark pairs a 1-slot buffer with a
+slow subscriber and a short per-call `context.Context` deadline, so most
+`Publish` calls hit that deadline and return `ctx.Err()` — that is what
+`publish-timeouts` counts. Real drop-on-full semantics don't exist in
+`MemRelay` today; they're deferred to the Redis-relay follow-up (#187,
+see the drafted follow-up issue below).
+
+**`provider/websocket` — room creation, reconnect reuse, broadcast fan-out:**
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `GetOrCreateRoom_ConcurrentDistinctRoomLoads` | 21,002,204 | 206,628 | 924 |
+| `ReconnectReuse_WarmIdleRoom` | 158.4 | 0 | 0 |
+| `BroadcastFanout/N=10` | 2,467 | 2,790 | 38 |
+| `BroadcastFanout/N=100` | 6,750 | 4,022 | 39 |
+| `BroadcastFanout/N=500` | 234,058 | 13,410 | 63 |
+
+### Scaling probe
+
+`SCALE_PROBE_N=1000 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/`
+— completed on the reference machine:
+
+```
+rooms    heapAllocMiB  sysMiB   goroutines rss
+1000     1             12       2          n/a
+```
+
+(`rss` is `n/a` because RSS sampling in `TestScaleProbe` reads
+`/proc/self/status`, which doesn't exist on macOS — Darwin is where this
+document's numbers were captured, so `rss` is unavailable here by
+construction, not a measurement failure. Run on Linux to get an RSS
+figure.)
+
+**Larger `SCALE_PROBE_N` (5,000 / 10,000+ rooms) and the true "10k rooms"
+capacity-planning scenario:** not run for this document — **run on target
+hardware.** The reference machine's 48 GiB completed 1,000 simulated rooms
+trivially (1 MiB heap, 12 MiB sys), so scaling to 10k+ is plausibly fine on
+this machine too, but that is an inference, not a measurement; don't take
+it as a substitute for actually running:
+
+```
+SCALE_PROBE_N=10000 go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
+```
+
+on hardware representative of production before using it for capacity
+planning.
+
+## Cross-implementation comparison
+
+The engine-scenario benchmarks in this suite (`crdt/bench_test.go`'s
+B1-style Prepend/RandomInsert/InsertThenDelete/WordInsert/MixedEdits, and
+`crdt/bench_heavy_test.go`'s B2/B3 conflict scenarios, plus the pre-existing
+B4 editing-trace suite in `benchmarks/`) are deliberately named and shaped
+to mirror
+[`dmonad/crdt-benchmarks`](https://github.com/dmonad/crdt-benchmarks)'
+operation definitions, so that a future native yjs (JS)/yrs (Rust) run on
+the same hardware is a drop-in comparison rather than a re-design.
+
+That native re-run has **not** been done as part of this task — it is
+explicitly out of scope here and tracked as a follow-up (see "Draft
+follow-up issues" below). Existing prior art already comparing ygo against
+yrs/Yjs JS on non-identical hardware exists at
+`docs/comparison/ygo-vs-yrs.md` (which itself flags the hardware mismatch
+caveat: its Yjs JS numbers are from an Intel Core i5-8400, its ygo numbers
+from an Apple M4 Max, so it reports ratios rather than claiming absolute
+apples-to-apples parity). This document's heavy-tier and light-tier numbers
+above are pure-Go engine/server/persistence/relay measurements on one
+machine; they are not yet lined up against yjs/yrs on the same hardware.
+That apples-to-apples run is the deferred follow-up.
+
+Separately, an earlier investigation (see
+[`move_fuzzer_and_yrs_nonconformance`](https://github.com/reearth/ygo) —
+internal project notes) found that yrs 0.21 actually diverges from Yjs's
+own reference behavior on several push/insert-with-tombstone scenarios,
+while ygo matches Yjs in the same scenarios — a *conformance* result, not
+a *performance* one, but relevant context for interpreting any future
+cross-impl performance numbers: "faster than yrs" and "as conformant as
+yrs" are separate claims, and on the conformance axis ygo already has
+better-documented parity with the Yjs reference than yrs does.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test lint fuzz bench coverage vet tools fixtures fmt clean
+.PHONY: all test lint fuzz bench bench-heavy coverage vet tools fixtures fmt clean
 
 GOTEST  := go test -race -timeout 120s
 PACKAGES := ./...
@@ -31,6 +31,14 @@ fuzz:
 bench:
 	@mkdir -p benchmarks
 	go test -bench=. -benchmem -count=3 $(PACKAGES) | tee benchmarks/latest.txt
+
+# Heavy tier (see BENCHMARKS.md): 100k-scale + conflict benches gated behind
+# the benchheavy build tag, plus the websocket scaling probe. Too slow for
+# the PR gate; run locally before/after perf-sensitive changes, or let the
+# nightly CI cron job (.github/workflows/benchmark.yml) run it on main.
+bench-heavy:
+	go test -tags benchheavy -bench=. -benchmem -count=6 $(PACKAGES)
+	go test -tags benchheavy -run TestScaleProbe -v ./provider/websocket/
 
 # Regenerates the deterministic cross-impl conformance fixtures
 # (crdt/testdata/*_yjs_fixtures.json) from the pinned yjs. The legacy

--- a/cluster/relay_bench_test.go
+++ b/cluster/relay_bench_test.go
@@ -165,9 +165,14 @@ const (
 // one slowSink per b.N iteration, publishes benchBackpressureMessages
 // messages each under a short deadline, and reports "publish-timeouts"
 // (Publish calls that hit their caller-side deadline against the full
-// buffer) and "published" (K) via b.ReportMetric.
+// buffer) and "published" (K) via b.ReportMetric — accumulated across all
+// b.N iterations and reported once after the loop, since testing.B keeps
+// only the last value passed to ReportMetric per unit name (calling it
+// per-iteration, as a prior version of this benchmark did, silently
+// discarded every iteration but the last).
 func benchMemRelayBackpressure(b *testing.B) {
 	b.ReportAllocs()
+	var totalPublished, totalPublishTimeouts int64
 	for i := 0; i < b.N; i++ {
 		relay := cluster.NewMemRelay(cluster.WithBufferSize(1))
 		sink := &slowSink{room: "room", delay: benchBackpressureSinkDelay}
@@ -205,12 +210,17 @@ func benchMemRelayBackpressure(b *testing.B) {
 		// or sub-benchmarks.
 		time.Sleep(2*benchBackpressureSinkDelay + 10*time.Millisecond)
 
-		// These are CALLER-SIDE context-deadline timeouts against MemRelay's
-		// blocking backpressure, NOT relay-internal drops: MemRelay has no
-		// drop-on-full path (mem_relay.go's Publish doc: "intentionally does
-		// NOT drop on full"). Real drop-on-full semantics are deferred to the
-		// #187 Redis-relay work. Metric name reflects that deliberately.
-		b.ReportMetric(float64(publishTimeouts), "publish-timeouts")
-		b.ReportMetric(float64(published), "published")
+		totalPublished += published
+		totalPublishTimeouts += publishTimeouts
 	}
+
+	// These are CALLER-SIDE context-deadline timeouts against MemRelay's
+	// blocking backpressure, NOT relay-internal drops: MemRelay has no
+	// drop-on-full path (mem_relay.go's Publish doc: "intentionally does
+	// NOT drop on full"). Real drop-on-full semantics are deferred to the
+	// #187 Redis-relay work. Metric name reflects that deliberately. Totals
+	// (not per-iteration averages) are reported so "published" stays an
+	// exact K-per-iteration-times-b.N count.
+	b.ReportMetric(float64(totalPublishTimeouts), "publish-timeouts")
+	b.ReportMetric(float64(totalPublished), "published")
 }

--- a/cluster/relay_bench_test.go
+++ b/cluster/relay_bench_test.go
@@ -3,8 +3,10 @@
 // Package cluster_test benchmark for issue #180 (Task 6): MemRelay fan-out.
 // Measures Publish throughput fanning a sync update out to M subscriber
 // sinks (BenchmarkMemRelay_Fanout/Fanout), and exercises the small-buffer +
-// slow-subscriber path that #187 raised concerns about
-// (BenchmarkMemRelay_Fanout/DropOnFull).
+// slow-subscriber backpressure path that #187 raised concerns about
+// (BenchmarkMemRelay_Fanout/Backpressure) — MemRelay blocks rather than drops
+// on a full buffer, so this measures caller-side publish timeouts against
+// that blocking, not relay-internal drops; see the Backpressure doc below.
 //
 // Run:
 //
@@ -59,16 +61,16 @@ const benchFanoutSubscribers = 8
 const benchFanoutDrainTimeout = 5 * time.Second
 
 // BenchmarkMemRelay_Fanout groups the two relay fan-out scenarios from issue
-// #180 Task 6: plain fan-out throughput (Fanout) and the drop-on-full path
-// under a saturated small buffer + slow subscriber (DropOnFull).
+// #180 Task 6: plain fan-out throughput (Fanout) and the backpressure path
+// under a saturated small buffer + slow subscriber (Backpressure).
 func BenchmarkMemRelay_Fanout(b *testing.B) {
 	b.Run("Fanout", benchMemRelayFanout)
-	b.Run("DropOnFull", benchMemRelayDropOnFull)
+	b.Run("Backpressure", benchMemRelayBackpressure)
 }
 
 // benchMemRelayFanout starts a MemRelay with benchFanoutSubscribers counting
 // sinks behind a generous buffer (so Publish never blocks on delivery — that
-// backpressure path is what DropOnFull covers instead), then times b.N
+// backpressure path is what Backpressure covers instead), then times b.N
 // Publish calls of a representative sync-update payload.
 func benchMemRelayFanout(b *testing.B) {
 	relay := cluster.NewMemRelay(cluster.WithBufferSize(4096))
@@ -118,17 +120,18 @@ func benchMemRelayFanout(b *testing.B) {
 //
 // MemRelay itself has no drop-on-full path: mem_relay.go's Publish doc is
 // explicit that it "intentionally does NOT drop on full" — a full per-node
-// channel makes Publish block until the node drains, ctx is cancelled, or the
+// channel makes Publish BLOCK until the node drains, ctx is cancelled, or the
 // node shuts down (that blocking-not-dropping choice is exactly what #187
 // raised). Since MemRelay is production code and this task must not modify
-// production code, DropOnFull exercises that real blocking path from the
+// production code, Backpressure exercises that real blocking path from the
 // benchmark side instead: pairing WithBufferSize(1) with this slow sink
 // saturates the node's channel almost immediately, and each Publish call is
 // given a short per-call context deadline. A Publish that would otherwise
 // block past that deadline returns ctx.Err() (MemRelay's Publish selects on
-// ctx.Done()) and is counted as "dropped" here at the call site — i.e. this
-// benchmark is the thing choosing not to wait, not MemRelay silently
-// discarding data.
+// ctx.Done()) and is counted as a caller-side publish-timeout here at the
+// call site — i.e. this benchmark is the thing choosing not to wait, not
+// MemRelay dropping anything. Real drop-on-full semantics (if ever added) are
+// deferred to the #187 Redis-relay work; MemRelay has none today.
 type slowSink struct {
 	room  string
 	delay time.Duration
@@ -146,41 +149,42 @@ func (s *slowSink) GetAwareness(string) (*awareness.Awareness, bool) { return ni
 func (s *slowSink) GetDoc(string) *crdt.Doc { return nil }
 
 const (
-	// benchDropOnFullMessages is K, the number of Publish calls attempted
+	// benchBackpressureMessages is K, the number of Publish calls attempted
 	// per b.N iteration against the saturated single-slot buffer.
-	benchDropOnFullMessages = 200
-	// benchDropOnFullSinkDelay is how long the slow sink's Inject stalls —
+	benchBackpressureMessages = 200
+	// benchBackpressureSinkDelay is how long the slow sink's Inject stalls —
 	// long enough that, combined with a 1-slot buffer, most Publish calls
 	// below hit their deadline instead of enqueuing.
-	benchDropOnFullSinkDelay = 20 * time.Millisecond
-	// benchDropOnFullPublishDeadline is the per-Publish context timeout that
-	// stands in for a bounded-wait caller giving up on a full buffer.
-	benchDropOnFullPublishDeadline = 2 * time.Millisecond
+	benchBackpressureSinkDelay = 20 * time.Millisecond
+	// benchBackpressurePublishDeadline is the per-Publish context timeout
+	// that stands in for a bounded-wait caller giving up on a full buffer.
+	benchBackpressurePublishDeadline = 2 * time.Millisecond
 )
 
-// benchMemRelayDropOnFull starts a fresh MemRelay(WithBufferSize(1)) with one
-// slowSink per b.N iteration, publishes benchDropOnFullMessages messages each
-// under a short deadline, and reports "dropped" (Publish calls that timed out
-// against the full buffer) and "published" (K) via b.ReportMetric.
-func benchMemRelayDropOnFull(b *testing.B) {
+// benchMemRelayBackpressure starts a fresh MemRelay(WithBufferSize(1)) with
+// one slowSink per b.N iteration, publishes benchBackpressureMessages
+// messages each under a short deadline, and reports "publish-timeouts"
+// (Publish calls that hit their caller-side deadline against the full
+// buffer) and "published" (K) via b.ReportMetric.
+func benchMemRelayBackpressure(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		relay := cluster.NewMemRelay(cluster.WithBufferSize(1))
-		sink := &slowSink{room: "room", delay: benchDropOnFullSinkDelay}
+		sink := &slowSink{room: "room", delay: benchBackpressureSinkDelay}
 		if err := relay.Start(context.Background(), sink); err != nil {
 			b.Fatalf("Start: %v", err)
 		}
 
-		var published, dropped int64
-		for j := 0; j < benchDropOnFullMessages; j++ {
-			ctx, cancel := context.WithTimeout(context.Background(), benchDropOnFullPublishDeadline)
+		var published, publishTimeouts int64
+		for j := 0; j < benchBackpressureMessages; j++ {
+			ctx, cancel := context.WithTimeout(context.Background(), benchBackpressurePublishDeadline)
 			err := relay.Publish(ctx, cluster.Outbound{
 				Room: "room", Kind: cluster.KindSync, Data: []byte{byte(j)},
 			})
 			cancel()
 			published++
 			if err != nil {
-				dropped++
+				publishTimeouts++
 			}
 		}
 
@@ -189,15 +193,24 @@ func benchMemRelayDropOnFull(b *testing.B) {
 		}
 		// relay.Close only signals shutdown (mem_relay.go's Close doc: it
 		// closes the relay-level done channel but never the per-node
-		// channel, precisely so a concurrent send can't panic). The node's
-		// delivery goroutine may still be mid-Inject (sleeping up to
-		// benchDropOnFullSinkDelay) when Close returns; give it a bounded
-		// grace period to finish that call and exit on the now-closed done
-		// channel before the next iteration (or the benchmark) proceeds, so
-		// no goroutine leaks across b.N iterations or sub-benchmarks.
-		time.Sleep(benchDropOnFullSinkDelay + 10*time.Millisecond)
+		// channel, precisely so a concurrent send can't panic). At loop end
+		// the node is often mid-Inject AND still holding one queued item
+		// (buffer size 1), so up to ~2×benchBackpressureSinkDelay of work can
+		// remain when Close returns. This sleep is a probabilistic bound, not
+		// a guaranteed join (MemRelay exposes no WaitGroup/join API) — it
+		// relies on iteration isolation (each b.N iteration gets its own
+		// relay/sink) plus generous per-iteration wall time for the run()
+		// goroutine to actually exit before the next iteration or the
+		// benchmark proceeds, so no goroutine leaks pile up across iterations
+		// or sub-benchmarks.
+		time.Sleep(2*benchBackpressureSinkDelay + 10*time.Millisecond)
 
-		b.ReportMetric(float64(dropped), "dropped")
+		// These are CALLER-SIDE context-deadline timeouts against MemRelay's
+		// blocking backpressure, NOT relay-internal drops: MemRelay has no
+		// drop-on-full path (mem_relay.go's Publish doc: "intentionally does
+		// NOT drop on full"). Real drop-on-full semantics are deferred to the
+		// #187 Redis-relay work. Metric name reflects that deliberately.
+		b.ReportMetric(float64(publishTimeouts), "publish-timeouts")
 		b.ReportMetric(float64(published), "published")
 	}
 }

--- a/cluster/relay_bench_test.go
+++ b/cluster/relay_bench_test.go
@@ -1,0 +1,203 @@
+//go:build benchheavy
+
+// Package cluster_test benchmark for issue #180 (Task 6): MemRelay fan-out.
+// Measures Publish throughput fanning a sync update out to M subscriber
+// sinks (BenchmarkMemRelay_Fanout/Fanout), and exercises the small-buffer +
+// slow-subscriber path that #187 raised concerns about
+// (BenchmarkMemRelay_Fanout/DropOnFull).
+//
+// Run:
+//
+//	go test -tags benchheavy ./cluster/ -run '^$' -bench MemRelay_Fanout -benchtime=1x -benchmem
+package cluster_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/reearth/ygo/awareness"
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
+)
+
+// countingSink is a minimal cluster.Sink that atomically counts every
+// delivered Inject call and returns immediately. MemRelay.Start already runs
+// one dedicated delivery goroutine per node (memNode.run in mem_relay.go)
+// that drains that node's channel and calls Sink.Inject synchronously — since
+// Inject here never blocks, that goroutine drains as fast as Publish can
+// enqueue, so no extra "drainer" goroutine is needed on top of what MemRelay
+// already provides.
+type countingSink struct {
+	room     string
+	received atomic.Int64
+}
+
+func newCountingSink(room string) *countingSink { return &countingSink{room: room} }
+
+func (s *countingSink) Inject(_ context.Context, _ cluster.Inbound) error {
+	s.received.Add(1)
+	return nil
+}
+
+func (s *countingSink) Rooms() []string { return []string{s.room} }
+
+func (s *countingSink) GetAwareness(string) (*awareness.Awareness, bool) { return nil, false }
+
+func (s *countingSink) GetDoc(string) *crdt.Doc { return nil }
+
+// benchFanoutSubscribers is the number of Sink nodes (M) started on the
+// shared relay for the Fanout sub-benchmark, modelling M peers all receiving
+// every Publish.
+const benchFanoutSubscribers = 8
+
+// benchFanoutDrainTimeout bounds how long the Fanout sub-benchmark waits,
+// after the timed Publish loop, for every subscriber to observe all b.N
+// deliveries before returning. This keeps in-flight deliveries from one
+// b.N iteration from bleeding into the next sub-benchmark's fresh relay.
+const benchFanoutDrainTimeout = 5 * time.Second
+
+// BenchmarkMemRelay_Fanout groups the two relay fan-out scenarios from issue
+// #180 Task 6: plain fan-out throughput (Fanout) and the drop-on-full path
+// under a saturated small buffer + slow subscriber (DropOnFull).
+func BenchmarkMemRelay_Fanout(b *testing.B) {
+	b.Run("Fanout", benchMemRelayFanout)
+	b.Run("DropOnFull", benchMemRelayDropOnFull)
+}
+
+// benchMemRelayFanout starts a MemRelay with benchFanoutSubscribers counting
+// sinks behind a generous buffer (so Publish never blocks on delivery — that
+// backpressure path is what DropOnFull covers instead), then times b.N
+// Publish calls of a representative sync-update payload.
+func benchMemRelayFanout(b *testing.B) {
+	relay := cluster.NewMemRelay(cluster.WithBufferSize(4096))
+	defer func() {
+		if err := relay.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+	}()
+
+	sinks := make([]*countingSink, benchFanoutSubscribers)
+	for i := range sinks {
+		sinks[i] = newCountingSink("room")
+		if err := relay.Start(context.Background(), sinks[i]); err != nil {
+			b.Fatalf("Start: %v", err)
+		}
+	}
+
+	payload := make([]byte, 256) // representative V1 sync-update size
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := relay.Publish(context.Background(), cluster.Outbound{
+			Room: "room", Kind: cluster.KindSync, Data: payload,
+		}); err != nil {
+			b.Fatalf("Publish: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	// Drain (bounded): wait for every subscriber to have observed all b.N
+	// deliveries so relay.Close() above tears down settled goroutines rather
+	// than ones mid-delivery. Best-effort — a timeout here would mean
+	// delivery is unexpectedly slow, not a benchmark failure, so it is not
+	// asserted.
+	want := int64(b.N)
+	deadline := time.Now().Add(benchFanoutDrainTimeout)
+	for _, s := range sinks {
+		for time.Now().Before(deadline) && s.received.Load() < want {
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// slowSink is a cluster.Sink whose Inject stalls for a fixed delay, standing
+// in for a slow/backed-up subscriber.
+//
+// MemRelay itself has no drop-on-full path: mem_relay.go's Publish doc is
+// explicit that it "intentionally does NOT drop on full" — a full per-node
+// channel makes Publish block until the node drains, ctx is cancelled, or the
+// node shuts down (that blocking-not-dropping choice is exactly what #187
+// raised). Since MemRelay is production code and this task must not modify
+// production code, DropOnFull exercises that real blocking path from the
+// benchmark side instead: pairing WithBufferSize(1) with this slow sink
+// saturates the node's channel almost immediately, and each Publish call is
+// given a short per-call context deadline. A Publish that would otherwise
+// block past that deadline returns ctx.Err() (MemRelay's Publish selects on
+// ctx.Done()) and is counted as "dropped" here at the call site — i.e. this
+// benchmark is the thing choosing not to wait, not MemRelay silently
+// discarding data.
+type slowSink struct {
+	room  string
+	delay time.Duration
+}
+
+func (s *slowSink) Inject(_ context.Context, _ cluster.Inbound) error {
+	time.Sleep(s.delay)
+	return nil
+}
+
+func (s *slowSink) Rooms() []string { return []string{s.room} }
+
+func (s *slowSink) GetAwareness(string) (*awareness.Awareness, bool) { return nil, false }
+
+func (s *slowSink) GetDoc(string) *crdt.Doc { return nil }
+
+const (
+	// benchDropOnFullMessages is K, the number of Publish calls attempted
+	// per b.N iteration against the saturated single-slot buffer.
+	benchDropOnFullMessages = 200
+	// benchDropOnFullSinkDelay is how long the slow sink's Inject stalls —
+	// long enough that, combined with a 1-slot buffer, most Publish calls
+	// below hit their deadline instead of enqueuing.
+	benchDropOnFullSinkDelay = 20 * time.Millisecond
+	// benchDropOnFullPublishDeadline is the per-Publish context timeout that
+	// stands in for a bounded-wait caller giving up on a full buffer.
+	benchDropOnFullPublishDeadline = 2 * time.Millisecond
+)
+
+// benchMemRelayDropOnFull starts a fresh MemRelay(WithBufferSize(1)) with one
+// slowSink per b.N iteration, publishes benchDropOnFullMessages messages each
+// under a short deadline, and reports "dropped" (Publish calls that timed out
+// against the full buffer) and "published" (K) via b.ReportMetric.
+func benchMemRelayDropOnFull(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		relay := cluster.NewMemRelay(cluster.WithBufferSize(1))
+		sink := &slowSink{room: "room", delay: benchDropOnFullSinkDelay}
+		if err := relay.Start(context.Background(), sink); err != nil {
+			b.Fatalf("Start: %v", err)
+		}
+
+		var published, dropped int64
+		for j := 0; j < benchDropOnFullMessages; j++ {
+			ctx, cancel := context.WithTimeout(context.Background(), benchDropOnFullPublishDeadline)
+			err := relay.Publish(ctx, cluster.Outbound{
+				Room: "room", Kind: cluster.KindSync, Data: []byte{byte(j)},
+			})
+			cancel()
+			published++
+			if err != nil {
+				dropped++
+			}
+		}
+
+		if err := relay.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+		// relay.Close only signals shutdown (mem_relay.go's Close doc: it
+		// closes the relay-level done channel but never the per-node
+		// channel, precisely so a concurrent send can't panic). The node's
+		// delivery goroutine may still be mid-Inject (sleeping up to
+		// benchDropOnFullSinkDelay) when Close returns; give it a bounded
+		// grace period to finish that call and exit on the now-closed done
+		// channel before the next iteration (or the benchmark) proceeds, so
+		// no goroutine leaks across b.N iterations or sub-benchmarks.
+		time.Sleep(benchDropOnFullSinkDelay + 10*time.Millisecond)
+
+		b.ReportMetric(float64(dropped), "dropped")
+		b.ReportMetric(float64(published), "published")
+	}
+}

--- a/crdt/bench_heavy_test.go
+++ b/crdt/bench_heavy_test.go
@@ -1,0 +1,162 @@
+//go:build benchheavy
+
+package crdt
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// nHeavy is the document size used by the heavy-tier 100k random-access
+// benchmarks below. These are gated behind the benchheavy build tag because
+// building a 100k-element document is too slow for the default PR test gate.
+const nHeavy = 100_000
+
+// buildHeavyTextDoc builds a doc whose YText "t" contains n single-character
+// inserts, appended one at a time (mirrors buildTextDoc in bench_test.go but
+// lives here so this file has no dependency on non-benchheavy helpers).
+func buildHeavyTextDoc(n int) (*Doc, *YText) {
+	doc := New(WithClientID(ClientID(1)))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) {
+		for i := 0; i < n; i++ {
+			txt.Insert(txn, txt.Len(), "a", nil)
+		}
+	})
+	return doc, txt
+}
+
+// buildHeavyArrayDoc builds a doc whose YArray "a" contains n scalar
+// elements, appended one at a time.
+func buildHeavyArrayDoc(n int) (*Doc, *YArray) {
+	doc := New(WithClientID(ClientID(1)))
+	arr := doc.GetArray("a")
+	doc.Transact(func(txn *Transaction) {
+		for i := 0; i < n; i++ {
+			arr.Insert(txn, arr.Len(), []any{i})
+		}
+	})
+	return doc, arr
+}
+
+// BenchmarkYArray_RandomGet_100k measures the cost of a single positional
+// Get at a uniformly random index into a 100k-element YArray. This exercises
+// the move-aware search-marker path (see v1.39.0) that makes positional
+// access O(1) rather than O(n).
+func BenchmarkYArray_RandomGet_100k(b *testing.B) {
+	b.ReportAllocs()
+
+	_, arr := buildHeavyArrayDoc(nHeavy)
+	r := rand.New(rand.NewSource(42))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = arr.Get(r.Intn(nHeavy))
+	}
+}
+
+// BenchmarkYArray_RandomInsert_100k measures the cost of a single insert at a
+// uniformly random index into a 100k-element YArray.
+func BenchmarkYArray_RandomInsert_100k(b *testing.B) {
+	b.ReportAllocs()
+
+	doc, arr := buildHeavyArrayDoc(nHeavy)
+	r := rand.New(rand.NewSource(42))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx := r.Intn(arr.Len() + 1)
+		doc.Transact(func(txn *Transaction) {
+			arr.Insert(txn, idx, []any{i})
+		})
+	}
+}
+
+// BenchmarkYText_RandomInsert_100k measures the cost of a single
+// single-character insert at a uniformly random position into a
+// ~100k-character YText, exercising the search-marker positional-write path.
+func BenchmarkYText_RandomInsert_100k(b *testing.B) {
+	b.ReportAllocs()
+
+	doc, txt := buildHeavyTextDoc(nHeavy)
+	r := rand.New(rand.NewSource(42))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx := r.Intn(txt.Len() + 1)
+		doc.Transact(func(txn *Transaction) {
+			txt.Insert(txn, idx, "x", nil)
+		})
+	}
+}
+
+// BenchmarkYText_RandomDelete_100k measures the cost of deleting a single
+// character at a uniformly random position into a ~100k-character YText.
+func BenchmarkYText_RandomDelete_100k(b *testing.B) {
+	b.ReportAllocs()
+
+	doc, txt := buildHeavyTextDoc(nHeavy)
+	r := rand.New(rand.NewSource(42))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if txt.Len() == 0 {
+			// Guard against exhausting the doc across an unusually large b.N;
+			// refill so the loop keeps measuring steady-state deletes.
+			b.StopTimer()
+			doc, txt = buildHeavyTextDoc(nHeavy)
+			b.StartTimer()
+		}
+		idx := r.Intn(txt.Len())
+		doc.Transact(func(txn *Transaction) {
+			txt.Delete(txn, idx, 1)
+		})
+	}
+}
+
+// benchConflict simulates `users` independent peers, each performing
+// opsPerUser concurrent inserts at the same start position (index 0) of a
+// shared YText, then converging all peers via a single MergeUpdatesV1 +
+// ApplyUpdateV1 round (mirrors BenchmarkTwoPeerConvergence but with N peers
+// and heavier conflict rates — this is the B2/B3 scenario from
+// dmonad/crdt-benchmarks).
+func benchConflict(b *testing.B, users, opsPerUser int) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		docs := make([]*Doc, users)
+		for u := range docs {
+			docs[u] = New(WithClientID(ClientID(u + 1)))
+			t := docs[u].GetText("t")
+			docs[u].Transact(func(txn *Transaction) {
+				for j := 0; j < opsPerUser; j++ {
+					t.Insert(txn, 0, "x", nil)
+				}
+			})
+		}
+
+		updates := make([][]byte, users)
+		for u, d := range docs {
+			updates[u] = EncodeStateAsUpdateV1(d, nil)
+		}
+
+		merged, err := MergeUpdatesV1(updates...)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		for _, d := range docs {
+			if err := ApplyUpdateV1(d, merged, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkConflict_B2_TwoUsers is the B2 scenario: two peers concurrently
+// insert at the same position, then converge.
+func BenchmarkConflict_B2_TwoUsers(b *testing.B) { benchConflict(b, 2, 1000) }
+
+// BenchmarkConflict_B3_ManyUsers is the B3 scenario: 20 peers concurrently
+// insert at the same position, then converge.
+func BenchmarkConflict_B3_ManyUsers(b *testing.B) { benchConflict(b, 20, 1000) }

--- a/crdt/bench_heavy_test.go
+++ b/crdt/bench_heavy_test.go
@@ -153,10 +153,25 @@ func benchConflict(b *testing.B, users, opsPerUser int) {
 	}
 }
 
-// BenchmarkConflict_B2_TwoUsers is the B2 scenario: two peers concurrently
-// insert at the same position, then converge.
-func BenchmarkConflict_B2_TwoUsers(b *testing.B) { benchConflict(b, 2, 1000) }
+// NOTE: same-start-position concurrent inserts are the pathological O(n^2)-ish
+// conflict-arbitration case for a CRDT text type (every peer's insert is
+// causally concurrent with, and ordered against, every other peer's insert at
+// that position), which is exactly the shape B2/B3 are meant to exercise. The
+// sizes below are deliberately bounded (not the dmonad/crdt-benchmarks
+// upstream sizes) so a single -benchtime=1x iteration stays under ~3s and
+// ~1GB allocated — nightly CI runs the benchheavy tier at -count=6 on
+// GitHub-hosted runners with only ~7-16GB of RAM, and an unbounded conflict
+// bench at that scale (e.g. 20 users x 1000 ops measured ~160s/iter and
+// ~223GB allocated/iter) would OOM or hang the job. Profiling larger N is a
+// manual `go test -bench` exercise outside CI, not something this suite runs
+// automatically.
 
-// BenchmarkConflict_B3_ManyUsers is the B3 scenario: 20 peers concurrently
-// insert at the same position, then converge.
-func BenchmarkConflict_B3_ManyUsers(b *testing.B) { benchConflict(b, 20, 1000) }
+// BenchmarkConflict_B2_TwoUsers is the B2 scenario: two peers concurrently
+// insert at the same position, then converge. Measured (this machine,
+// -benchtime=1x -benchmem): ~12ms/iter, ~19.6MB/iter, ~21.9k allocs/iter.
+func BenchmarkConflict_B2_TwoUsers(b *testing.B) { benchConflict(b, 2, 500) }
+
+// BenchmarkConflict_B3_ManyUsers is the B3 scenario: many peers concurrently
+// insert at the same position, then converge. Measured (this machine,
+// -benchtime=1x -benchmem): ~413ms/iter, ~596MB/iter, ~274k allocs/iter.
+func BenchmarkConflict_B3_ManyUsers(b *testing.B) { benchConflict(b, 10, 150) }

--- a/crdt/bench_test.go
+++ b/crdt/bench_test.go
@@ -676,3 +676,182 @@ func TestBenchSearchMarker_ArrayGetHelperMatchesCold(t *testing.T) {
 		t.Fatalf("marker/cold divergence:\n got  %v\n want %v", got, want)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Engine light-tier slow-path benchmarks (Task 1, #180).
+//
+// These mirror the dmonad/crdt-benchmarks B1 scenario shapes (append is
+// already covered by BenchmarkYText_Insert above; prepend/random/word/
+// insert-then-delete/mixed follow here) at light-tier sizes (nLight ops,
+// fixed-seed RNG) so the PR gate stays fast and deterministic. Heavy-tier
+// (100k) equivalents live behind the benchheavy build tag elsewhere.
+// ---------------------------------------------------------------------------
+
+const benchSeed = 42
+const nLight = 2000
+
+// BenchmarkYText_Prepend inserts at index 0 repeatedly — the worst case for a
+// forward-only cursor/cache, since every insert lands behind everything
+// already in the document.
+func BenchmarkYText_Prepend(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *Transaction) {
+			for j := 0; j < nLight; j++ {
+				txt.Insert(txn, 0, "x", nil)
+			}
+		})
+	}
+}
+
+// BenchmarkYText_RandomInsert inserts nLight characters at seeded-random
+// positions into a growing document.
+func BenchmarkYText_RandomInsert(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		r := rand.New(rand.NewSource(benchSeed))
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *Transaction) {
+			for j := 0; j < nLight; j++ {
+				txt.Insert(txn, r.Intn(txt.Len()+1), "x", nil)
+			}
+		})
+	}
+}
+
+// BenchmarkYText_InsertThenDelete inserts nLight characters at seeded-random
+// positions, then deletes them one at a time from seeded-random positions
+// until the document is empty again.
+func BenchmarkYText_InsertThenDelete(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		r := rand.New(rand.NewSource(benchSeed))
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *Transaction) {
+			for j := 0; j < nLight; j++ {
+				txt.Insert(txn, r.Intn(txt.Len()+1), "x", nil)
+			}
+		})
+		for txt.Len() > 0 {
+			doc.Transact(func(txn *Transaction) {
+				txt.Delete(txn, r.Intn(txt.Len()), 1)
+			})
+		}
+	}
+}
+
+// BenchmarkYText_WordInsert inserts nLight short "words" at the current end
+// of the document, one Transact per word.
+func BenchmarkYText_WordInsert(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		for j := 0; j < nLight; j++ {
+			doc.Transact(func(txn *Transaction) {
+				txt.Insert(txn, txt.Len(), "lorem ", nil)
+			})
+		}
+	}
+}
+
+// BenchmarkYText_MixedEdits runs a seeded walk of nLight steps: 70% insert a
+// character at a random position, 30% delete one character at a random
+// position (an insert is forced whenever the document is empty).
+func BenchmarkYText_MixedEdits(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		r := rand.New(rand.NewSource(benchSeed))
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *Transaction) {
+			for j := 0; j < nLight; j++ {
+				if txt.Len() == 0 || r.Float64() < 0.7 {
+					txt.Insert(txn, r.Intn(txt.Len()+1), "x", nil)
+				} else {
+					txt.Delete(txn, r.Intn(txt.Len()), 1)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkYText_Format seeds an nLight-character document once (outside the
+// timed loop, so setup cost isn't attributed to the format op) and then
+// repeatedly formats a random 10-character span within it.
+func BenchmarkYText_Format(b *testing.B) {
+	b.ReportAllocs()
+
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, strings.Repeat("x", nLight), nil)
+	})
+	r := rand.New(rand.NewSource(benchSeed))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc.Transact(func(txn *Transaction) {
+			txt.Format(txn, r.Intn(txt.Len()-10), 10, Attributes{"bold": true})
+		})
+	}
+}
+
+// BenchmarkYText_ApplyDelta applies a fixed retain/delete/insert/format delta
+// (the shape a rich-text editor emits for a single user edit) to a fresh
+// small document on every iteration.
+func BenchmarkYText_ApplyDelta(b *testing.B) {
+	b.ReportAllocs()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		doc.Transact(func(txn *Transaction) {
+			txt.Insert(txn, 0, "Hello World", nil)
+		})
+		b.StartTimer()
+
+		doc.Transact(func(txn *Transaction) {
+			txt.ApplyDelta(txn, []Delta{
+				{Op: DeltaOpRetain, Retain: 6},
+				{Op: DeltaOpDelete, Delete: 5},
+				{Op: DeltaOpInsert, Insert: "Go", Attributes: Attributes{"bold": true}},
+			})
+		})
+	}
+}
+
+// benchObservedTxn measures the cost of a single-character append transaction
+// with (withObserver=true) and without an active YText.Observe subscriber.
+// The delta between BenchmarkObservedTxn_Apply and _ApplyBaseline IS the
+// signal: it isolates the marginal cost of computing and dispatching the
+// observer event on every transaction commit.
+func benchObservedTxn(b *testing.B, withObserver bool) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "seed", nil) })
+	if withObserver {
+		unsub := txt.Observe(func(YTextEvent) {}) // minimal observer
+		defer unsub()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "x", nil) })
+	}
+}
+
+func BenchmarkObservedTxn_Apply(b *testing.B)         { benchObservedTxn(b, true) }
+func BenchmarkObservedTxn_ApplyBaseline(b *testing.B) { benchObservedTxn(b, false) }

--- a/persistence/scale_bench_test.go
+++ b/persistence/scale_bench_test.go
@@ -1,0 +1,257 @@
+//go:build benchheavy
+
+// Package persistence benchmarks for issue #180 (Task 5): heavy-tier
+// persistence scale benchmarks.
+//
+//   - BenchmarkMemoryPersistence_FlushVsDocSize measures the cost of
+//     LoadDoc (materialize) as the number of stored single-op V1 updates for
+//     a room grows — surfacing the MergeUpdatesV1-over-all-blobs cost that a
+//     LegacyAdapter-backed VersionedPersistence pays on every load when no
+//     compaction has run.
+//   - BenchmarkPersistThroughput_Coalescing measures end-to-end update
+//     throughput through a websocket Server with default persistence
+//     coalescing enabled, and reports the resulting coalesce-hit-rate (the
+//     fraction of updates absorbed into a batch rather than persisted
+//     individually) via a counting PersistenceAdapter shim — no production
+//     code is touched or instrumented.
+//
+// Run:
+//
+//	go test -tags benchheavy ./persistence/ -run '^$' -bench 'FlushVsDocSize|Coalescing' -benchtime=1x -benchmem
+package persistence_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+	"github.com/reearth/ygo/persistence"
+	ygws "github.com/reearth/ygo/provider/websocket"
+	ygsync "github.com/reearth/ygo/sync"
+)
+
+// ── BenchmarkMemoryPersistence_FlushVsDocSize ──────────────────────────────
+
+// buildSingleOpUpdates builds n single-character-append V1 updates from one
+// growing doc (client 1), each update carrying only the diff introduced by
+// its own transaction (via doc.StateVector() taken immediately before the
+// transact). This mirrors how a real editor streams incremental updates to a
+// PersistenceAdapter's StoreUpdate — one call per committed transaction —
+// rather than n copies of the full document state.
+func buildSingleOpUpdates(n int) [][]byte {
+	doc := crdt.New(crdt.WithClientID(1))
+	txt := doc.GetText("t")
+	updates := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		sv := doc.StateVector()
+		doc.Transact(func(txn *crdt.Transaction) {
+			txt.Insert(txn, txt.Len(), "a", nil)
+		})
+		updates[i] = crdt.EncodeStateAsUpdateV1(doc, sv)
+	}
+	return updates
+}
+
+// BenchmarkMemoryPersistence_FlushVsDocSize times LoadDoc (the materialize
+// path: MergeUpdatesV1 folding every stored blob into one head) against a
+// MemoryPersistence room seeded with N single-op updates via a LegacyAdapter.
+// The N updates are built and stored OUTSIDE the timer; only LoadDoc is
+// timed, isolating the per-load merge cost as N grows.
+//
+// Sizes are bounded to {1_000, 10_000, 100_000}: 100_000 was measured at
+// well under the ~3s/~1GB CI-safety ceiling noted in the task brief (see
+// task-5-report.md), so no reduction was needed.
+func BenchmarkMemoryPersistence_FlushVsDocSize(b *testing.B) {
+	for _, n := range []int{1_000, 10_000, 100_000} {
+		n := n
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			updates := buildSingleOpUpdates(n)
+
+			store := persistence.NewMemoryPersistence()
+			ad := persistence.NewLegacyAdapter(store)
+			const room = "room"
+			for _, upd := range updates {
+				if err := ad.StoreUpdate(room, upd); err != nil {
+					b.Fatalf("StoreUpdate: %v", err)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := ad.LoadDoc(room); err != nil {
+					b.Fatalf("LoadDoc: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// ── BenchmarkPersistThroughput_Coalescing ──────────────────────────────────
+
+// countingAdapter wraps a ygws.PersistenceAdapter and atomically counts every
+// StoreUpdate call, so the coalesce-hit-rate below can be computed purely
+// from an external observation point (the adapter boundary) rather than by
+// reading any Server-internal state.
+type countingAdapter struct {
+	inner  ygws.PersistenceAdapter
+	stores int64 // atomic
+}
+
+func (c *countingAdapter) LoadDoc(room string) ([]byte, error) { return c.inner.LoadDoc(room) }
+
+func (c *countingAdapter) StoreUpdate(room string, u []byte) error {
+	atomic.AddInt64(&c.stores, 1)
+	return c.inner.StoreUpdate(room, u)
+}
+
+// persistThroughputM is the number of updates driven through the server per
+// benchmark iteration. Kept modest so the workload (M sequential WS sends
+// plus one flush) stays bounded under -benchtime=1x.
+const persistThroughputM = 1000
+
+// persistThroughputCoalesceWindow is a short debounce window (vs. the 2s
+// production default) so the benchmark's forced flush at the end of each
+// iteration has an actual batch to drain instead of racing a multi-second
+// timer.
+const persistThroughputCoalesceWindow = 50 * time.Millisecond
+
+// BenchmarkPersistThroughput_Coalescing drives persistThroughputM sequential
+// updates from one websocket peer into a room backed by a countingAdapter,
+// waits for the server to have received and applied all of them, then forces
+// the pending coalesced batch to flush (Server.CloseRoom drains
+// flush-before-evict) and reports:
+//
+//   - "updates/s": persistThroughputM divided by the elapsed time from the
+//     first send through the forced flush completing.
+//   - "coalesce-hit-rate": 1 - (StoreUpdate calls observed / updates sent),
+//     i.e. the fraction of updates that were absorbed into a coalesced batch
+//     rather than causing their own persistence write. Computed purely from
+//     the countingAdapter's counter, never from Server internals.
+func BenchmarkPersistThroughput_Coalescing(b *testing.B) {
+	b.Run(fmt.Sprintf("M=%d", persistThroughputM), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			runPersistThroughputIteration(b)
+		}
+	})
+}
+
+func runPersistThroughputIteration(b *testing.B) {
+	b.Helper()
+
+	counting := &countingAdapter{inner: persistence.NewLegacyAdapter(persistence.NewMemoryPersistence())}
+	s := ygws.NewServerWithPersistence(counting)
+	s.PersistCoalesceWindow = persistThroughputCoalesceWindow
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	const room = "room"
+	doc := crdt.New(crdt.WithClientID(1))
+	txt := doc.GetText("t")
+
+	conn := dialWSBench(b, ts, room)
+	defer func() { _ = conn.Close() }()
+	drainHandshakeBench(b, conn)
+
+	start := time.Now()
+	for j := 0; j < persistThroughputM; j++ {
+		sv := doc.StateVector()
+		doc.Transact(func(txn *crdt.Transaction) {
+			txt.Insert(txn, txt.Len(), "a", nil)
+		})
+		sendV1UpdateBench(b, conn, crdt.EncodeStateAsUpdateV1(doc, sv))
+	}
+
+	// Confirm the server has actually received and applied every update
+	// (over a real loopback socket, delivery to the room's doc is
+	// asynchronous relative to WriteMessage returning) before forcing the
+	// flush and reading the counter — otherwise a straggling in-flight
+	// update could still be pending when CloseRoom evicts the room.
+	waitForDocTextLen(b, s, room, persistThroughputM, 5*time.Second)
+
+	// Force the pending coalesced batch to flush while the room is still
+	// discoverable (Server.CloseRoom's flush-before-evict guarantee — see
+	// TestPersistTeardown_CloseRoomFlushesBeforeEvict in
+	// provider/websocket/persistence_coalesce_test.go). force=true because a
+	// peer is still connected.
+	if err := s.CloseRoom(room, true); err != nil {
+		b.Fatalf("CloseRoom: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	stores := atomic.LoadInt64(&counting.stores)
+	b.ReportMetric(float64(persistThroughputM)/elapsed.Seconds(), "updates/s")
+	b.ReportMetric(1-float64(stores)/float64(persistThroughputM), "coalesce-hit-rate")
+}
+
+// waitForDocTextLen polls the server's live, in-memory doc (an exported
+// Server.GetDoc — not an internal field) until the room's "t" text reaches
+// the expected length or timeout elapses. Used only to synchronize the
+// benchmark before it forces a flush; the coalesce-hit-rate metric itself is
+// still computed solely from the countingAdapter's counter.
+func waitForDocTextLen(b *testing.B, s *ygws.Server, room string, want int, timeout time.Duration) {
+	b.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if doc := s.GetDoc(room); doc != nil {
+			if doc.GetText("t").Len() >= want {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			b.Fatalf("timed out waiting for room %q text len >= %d", room, want)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// ── minimal WS benchmark helpers ────────────────────────────────────────
+//
+// adapter_test.go already defines dialWS/drainWS/sendV1Update in this same
+// package, but those take *testing.T (via testify's require) and can't be
+// reused from a *testing.B context. These *Bench variants are self-contained
+// (b.Fatalf instead of require) and named to avoid colliding with the
+// non-benchheavy helpers when both files compile together under -tags
+// benchheavy.
+
+func dialWSBench(b *testing.B, ts *httptest.Server, room string) *gws.Conn {
+	b.Helper()
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/" + room
+	conn, _, err := gws.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		b.Fatalf("dial %s: %v", room, err)
+	}
+	return conn
+}
+
+func drainHandshakeBench(b *testing.B, conn *gws.Conn) {
+	b.Helper()
+	for i := 0; i < 3; i++ {
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, _, err := conn.ReadMessage()
+		_ = conn.SetReadDeadline(time.Time{})
+		if err != nil {
+			b.Fatalf("drain handshake frame %d: %v", i, err)
+		}
+	}
+}
+
+func sendV1UpdateBench(b *testing.B, conn *gws.Conn, update []byte) {
+	b.Helper()
+	inner := encoding.NewEncoder()
+	inner.WriteVarUint(ygsync.MsgUpdate)
+	inner.WriteVarBytes(update)
+	outer := encoding.NewEncoder()
+	outer.WriteVarUint(0) // msgSync
+	outer.WriteRaw(inner.Bytes())
+	if err := conn.WriteMessage(gws.BinaryMessage, outer.Bytes()); err != nil {
+		b.Fatalf("write update: %v", err)
+	}
+}

--- a/persistence/scale_bench_test.go
+++ b/persistence/scale_bench_test.go
@@ -21,6 +21,7 @@
 package persistence_test
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -137,18 +138,35 @@ const persistThroughputCoalesceWindow = 50 * time.Millisecond
 //     the countingAdapter's counter, never from Server internals.
 func BenchmarkPersistThroughput_Coalescing(b *testing.B) {
 	b.Run(fmt.Sprintf("M=%d", persistThroughputM), func(b *testing.B) {
+		var totalElapsed time.Duration
+		var totalStores int64
 		for i := 0; i < b.N; i++ {
-			runPersistThroughputIteration(b)
+			elapsed, stores := runPersistThroughputIteration(b)
+			totalElapsed += elapsed
+			totalStores += stores
 		}
+		// Reported once for the whole run (b.N iterations): testing.B keeps
+		// only the last value passed to ReportMetric per unit name, so
+		// calling it per-iteration (as a prior version of this benchmark
+		// did) silently discarded every iteration but the last. Aggregating
+		// totals across all b.N iterations first and reporting once here
+		// makes both metrics reflect the full run.
+		b.ReportMetric(float64(persistThroughputM*b.N)/totalElapsed.Seconds(), "updates/s")
+		b.ReportMetric(1-float64(totalStores)/float64(persistThroughputM*b.N), "coalesce-hit-rate")
 	})
 }
 
-func runPersistThroughputIteration(b *testing.B) {
+// runPersistThroughputIteration runs one iteration of the throughput
+// workload and returns the elapsed time (send-through-flush) and the number
+// of StoreUpdate calls observed, for the caller to aggregate across all b.N
+// iterations before reporting metrics once.
+func runPersistThroughputIteration(b *testing.B) (elapsed time.Duration, stores int64) {
 	b.Helper()
 
 	counting := &countingAdapter{inner: persistence.NewLegacyAdapter(persistence.NewMemoryPersistence())}
 	s := ygws.NewServerWithPersistence(counting)
 	s.PersistCoalesceWindow = persistThroughputCoalesceWindow
+	defer func() { _ = s.Shutdown(context.Background()) }()
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
@@ -184,11 +202,9 @@ func runPersistThroughputIteration(b *testing.B) {
 	if err := s.CloseRoom(room, true); err != nil {
 		b.Fatalf("CloseRoom: %v", err)
 	}
-	elapsed := time.Since(start)
-
-	stores := atomic.LoadInt64(&counting.stores)
-	b.ReportMetric(float64(persistThroughputM)/elapsed.Seconds(), "updates/s")
-	b.ReportMetric(1-float64(stores)/float64(persistThroughputM), "coalesce-hit-rate")
+	elapsed = time.Since(start)
+	stores = atomic.LoadInt64(&counting.stores)
+	return elapsed, stores
 }
 
 // waitForDocTextLen polls the server's live, in-memory doc (an exported

--- a/provider/websocket/scale_bench_test.go
+++ b/provider/websocket/scale_bench_test.go
@@ -45,16 +45,21 @@ func dialWSBench(b *testing.B, ts *httptest.Server, room string) *gws.Conn {
 // Adapted from drainWS: this benchmark only cares that clients are fully
 // joined before timing starts, not the frame contents, so unlike drainWS it
 // does not decode/apply sync frames into a local doc.
-func drainHandshakeBench(b *testing.B, conn *gws.Conn) {
-	b.Helper()
+//
+// It returns an error rather than calling b.Fatalf directly so the caller
+// can close the partially-joined connection first — failing straight into
+// b.Fatalf here would leak the socket (never recorded anywhere for cleanup)
+// on a mid-setup failure, e.g. a tight fd ulimit at N=500.
+func drainHandshakeBench(conn *gws.Conn) error {
 	for i := 0; i < 3; i++ {
 		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		_, _, err := conn.ReadMessage()
 		_ = conn.SetReadDeadline(time.Time{})
 		if err != nil {
-			b.Fatalf("drain handshake frame %d: %v", i, err)
+			return fmt.Errorf("drain handshake frame %d: %w", i, err)
 		}
 	}
+	return nil
 }
 
 // drainLoop continuously reads (and discards) messages from conn until the
@@ -102,23 +107,39 @@ func BenchmarkBroadcastFanout(b *testing.B) {
 			defer ts.Close()
 			defer func() { _ = s.Shutdown(context.Background()) }()
 
+			// conns/doneCh are preallocated to size n, but a mid-setup failure
+			// (plausible at N=500 under a tight fd ulimit: 500 client + 500
+			// server sockets) can leave a suffix of both slices unset. joined
+			// tracks how many entries actually got a live conn + a started
+			// drainLoop goroutine; the cleanup defer below bounds itself to
+			// conns[:joined]/doneCh[:joined] so it never touches a nil *gws.Conn
+			// (which would panic in Close, crashing the whole bench binary
+			// during the b.Fatalf-triggered Goexit unwind) or blocks forever on
+			// a nil doneCh receive.
 			conns := make([]*gws.Conn, n)
 			doneCh := make([]chan struct{}, n)
+			joined := 0
 			defer func() {
-				for _, c := range conns {
-					_ = c.Close()
+				for i := 0; i < joined; i++ {
+					_ = conns[i].Close()
 				}
-				for _, d := range doneCh {
-					<-d
+				for i := 0; i < joined; i++ {
+					<-doneCh[i]
 				}
 			}()
 
 			for i := 0; i < n; i++ {
 				conn := dialWSBench(b, ts, "room")
-				drainHandshakeBench(b, conn)
+				if err := drainHandshakeBench(conn); err != nil {
+					// Not yet recorded in conns/joined, so close it here —
+					// otherwise this socket leaks past the b.Fatalf below.
+					_ = conn.Close()
+					b.Fatalf("client %d: %v", i, err)
+				}
 				conns[i] = conn
 				doneCh[i] = make(chan struct{})
 				go drainLoop(conn, doneCh[i])
+				joined++
 			}
 
 			b.ReportAllocs()

--- a/provider/websocket/scale_bench_test.go
+++ b/provider/websocket/scale_bench_test.go
@@ -1,0 +1,134 @@
+//go:build benchheavy
+
+// Package websocket benchmark for issue #180 (Task 3): server broadcast
+// fan-out. Measures the cost of Server.BroadcastUpdate as the number of
+// connected peers in the target room grows (N=10/100/500). Every peer runs
+// a reader goroutine that continuously drains its connection so the
+// server's per-peer writeCh never fills — a full writeCh would make this
+// benchmark measure back-pressure/blocking instead of pure fan-out cost.
+//
+// Run:
+//
+//	go test -tags benchheavy ./provider/websocket/ -run '^$' -bench BroadcastFanout -benchtime=1x -benchmem
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+
+	"github.com/reearth/ygo/crdt"
+)
+
+// dialWSBench opens a WebSocket connection to the test server for the given
+// room. Adapted from the dialWS helper in persistence_coalesce_test.go (and
+// mirrored in persistence/adapter_test.go) for benchmark use: takes *testing.B
+// and fails via b.Fatalf instead of require.NoError, since testify's require
+// is unavailable/unnecessary in the benchmark path.
+func dialWSBench(b *testing.B, ts *httptest.Server, room string) *gws.Conn {
+	b.Helper()
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + "/" + room
+	conn, _, err := gws.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		b.Fatalf("dial %s: %v", room, err)
+	}
+	return conn
+}
+
+// drainHandshakeBench reads and discards the three handshake frames the
+// server always sends on connect (sync step-1, sync step-2, awareness).
+// Adapted from drainWS: this benchmark only cares that clients are fully
+// joined before timing starts, not the frame contents, so unlike drainWS it
+// does not decode/apply sync frames into a local doc.
+func drainHandshakeBench(b *testing.B, conn *gws.Conn) {
+	b.Helper()
+	for i := 0; i < 3; i++ {
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, _, err := conn.ReadMessage()
+		_ = conn.SetReadDeadline(time.Time{})
+		if err != nil {
+			b.Fatalf("drain handshake frame %d: %v", i, err)
+		}
+	}
+}
+
+// drainLoop continuously reads (and discards) messages from conn until the
+// connection errors (closed locally via Close, or by the server on
+// shutdown). It must run for the lifetime of every dialed client so the
+// server's per-peer writeCh never fills during the timed broadcast loop —
+// a full writeCh would make BroadcastFanout measure slow-peer back-pressure
+// instead of fan-out cost. Closes done on exit so callers can wait for every
+// reader goroutine to unwind before tearing down the server (no goroutine
+// leaks across sub-benchmarks).
+func drainLoop(conn *gws.Conn, done chan<- struct{}) {
+	defer close(done)
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+	}
+}
+
+// seedBroadcastUpdate builds one small, deterministic V1 update — a short
+// text insert into a freshly seeded doc — used as the fixed payload every
+// BroadcastUpdate call fans out in BenchmarkBroadcastFanout.
+func seedBroadcastUpdate() []byte {
+	doc := crdt.New(crdt.WithClientID(1))
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *crdt.Transaction) {
+		txt.Insert(txn, 0, "hello benchmark", nil)
+	})
+	return crdt.EncodeStateAsUpdateV1(doc, nil)
+}
+
+// BenchmarkBroadcastFanout measures Server.BroadcastUpdate's fan-out cost to
+// a single room as the number of connected peers (N) grows. Each sub-bench
+// dials N loopback WebSocket clients into "room", drains their handshake
+// frames so they are fully joined, then times b.N BroadcastUpdate calls with
+// every client's reader goroutine draining continuously in the background.
+func BenchmarkBroadcastFanout(b *testing.B) {
+	update := seedBroadcastUpdate()
+
+	for _, n := range []int{10, 100, 500} {
+		n := n
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			s := NewServer()
+			ts := httptest.NewServer(s)
+			defer ts.Close()
+			defer func() { _ = s.Shutdown(context.Background()) }()
+
+			conns := make([]*gws.Conn, n)
+			doneCh := make([]chan struct{}, n)
+			defer func() {
+				for _, c := range conns {
+					_ = c.Close()
+				}
+				for _, d := range doneCh {
+					<-d
+				}
+			}()
+
+			for i := 0; i < n; i++ {
+				conn := dialWSBench(b, ts, "room")
+				drainHandshakeBench(b, conn)
+				conns[i] = conn
+				doneCh[i] = make(chan struct{})
+				go drainLoop(conn, doneCh[i])
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := s.BroadcastUpdate(context.Background(), "room", update); err != nil {
+					b.Fatalf("BroadcastUpdate: %v", err)
+				}
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/provider/websocket/scale_probe_test.go
+++ b/provider/websocket/scale_probe_test.go
@@ -1,0 +1,88 @@
+//go:build benchheavy
+
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestScaleProbe is a measurement harness, not a benchmark: for each room
+// count N it creates N rooms directly via getOrCreateRoom (bypassing real
+// peer connections), forces a GC, and logs heap/sys memory, goroutine count,
+// and RSS (Linux only, via /proc/self/status) for that size. It exists to
+// spot O(rooms) growth in server-side resource usage as room count scales.
+//
+// This is deliberately not a pass/fail assertion on the numbers themselves —
+// normal fluctuation in heap/goroutine counts across Go versions/GOMAXPROCS
+// is expected and not a regression. It only fails (via t.Fatalf) on a
+// genuine room-creation error.
+//
+// Run: go test -tags benchheavy ./provider/websocket/ -run TestScaleProbe -v
+// Smoke override (smaller, single size): SCALE_PROBE_N=200 go test -tags
+// benchheavy ./provider/websocket/ -run TestScaleProbe -v
+func TestScaleProbe(t *testing.T) {
+	sizes := []int{1000, 10000}
+	if v := os.Getenv("SCALE_PROBE_N"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			t.Fatalf("SCALE_PROBE_N=%q must be a positive integer", v)
+		}
+		sizes = []int{n}
+	}
+
+	ctx := context.Background()
+	t.Logf("%-8s %-13s %-8s %-10s %s", "rooms", "heapAllocMiB", "sysMiB", "goroutines", "rss")
+	for _, n := range sizes {
+		s := NewServer()
+		for i := 0; i < n; i++ {
+			if _, _, err := s.getOrCreateRoom(ctx, fmt.Sprintf("room-%d", i)); err != nil {
+				t.Fatalf("room %d: %v", i, err)
+			}
+		}
+
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		t.Logf("%-8d %-13d %-8d %-10d %s",
+			n, m.HeapAlloc>>20, m.Sys>>20, runtime.NumGoroutine(), readRSS())
+
+		// Isolate this size from the next one: Shutdown releases the server's
+		// peer/relay/persistence goroutines (there are none here, since
+		// getOrCreateRoom bypasses real peer connections and this server has no
+		// persistence/relay configured), and letting s go out of scope at the
+		// end of this iteration plus a forced GC reclaims the rooms/docs
+		// themselves, so consecutive sizes don't accumulate memory or
+		// goroutines from prior iterations.
+		if err := s.Shutdown(ctx); err != nil {
+			t.Logf("shutdown (size %d): %v", n, err)
+		}
+		runtime.GC()
+	}
+}
+
+// readRSS returns the process's resident set size (VmRSS) from
+// /proc/self/status on Linux, or "n/a" if that file doesn't exist (e.g. on
+// macOS) or the VmRSS line can't be found/parsed.
+func readRSS() string {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return "n/a"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "VmRSS:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return "n/a"
+		}
+		return strings.Join(fields[1:], "")
+	}
+	return "n/a"
+}


### PR DESCRIPTION
## Summary

Establishes the honest performance + scalability benchmark suite from #180 (the P2 precondition of epic #189) — turning ygo's perf claims from *argued* to *measured*. **Test/docs/CI only: zero production code changed.**

A single `//go:build benchheavy` tag splits a fast **light tier** (runs on the existing PR benchmark gate) from a **heavy tier** (nightly + manual). Engine scenarios are pinned to `dmonad/crdt-benchmarks` op definitions so a native yjs/yrs comparison is a drop-in later (filed as #195).

### What's added
- **Engine (`crdt/`):** slow-path light benches the old fast-path ones missed — prepend, random-position insert, insert-then-delete, word-insert, mixed, `Format`, `ApplyDelta`, and an observed-transaction pair (± active `Observe`r). Heavy tier: 100k-node random access (`YArray.Get`, `YText` random insert/delete) + B2/B3 concurrent-conflict (bounded to CI-safe sizes).
- **Server (`provider/websocket/`):** `BenchmarkBroadcastFanout` (N=10/100/500, in-process loopback WS) + a `TestScaleProbe` harness reporting heap/goroutines (+ Linux RSS) at 1k/10k rooms.
- **Persistence (`persistence/`):** `MemoryPersistence` flush-cost-vs-doc-size (surfaces the superlinear merge-per-flush baseline that #186 will improve) + sustained-edit throughput & coalesce-hit-rate via a counting adapter (no production instrumentation).
- **Cluster (`cluster/`):** `MemRelay` fan-out + a backpressure sub-bench (honestly labeled "publish-timeouts" — MemRelay blocks rather than drops; real drop-on-full is #196, landing with #187).
- **`BENCHMARKS.md`:** methodology, named reference machine, the three run tiers, and real measured numbers (large capacity-planning tiers explicitly marked "run on target hardware" — no invented numbers).
- **CI (`benchmark.yml`):** PR gate unchanged; heavy tier + scale probe run nightly **and** on manual `workflow_dispatch`, artifacts uploaded. `make bench-heavy` added.

### Honesty notes (this suite is about not overclaiming)
- Flush cost documented as **superlinear, not strict O(doc²)** (ygo's `MergeUpdatesV1` is struct-level dedup) — matches what was measured.
- The MemRelay backpressure metric is **publish-timeouts**, not "drops" — MemRelay has no drop-on-full path by design.
- The yjs/yrs cross-impl comparison is a **documented stub**, not fabricated — see #195.

## Testing
- `go build ./...`, `go test ./...` (default build) — all pass.
- Whole suite compiles + runs under `-tags benchheavy`; `-race` clean on the concurrency-bearing benches (fan-out, relay).
- `golangci-lint` clean. `git diff` vs base = only `*_test.go`, `BENCHMARKS.md`, `benchmark.yml`, `Makefile` — no production `.go`.
- Built subagent-driven with per-task + whole-branch review.

## Follow-ups filed
- #195 — native yjs/yrs cross-impl comparison on one machine.
- #196 — real-Redis relay round-trip + drop-rate benchmark (with #187).

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
