### PR TITLE
feat(persistence,websocket): labelled snapshots, room enumeration, and auto-versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read state blobs so listing stays cheap. The older name-keyed pair is
   unchanged and still supported, but is superseded for new code.
 
+- **`RoomLister`: store-wide room enumeration** (`persistence/rooms.go`): a new
+  optional `ListRooms` extension implemented by the memory, file and sqlite
+  backends, with its own conformance suite. `VersionedPersistence` could only be
+  addressed one room at a time, so store-wide retention, cleanup, migration and
+  reconciliation all required an external index of room names with no way to
+  detect drift against what was actually persisted. It reports every room holding
+  at least one update or snapshot, so a snapshot-only room stays reclaimable, and
+  returns the original room name rather than a backend's on-disk encoding.
+
+- **Auto-versioning: `VersionableAdapter` + `Server.AutoVersionEvery`**
+  (`provider/websocket`): the server can now drive a user-facing version history
+  itself instead of leaving every application to build one. When the persistence
+  adapter implements `VersionableAdapter` and `AutoVersionEvery > 0`, the server
+  asks it to capture a labelled version (`AutoVersionLabel`, `"auto"`) at most
+  once per interval per room, **and only when the room actually changed**, plus
+  once on room unload if it changed after the last version. A quiet room is never
+  versioned. That pairing is the point: versioning per update is what makes a
+  history panel unusable.
+
+  `persistence.LegacyAdapter` implements it over `SnapshotStore`, with a new
+  `KeepSnapshots` field bounding retained versions (0 = keep all, matching
+  `KeepVersions`, which is the separate update-log axis). A store without
+  `SnapshotStore` support returns the new `ErrSnapshotsUnsupported` rather than
+  silently discarding versions.
+
+  The hook lives in the persistence worker's `store()` helper, so both the
+  coalescing and the strict per-update paths are covered without touching either
+  select loop, and all of its state is owned by that one goroutine.
+
 ### Fixed
 
 - **sqlite `Delete(room)` now also removes labelled snapshots**: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.41.0] — 2026-07-30
 
 ### Added
 
@@ -63,12 +63,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coalescing and the strict per-update paths are covered without touching either
   select loop, and all of its state is owned by that one goroutine.
 
+### Performance
+
+- **`FilePersistence.ListSnapshots` no longer reads snapshot state blobs**: it
+  read each record in full via `os.ReadFile` just to report metadata, making
+  listing O(total snapshot bytes) and contradicting the `SnapshotStore` contract's
+  promise that listing stays cheap. It now reads only the 12-byte header plus the
+  label and derives `Size` from the directory entry, so listing is O(records).
+
 ### Fixed
 
 - **sqlite `Delete(room)` now also removes labelled snapshots**: the
   `snapshot_versions` rows for a room survived a room delete, contrary to the
   documented "removes all data for room" contract. The memory and file backends
   were already correct. Caught by the new conformance suite.
+
+### Testing
+
+- **Honest performance and scalability benchmark suite**
+  ([#180](https://github.com/reearth/ygo/issues/180)): the full
+  `dmonad/crdt-benchmarks` B1-B4 set plus cluster-relay, persistence and
+  websocket scale benchmarks, a `benchmark` CI workflow, and `BENCHMARKS.md`
+  publishing the results with their caveats rather than only the flattering
+  numbers.
+
+- Two new shared conformance suites, `RunSnapshotStoreConformance` and
+  `RunRoomListerConformance`, run against all three backends so a third-party
+  backend can self-verify the new contracts.
 
 ## [1.40.0] — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+
+- **`SnapshotStore`: enumerable, individually-deletable labelled snapshots**
+  (`persistence/snapshots.go`): a new optional extension interface with
+  `SaveSnapshot`/`ListSnapshots`/`GetSnapshotState`/`DeleteSnapshot`, plus
+  `SnapshotInfo{ID, Label, CreatedAt, Size}` and
+  `SnapshotVersionedPersistence`. Implemented by the memory, file, and sqlite
+  backends and covered by a new shared conformance suite
+  (`RunSnapshotStoreConformance`).
+
+  This closes a lifecycle gap in the existing name-keyed
+  `CaptureSnapshot`/`RestoreSnapshot` pair, which could be written and read by
+  exact name but **not enumerated, not individually deleted, and carried no
+  metadata** — making labelled snapshots an unbounded, unreclaimable resource
+  that only `Delete(room)` could clear. Applications building a user-facing
+  version history needed all four operations, and previously had to maintain
+  their own parallel index with no way to reconcile it against storage.
+
+  Snapshots are ID-keyed with **non-unique** labels, so repeated saves under the
+  same label create distinct snapshots instead of overwriting. IDs are unique
+  and monotonic *within a room* and are never reused there, but are not
+  guaranteed globally unique — always carry the room alongside the ID.
+  `ListSnapshots` returns newest-first, matching `ListVersions`, and does not
+  read state blobs so listing stays cheap. The older name-keyed pair is
+  unchanged and still supported, but is superseded for new code.
+
+### Fixed
+
+- **sqlite `Delete(room)` now also removes labelled snapshots**: the
+  `snapshot_versions` rows for a room survived a room delete, contrary to the
+  documented "removes all data for room" contract. The memory and file backends
+  were already correct. Caught by the new conformance suite.
+
 ## [1.40.0] — 2026-07-28
 
 ### Fixed
@@ -80,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   how many idle-resident rooms stay warm at once — once the count exceeds it,
   a background sweeper evicts the least-recently-idle rooms first; zero is
   unbounded and only meaningful together with `RoomIdleTimeout > 0`.
+
 
 ## [1.38.0] — 2026-07-24
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,86 @@
+## v1.41.0
+
+Three additions that together let an application build a real, bounded,
+user-facing version history instead of hand-rolling one, plus a published
+benchmark suite. Labelled snapshots can now be enumerated and individually
+deleted, a store can report which rooms it holds, and the websocket server can
+capture versions on its own on a throttled, change-driven cadence. All three are
+optional extension interfaces, so no existing interface gained a method and
+every third-party backend keeps compiling. Everything is off by default. No
+breaking API changes.
+
+### Added
+
+- **`SnapshotStore`: enumerable, individually-deletable labelled snapshots.** The
+  existing name-keyed `CaptureSnapshot`/`RestoreSnapshot` pair could be written
+  and read by exact name but never enumerated, never individually deleted, and
+  carried no metadata, so labelled snapshots were an unbounded, unreclaimable
+  resource that only `Delete(room)` could clear. New interface:
+  `SaveSnapshot`/`ListSnapshots`/`GetSnapshotState`/`DeleteSnapshot`, plus
+  `SnapshotInfo{ID, Label, CreatedAt, Size}` and `SnapshotVersionedPersistence`.
+  Snapshots are ID-keyed with non-unique labels, so repeated saves create distinct
+  versions rather than overwriting. IDs are unique and monotonic within a room and
+  never reused there, but are not globally unique. `ListSnapshots` is newest-first
+  and never reads state blobs. The older name-keyed pair is unchanged and still
+  supported, superseded for new code.
+
+- **`RoomLister`: store-wide room enumeration.** `VersionedPersistence` could only
+  be addressed one room at a time, so store-wide retention, cleanup, migration and
+  reconciliation all needed an external index of room names with no way to detect
+  drift against what was actually persisted. `ListRooms` reports every room
+  holding at least one update or snapshot, so a snapshot-only room stays
+  reclaimable, and returns the original room name rather than a backend's on-disk
+  encoding.
+
+- **Auto-versioning: `VersionableAdapter` + `Server.AutoVersionEvery`.** The
+  server can now drive a version history itself. When the adapter implements
+  `VersionableAdapter` and `AutoVersionEvery > 0`, it captures a labelled version
+  (`AutoVersionLabel`, `"auto"`) at most once per interval per room **and only
+  when the room actually changed**, plus one final version on room unload if it
+  changed after the last one. A quiet room is never versioned. That pairing is the
+  point: versioning per update is what makes a history panel unusable.
+  `persistence.LegacyAdapter` implements it over `SnapshotStore` and gains
+  `KeepSnapshots` to bound retained versions (0 = keep all, mirroring
+  `KeepVersions`, which is the separate update-log axis). A store lacking
+  `SnapshotStore` returns the new `ErrSnapshotsUnsupported` rather than silently
+  discarding versions, so a misconfiguration is visible instead of appearing to
+  work.
+
+### Performance
+
+- **`FilePersistence.ListSnapshots` no longer reads snapshot state blobs.** It
+  read each record in full just to report metadata, making listing O(total
+  snapshot bytes) and contradicting the `SnapshotStore` contract's own promise
+  that listing stays cheap. It now reads only the 12-byte header plus the label
+  and derives `Size` from the directory entry.
+
+### Fixed
+
+- **sqlite `Delete(room)` now also removes labelled snapshots.** The
+  `snapshot_versions` rows for a room survived a room delete, contrary to the
+  documented "removes all data for room" contract. The memory and file backends
+  were already correct. Caught by the new conformance suite.
+
+### Testing
+
+- **Honest performance and scalability benchmark suite**
+  ([#180](https://github.com/reearth/ygo/issues/180)): the full
+  `dmonad/crdt-benchmarks` B1-B4 set plus cluster-relay, persistence and websocket
+  scale benchmarks, a `benchmark` CI workflow, and `BENCHMARKS.md` publishing the
+  results with their caveats rather than only the flattering numbers.
+
+- Two new shared conformance suites, `RunSnapshotStoreConformance` and
+  `RunRoomListerConformance`, run against all three backends so a third-party
+  backend can self-verify the new contracts.
+
+## Install
+
+```
+go get github.com/reearth/ygo@v1.41.0
+```
+
+See [CHANGELOG.md](https://github.com/reearth/ygo/blob/main/CHANGELOG.md) for full details.
+
 ## v1.40.0
 
 Two convergence/lifecycle fixes plus new fuzz coverage. `YArray.Move` could

--- a/persistence/adapter.go
+++ b/persistence/adapter.go
@@ -1,6 +1,9 @@
 package persistence
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // LegacyAdapter adapts a VersionedPersistence to the provider/websocket
 // PersistenceAdapter contract (LoadDoc / StoreUpdate), so a versioned store can
@@ -27,7 +30,23 @@ type LegacyAdapter struct {
 	// trim to the newest KeepVersions updates on each compaction. Adapter-side
 	// retention policy; set before serving.
 	KeepVersions int
+
+	// KeepSnapshots bounds retained labelled snapshots when the websocket server
+	// asks the adapter to save a version (see the provider's VersionableAdapter /
+	// AutoVersionEvery). 0 (default) keeps every version, matching KeepVersions.
+	// Set > 0 to trim to the newest KeepSnapshots after each save, so an
+	// always-connected document cannot grow an unbounded history.
+	//
+	// Note this is retention over VERSIONS (SnapshotStore entries), which is a
+	// different axis from KeepVersions' retention over the raw update log.
+	KeepSnapshots int
 }
+
+// ErrSnapshotsUnsupported is returned by LegacyAdapter.SaveVersion when the
+// wrapped store does not implement SnapshotStore, so there is nowhere to record
+// a version. It is surfaced rather than ignored: silently discarding versions
+// would look like auto-versioning is working when it is not.
+var ErrSnapshotsUnsupported = errors.New("persistence: store does not implement SnapshotStore")
 
 // NewLegacyAdapter wraps store. The provider's LoadDoc/StoreUpdate are
 // context-free; the adapter uses context.Background() for the underlying calls.
@@ -85,4 +104,53 @@ func (a *LegacyAdapter) Compact(ctx context.Context, room string) error {
 // legacy provider integration.
 func (a *LegacyAdapter) Store() VersionedPersistence {
 	return a.store
+}
+
+// SaveVersion satisfies the provider's optional VersionableAdapter interface. It
+// materializes the room's current head and records it as a labelled snapshot via
+// the wrapped store's SnapshotStore, then applies KeepSnapshots retention.
+//
+// An empty room is a no-op returning (0, nil): there is no state worth
+// versioning, and creating an empty version on every idle room would be exactly
+// the history noise auto-versioning exists to avoid.
+//
+// Retention failures are deliberately NOT propagated: the version is already
+// durable at that point, and reporting an error would make the provider log a
+// failure for an operation that actually succeeded. A trim that does not happen
+// is retried after the next save.
+func (a *LegacyAdapter) SaveVersion(ctx context.Context, room, label string) (int64, error) {
+	ss, ok := a.store.(SnapshotStore)
+	if !ok {
+		return 0, ErrSnapshotsUnsupported
+	}
+	res, err := a.store.Load(ctx, room)
+	if err != nil {
+		return 0, err
+	}
+	if len(res.Update) == 0 {
+		return 0, nil
+	}
+	id, err := ss.SaveSnapshot(ctx, room, label, res.Update)
+	if err != nil {
+		return 0, err
+	}
+	a.trimSnapshots(ctx, ss, room)
+	return id, nil
+}
+
+// trimSnapshots deletes the oldest snapshots beyond KeepSnapshots. Best-effort:
+// see the SaveVersion doc for why errors are swallowed.
+func (a *LegacyAdapter) trimSnapshots(ctx context.Context, ss SnapshotStore, room string) {
+	if a.KeepSnapshots <= 0 {
+		return
+	}
+	snaps, err := ss.ListSnapshots(ctx, room)
+	if err != nil || len(snaps) <= a.KeepSnapshots {
+		return
+	}
+	// ListSnapshots is newest-first, so everything at or past KeepSnapshots is
+	// surplus.
+	for _, sn := range snaps[a.KeepSnapshots:] {
+		_ = ss.DeleteSnapshot(ctx, room, sn.ID)
+	}
 }

--- a/persistence/adapter_version_test.go
+++ b/persistence/adapter_version_test.go
@@ -1,0 +1,133 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/persistence"
+)
+
+// seedRoom appends n edits to room and returns the expected text length.
+func seedRoom(t *testing.T, store persistence.VersionedPersistence, room string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	doc := crdt.New()
+	txt := doc.GetText("t")
+	for i := 0; i < n; i++ {
+		before := crdt.EncodeStateVectorV1(doc)
+		doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "x", nil) })
+		sv, err := crdt.DecodeStateVectorV1(before)
+		require.NoError(t, err)
+		diff := crdt.EncodeStateAsUpdateV1(doc, sv)
+		_, err = store.AppendUpdate(ctx, room, diff)
+		require.NoError(t, err)
+	}
+}
+
+// SaveVersion captures the room's current head as an enumerable labelled
+// snapshot whose state materializes back to that head.
+func TestLegacyAdapterSaveVersion_CapturesHead(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+
+	seedRoom(t, store, "room", 3)
+
+	id, err := a.SaveVersion(ctx, "room", "before-migration")
+	require.NoError(t, err)
+	assert.NotZero(t, id, "a non-empty room yields a real snapshot id")
+
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	assert.Equal(t, "before-migration", snaps[0].Label)
+	assert.Equal(t, id, snaps[0].ID)
+
+	// The stored state must reconstruct the same document.
+	state, err := store.GetSnapshotState(ctx, "room", id)
+	require.NoError(t, err)
+	got := crdt.New()
+	require.NoError(t, crdt.ApplyUpdateV1(got, state, nil))
+	assert.Equal(t, 3, got.GetText("t").Len())
+}
+
+// An empty room has no state worth versioning: no snapshot, no error.
+func TestLegacyAdapterSaveVersion_EmptyRoomIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+
+	id, err := a.SaveVersion(ctx, "empty", "lbl")
+	require.NoError(t, err)
+	assert.Zero(t, id, "empty room yields no snapshot")
+
+	snaps, err := store.ListSnapshots(ctx, "empty")
+	require.NoError(t, err)
+	assert.Empty(t, snaps)
+}
+
+// KeepSnapshots bounds retention: the oldest auto versions are trimmed so the
+// history cannot grow without limit.
+func TestLegacyAdapterSaveVersion_KeepSnapshotsRetention(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+	a.KeepSnapshots = 2
+
+	seedRoom(t, store, "room", 1)
+
+	var ids []int64
+	for i := 0; i < 5; i++ {
+		id, err := a.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	require.Len(t, snaps, 2, "retention should keep only the newest KeepSnapshots")
+	// Newest-first: the two most recent ids survive.
+	assert.Equal(t, ids[4], snaps[0].ID)
+	assert.Equal(t, ids[3], snaps[1].ID)
+}
+
+// KeepSnapshots == 0 (default) keeps everything, matching KeepVersions.
+func TestLegacyAdapterSaveVersion_ZeroKeepsAll(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+
+	seedRoom(t, store, "room", 1)
+	for i := 0; i < 4; i++ {
+		_, err := a.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+	}
+
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	assert.Len(t, snaps, 4, "KeepSnapshots=0 must retain every version")
+}
+
+// bareStore is a VersionedPersistence that does NOT implement SnapshotStore, so
+// SaveVersion has nowhere to put a version.
+type bareStore struct {
+	persistence.VersionedPersistence
+}
+
+// A store without snapshot support must report the misconfiguration rather than
+// silently discarding versions.
+func TestLegacyAdapterSaveVersion_UnsupportedStoreErrors(t *testing.T) {
+	ctx := context.Background()
+	inner := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(bareStore{VersionedPersistence: inner})
+
+	seedRoom(t, inner, "room", 1)
+
+	_, err := a.SaveVersion(ctx, "room", "lbl")
+	assert.ErrorIs(t, err, persistence.ErrSnapshotsUnsupported,
+		"a store without SnapshotStore must report the misconfiguration")
+}

--- a/persistence/file.go
+++ b/persistence/file.go
@@ -587,3 +587,166 @@ func (f *FilePersistence) Delete(ctx context.Context, room string) error {
 	defer f.mu.Unlock()
 	return os.RemoveAll(f.roomDir(room))
 }
+
+// snapVersionsDir holds SnapshotStore entries: <id>.bin per snapshot plus a
+// "nextid" file so ids are not reused after a delete.
+func (f *FilePersistence) snapVersionsDir(room string) string {
+	return filepath.Join(f.roomDir(room), "snapversions")
+}
+
+func (f *FilePersistence) snapVersionPath(room string, id int64) string {
+	return filepath.Join(f.snapVersionsDir(room), strconv.FormatInt(id, 10)+".bin")
+}
+
+func (f *FilePersistence) snapNextIDPath(room string) string {
+	return filepath.Join(f.snapVersionsDir(room), "nextid")
+}
+
+// encodeSnapVersion frames a snapshot as
+// [8 createdAt unix-nano][4 labelLen][label][state].
+func encodeSnapVersion(createdAt time.Time, label string, state []byte) []byte {
+	lb := []byte(label)
+	buf := make([]byte, 8+4+len(lb)+len(state))
+	binary.BigEndian.PutUint64(buf[:8], uint64(createdAt.UnixNano()))
+	binary.BigEndian.PutUint32(buf[8:12], uint32(len(lb)))
+	copy(buf[12:], lb)
+	copy(buf[12+len(lb):], state)
+	return buf
+}
+
+// decodeSnapVersion is encodeSnapVersion's inverse.
+func decodeSnapVersion(buf []byte) (createdAt time.Time, label string, state []byte, err error) {
+	if len(buf) < 12 {
+		return time.Time{}, "", nil, fmt.Errorf("persistence: snapshot record too short (%d bytes)", len(buf))
+	}
+	createdAt = time.Unix(0, int64(binary.BigEndian.Uint64(buf[:8]))).UTC()
+	n := int(binary.BigEndian.Uint32(buf[8:12]))
+	if 12+n > len(buf) {
+		return time.Time{}, "", nil, fmt.Errorf("persistence: snapshot label length %d exceeds record", n)
+	}
+	label = string(buf[12 : 12+n])
+	state = buf[12+n:]
+	return createdAt, label, state, nil
+}
+
+// readSnapNextID returns the next id to assign (1 when unset). Caller holds mu.
+func (f *FilePersistence) readSnapNextID(room string) (int64, error) {
+	b, err := os.ReadFile(f.snapNextIDPath(room))
+	if errors.Is(err, os.ErrNotExist) {
+		return 1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if len(b) < 8 {
+		return 1, nil
+	}
+	id := int64(binary.BigEndian.Uint64(b[:8]))
+	if id < 1 {
+		id = 1
+	}
+	return id, nil
+}
+
+// SaveSnapshot stores state as a new labelled snapshot and returns its ID.
+func (f *FilePersistence) SaveSnapshot(ctx context.Context, room, label string, state []byte) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(state) == 0 {
+		return 0, ErrEmptySnapshot
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := os.MkdirAll(f.snapVersionsDir(room), 0o755); err != nil {
+		return 0, err
+	}
+	id, err := f.readSnapNextID(room)
+	if err != nil {
+		return 0, err
+	}
+	// Bump the counter BEFORE writing the record: a crash in between leaks an id
+	// (harmless) rather than risking two snapshots sharing one.
+	var next [8]byte
+	binary.BigEndian.PutUint64(next[:], uint64(id+1))
+	if err := atomicWrite(f.snapNextIDPath(room), next[:]); err != nil {
+		return 0, err
+	}
+	rec := encodeSnapVersion(time.Now().UTC(), label, state)
+	if err := atomicWrite(f.snapVersionPath(room, id), rec); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// ListSnapshots returns snapshot metadata newest-first.
+func (f *FilePersistence) ListSnapshots(ctx context.Context, room string) ([]SnapshotInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entries, err := os.ReadDir(f.snapVersionsDir(room))
+	if errors.Is(err, os.ErrNotExist) {
+		return []SnapshotInfo{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SnapshotInfo, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".bin") {
+			continue
+		}
+		id, perr := strconv.ParseInt(strings.TrimSuffix(e.Name(), ".bin"), 10, 64)
+		if perr != nil {
+			continue
+		}
+		b, rerr := os.ReadFile(f.snapVersionPath(room, id))
+		if rerr != nil {
+			return nil, rerr
+		}
+		createdAt, label, state, derr := decodeSnapVersion(b)
+		if derr != nil {
+			return nil, derr
+		}
+		out = append(out, SnapshotInfo{ID: id, Label: label, CreatedAt: createdAt, Size: int64(len(state))})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID }) // newest first
+	return out, nil
+}
+
+// GetSnapshotState returns one snapshot's state blob.
+func (f *FilePersistence) GetSnapshotState(ctx context.Context, room string, id int64) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b, err := os.ReadFile(f.snapVersionPath(room, id))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, ErrSnapshotNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	_, _, state, err := decodeSnapVersion(b)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), state...), nil
+}
+
+// DeleteSnapshot removes one snapshot. Deleting an unknown snapshot is a no-op.
+func (f *FilePersistence) DeleteSnapshot(ctx context.Context, room string, id int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	err := os.Remove(f.snapVersionPath(room, id))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/persistence/file.go
+++ b/persistence/file.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -629,6 +630,34 @@ func decodeSnapVersion(buf []byte) (createdAt time.Time, label string, state []b
 	return createdAt, label, state, nil
 }
 
+// readSnapVersionMeta reads ONLY a snapshot record's header and label, deriving
+// the state size from fileSize rather than reading the state blob. This is what
+// keeps ListSnapshots cheap (O(records), not O(total snapshot bytes)) as the
+// SnapshotStore contract promises; decodeSnapVersion is still used by
+// GetSnapshotState, which genuinely needs the payload.
+func readSnapVersionMeta(path string, fileSize int64) (time.Time, string, int64, error) {
+	fh, err := os.Open(path) //nolint:gosec // path is built from our own layout
+	if err != nil {
+		return time.Time{}, "", 0, err
+	}
+	defer func() { _ = fh.Close() }()
+
+	var hdr [12]byte
+	if _, err := io.ReadFull(fh, hdr[:]); err != nil {
+		return time.Time{}, "", 0, fmt.Errorf("persistence: snapshot record %q header: %w", path, err)
+	}
+	createdAt := time.Unix(0, int64(binary.BigEndian.Uint64(hdr[:8]))).UTC()
+	labelLen := int64(binary.BigEndian.Uint32(hdr[8:12]))
+	if int64(len(hdr))+labelLen > fileSize {
+		return time.Time{}, "", 0, fmt.Errorf("persistence: snapshot label length %d exceeds record %q", labelLen, path)
+	}
+	label := make([]byte, labelLen)
+	if _, err := io.ReadFull(fh, label); err != nil {
+		return time.Time{}, "", 0, fmt.Errorf("persistence: snapshot record %q label: %w", path, err)
+	}
+	return createdAt, string(label), fileSize - int64(len(hdr)) - labelLen, nil
+}
+
 // readSnapNextID returns the next id to assign (1 when unset). Caller holds mu.
 func (f *FilePersistence) readSnapNextID(room string) (int64, error) {
 	b, err := os.ReadFile(f.snapNextIDPath(room))
@@ -702,15 +731,16 @@ func (f *FilePersistence) ListSnapshots(ctx context.Context, room string) ([]Sna
 		if perr != nil {
 			continue
 		}
-		b, rerr := os.ReadFile(f.snapVersionPath(room, id))
-		if rerr != nil {
-			return nil, rerr
+		// Size comes from the directory entry, so the state blob is never read.
+		fi, ierr := e.Info()
+		if ierr != nil {
+			return nil, ierr
 		}
-		createdAt, label, state, derr := decodeSnapVersion(b)
+		createdAt, label, size, derr := readSnapVersionMeta(f.snapVersionPath(room, id), fi.Size())
 		if derr != nil {
 			return nil, derr
 		}
-		out = append(out, SnapshotInfo{ID: id, Label: label, CreatedAt: createdAt, Size: int64(len(state))})
+		out = append(out, SnapshotInfo{ID: id, Label: label, CreatedAt: createdAt, Size: size})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID }) // newest first
 	return out, nil

--- a/persistence/file.go
+++ b/persistence/file.go
@@ -750,3 +750,33 @@ func (f *FilePersistence) DeleteSnapshot(ctx context.Context, room string, id in
 	}
 	return nil
 }
+
+// ListRooms returns every room directory under the root, decoding the on-disk
+// hex names back to the original room names.
+func (f *FilePersistence) ListRooms(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entries, err := os.ReadDir(f.root)
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Room dirs are hex(roomName); anything else is not ours.
+		raw, derr := hex.DecodeString(e.Name())
+		if derr != nil {
+			continue
+		}
+		out = append(out, string(raw))
+	}
+	return out, nil
+}

--- a/persistence/memory.go
+++ b/persistence/memory.go
@@ -496,3 +496,22 @@ func (m *MemoryPersistence) DeleteSnapshot(ctx context.Context, room string, id 
 	}
 	return nil
 }
+
+// ListRooms returns every room holding at least one update or snapshot.
+func (m *MemoryPersistence) ListRooms(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.rooms))
+	for name, r := range m.rooms {
+		// Skip a room whose entry exists but holds nothing (e.g. pruned to empty):
+		// the contract is "has persisted data", not "was ever touched".
+		if len(r.records) == 0 && len(r.snapshots) == 0 && len(r.snapVersions) == 0 {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out, nil
+}

--- a/persistence/memory.go
+++ b/persistence/memory.go
@@ -38,11 +38,24 @@ type memRoom struct {
 	// the room after a prune so Load reflects target state even if a crash left
 	// stale records behind.
 	rolledBack []byte
+	// snapVersions holds SnapshotStore entries ascending by id. nextSnapID is
+	// monotonic and never rewound, so an id is not reused after a delete.
+	snapVersions []labelledSnapshot
+	nextSnapID   int64
 }
 
 type snapshot struct {
 	state   []byte
 	version Version
+}
+
+// labelledSnapshot is one SnapshotStore entry: ID-keyed, with a non-unique
+// label, independent of the update log.
+type labelledSnapshot struct {
+	id        int64
+	label     string
+	createdAt time.Time
+	state     []byte
 }
 
 // MemoryPersistence is an in-memory VersionedPersistence. It is the reference
@@ -89,7 +102,7 @@ func (r *memRoom) visibleRecords() []record {
 func (m *MemoryPersistence) getRoom(room string) *memRoom {
 	r, ok := m.rooms[room]
 	if !ok {
-		r = &memRoom{nextVer: 1, snapshots: make(map[string]snapshot)}
+		r = &memRoom{nextVer: 1, snapshots: make(map[string]snapshot), nextSnapID: 1}
 		m.rooms[room] = r
 	}
 	return r
@@ -396,5 +409,90 @@ func (m *MemoryPersistence) Delete(ctx context.Context, room string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.rooms, room)
+	return nil
+}
+
+// SaveSnapshot stores state as a new labelled snapshot and returns its ID.
+func (m *MemoryPersistence) SaveSnapshot(ctx context.Context, room, label string, state []byte) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(state) == 0 {
+		return 0, ErrEmptySnapshot
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.getRoom(room)
+	id := r.nextSnapID
+	r.nextSnapID++
+	r.snapVersions = append(r.snapVersions, labelledSnapshot{
+		id:        id,
+		label:     label,
+		createdAt: time.Now().UTC(),
+		state:     append([]byte(nil), state...),
+	})
+	return id, nil
+}
+
+// ListSnapshots returns snapshot metadata newest-first.
+func (m *MemoryPersistence) ListSnapshots(ctx context.Context, room string) ([]SnapshotInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.rooms[room]
+	if !ok {
+		return []SnapshotInfo{}, nil
+	}
+	out := make([]SnapshotInfo, 0, len(r.snapVersions))
+	for i := len(r.snapVersions) - 1; i >= 0; i-- { // newest first
+		s := r.snapVersions[i]
+		out = append(out, SnapshotInfo{
+			ID:        s.id,
+			Label:     s.label,
+			CreatedAt: s.createdAt,
+			Size:      int64(len(s.state)),
+		})
+	}
+	return out, nil
+}
+
+// GetSnapshotState returns one snapshot's state blob.
+func (m *MemoryPersistence) GetSnapshotState(ctx context.Context, room string, id int64) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.rooms[room]
+	if !ok {
+		return nil, ErrSnapshotNotFound
+	}
+	for _, s := range r.snapVersions {
+		if s.id == id {
+			return append([]byte(nil), s.state...), nil
+		}
+	}
+	return nil, ErrSnapshotNotFound
+}
+
+// DeleteSnapshot removes one snapshot. Deleting an unknown snapshot is a no-op.
+func (m *MemoryPersistence) DeleteSnapshot(ctx context.Context, room string, id int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.rooms[room]
+	if !ok {
+		return nil
+	}
+	for i, s := range r.snapVersions {
+		if s.id == id {
+			r.snapVersions = append(r.snapVersions[:i], r.snapVersions[i+1:]...)
+			return nil
+		}
+	}
 	return nil
 }

--- a/persistence/rooms.go
+++ b/persistence/rooms.go
@@ -1,0 +1,35 @@
+package persistence
+
+import "context"
+
+// RoomLister is the optional room-enumeration extension of VersionedPersistence.
+// A backend that implements it can report which rooms it holds data for, which
+// is what an operator needs in order to run retention, cleanup, migration, or
+// reconciliation across a whole store rather than one room at a time.
+//
+// Without it, a caller has to keep its own external index of room names and has
+// no way to detect drift between that index and what is actually persisted.
+//
+// Method contract:
+//
+//   - ListRooms returns the name of every room the store holds data for, meaning
+//     at least one stored update or at least one snapshot. Order is UNSPECIFIED:
+//     sort the result if you need determinism. Returns an empty slice (not an
+//     error) for an empty store.
+//
+// RoomLister deliberately does not embed VersionedPersistence, so adding it does
+// not break existing third-party backends; implement it only if enumeration is
+// cheap for the backend. Callers should type-assert for it.
+//
+// Enumeration may be O(rooms) and is not a hot path: treat it as an
+// administrative operation, not something to call per request.
+type RoomLister interface {
+	ListRooms(ctx context.Context) ([]string, error)
+}
+
+// Compile-time assertions that the in-tree backends can enumerate rooms.
+// (sqlite asserts the same in its own package.)
+var (
+	_ RoomLister = (*MemoryPersistence)(nil)
+	_ RoomLister = (*FilePersistence)(nil)
+)

--- a/persistence/rooms_conformance.go
+++ b/persistence/rooms_conformance.go
@@ -1,0 +1,138 @@
+package persistence
+
+import (
+	"context"
+	"sort"
+	"testing"
+)
+
+// RunRoomListerConformance exercises the RoomLister contract against a backend.
+// factory must return a fresh, empty store per call that implements both
+// VersionedPersistence (to create data) and RoomLister (to enumerate it).
+//
+// It lives in the non-test build (like RunConformance) so backends in other
+// packages can call it.
+func RunRoomListerConformance(t *testing.T, factory func() SnapshotVersionedPersistence) {
+	t.Helper()
+	ctx := context.Background()
+
+	// listed returns the store's rooms, sorted (ListRooms order is unspecified).
+	listed := func(t *testing.T, p SnapshotVersionedPersistence) []string {
+		t.Helper()
+		l, ok := p.(RoomLister)
+		if !ok {
+			t.Fatalf("%T does not implement RoomLister", p)
+		}
+		got, err := l.ListRooms(ctx)
+		if err != nil {
+			t.Fatalf("ListRooms: %v", err)
+		}
+		sort.Strings(got)
+		return got
+	}
+
+	equal := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("EmptyStoreListsNothing", func(t *testing.T) {
+		p := factory()
+		if got := listed(t, p); len(got) != 0 {
+			t.Fatalf("ListRooms on empty store = %v, want none", got)
+		}
+	})
+
+	t.Run("ListsRoomsWithUpdates", func(t *testing.T) {
+		p := factory()
+		updates, _ := genUpdates(t, 1)
+		for _, room := range []string{"beta", "alpha"} {
+			if _, err := p.AppendUpdate(ctx, room, updates[0]); err != nil {
+				t.Fatalf("AppendUpdate(%s): %v", room, err)
+			}
+		}
+		want := []string{"alpha", "beta"}
+		if got := listed(t, p); !equal(got, want) {
+			t.Fatalf("ListRooms = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ListsRoomWithOnlyASnapshot", func(t *testing.T) {
+		// A room that has a snapshot but no update log must still be reported,
+		// otherwise a cleanup pass would never see it and its snapshot would be
+		// unreclaimable.
+		p := factory()
+		if _, err := p.SaveSnapshot(ctx, "snaponly", "lbl", []byte("state")); err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		want := []string{"snaponly"}
+		if got := listed(t, p); !equal(got, want) {
+			t.Fatalf("ListRooms = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoDuplicatesWhenRoomHasBothUpdatesAndSnapshots", func(t *testing.T) {
+		p := factory()
+		updates, _ := genUpdates(t, 2)
+		for _, u := range updates {
+			if _, err := p.AppendUpdate(ctx, "both", u); err != nil {
+				t.Fatalf("AppendUpdate: %v", err)
+			}
+		}
+		if _, err := p.SaveSnapshot(ctx, "both", "a", []byte("s1")); err != nil {
+			t.Fatalf("SaveSnapshot #1: %v", err)
+		}
+		if _, err := p.SaveSnapshot(ctx, "both", "b", []byte("s2")); err != nil {
+			t.Fatalf("SaveSnapshot #2: %v", err)
+		}
+		want := []string{"both"}
+		if got := listed(t, p); !equal(got, want) {
+			t.Fatalf("ListRooms = %v, want exactly %v (no duplicates)", got, want)
+		}
+	})
+
+	t.Run("DeletedRoomIsNotListed", func(t *testing.T) {
+		p := factory()
+		updates, _ := genUpdates(t, 1)
+		for _, room := range []string{"keep", "drop"} {
+			if _, err := p.AppendUpdate(ctx, room, updates[0]); err != nil {
+				t.Fatalf("AppendUpdate(%s): %v", room, err)
+			}
+		}
+		if _, err := p.SaveSnapshot(ctx, "drop", "lbl", []byte("state")); err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if err := p.Delete(ctx, "drop"); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		want := []string{"keep"}
+		if got := listed(t, p); !equal(got, want) {
+			t.Fatalf("ListRooms after Delete = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("RoomNamesRoundTripExactly", func(t *testing.T) {
+		// Backends may encode room names on disk (the file backend hex-encodes
+		// them); enumeration must return the ORIGINAL name, not the encoded form.
+		p := factory()
+		names := []string{"plain", "with/slash", "with:colon", "üñïçödé", "with space"}
+		updates, _ := genUpdates(t, 1)
+		for _, n := range names {
+			if _, err := p.AppendUpdate(ctx, n, updates[0]); err != nil {
+				t.Fatalf("AppendUpdate(%q): %v", n, err)
+			}
+		}
+		want := append([]string(nil), names...)
+		sort.Strings(want)
+		if got := listed(t, p); !equal(got, want) {
+			t.Fatalf("ListRooms = %v, want %v", got, want)
+		}
+	})
+}

--- a/persistence/snapshots.go
+++ b/persistence/snapshots.go
@@ -1,0 +1,94 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// SnapshotInfo is the metadata of one stored snapshot. The state blob itself is
+// fetched separately via GetSnapshotState so listing stays cheap for rooms with
+// many large snapshots.
+type SnapshotInfo struct {
+	// ID is the store-assigned identifier, unique WITHIN A ROOM and
+	// monotonically increasing there (higher ID = newer snapshot). It is never
+	// reused within a room, even after the snapshot is deleted.
+	//
+	// IDs are NOT guaranteed globally unique: the same ID may name a different
+	// snapshot in a different room (backends may count per-room), so always
+	// carry the room alongside the ID and never key a cache on the ID alone.
+	ID int64
+	// Label is the optional caller-supplied name ("before-migration",
+	// "v2 draft"). NOT unique, and may be empty: saving twice under the same
+	// label creates two distinct snapshots rather than overwriting.
+	Label string
+	// CreatedAt is the store-stamped creation time (UTC).
+	CreatedAt time.Time
+	// Size is the state blob length in bytes.
+	Size int64
+}
+
+// ErrSnapshotNotFound is returned by GetSnapshotState when the (room, id) pair
+// does not exist.
+var ErrSnapshotNotFound = errors.New("persistence: snapshot not found")
+
+// ErrEmptySnapshot is returned by SaveSnapshot when state is empty: an empty
+// document has no state worth versioning.
+var ErrEmptySnapshot = errors.New("persistence: empty snapshot state")
+
+// SnapshotStore is the optional labelled-snapshot extension of
+// VersionedPersistence. A backend that implements it can capture labelled
+// point-in-time snapshots of a room independent of the live update log: the log
+// can be appended to, compacted, or pruned without touching stored snapshots,
+// and snapshots can be deleted without touching the log.
+//
+// This is the primitive an application builds a user-facing "version history"
+// on. Note the distinction from ListVersions, which enumerates the raw update
+// log (one entry per stored update) and is a durability concern, not a
+// user-facing one.
+//
+// Method contracts:
+//
+//   - SaveSnapshot stores state (a self-contained V1 update blob carrying the
+//     full room state) as a NEW snapshot and returns its ID. Empty state is
+//     rejected with ErrEmptySnapshot. label may be empty and need not be
+//     unique; repeated saves never overwrite.
+//
+//   - ListSnapshots returns the metadata of every snapshot of room,
+//     NEWEST FIRST (matching ListVersions' ordering). Returns an empty slice
+//     (not an error) for an unknown room or a room with no snapshots.
+//
+//   - GetSnapshotState returns the state blob of one snapshot.
+//     ErrSnapshotNotFound if the (room, id) pair is unknown.
+//
+//   - DeleteSnapshot removes one snapshot. Idempotent: deleting an unknown
+//     snapshot is a no-op returning a nil error.
+//
+// SnapshotStore deliberately does not embed VersionedPersistence so the latter's
+// contract stays frozen; backends implement both, and callers needing both can
+// take a SnapshotVersionedPersistence.
+//
+// The older name-keyed CaptureSnapshot/RestoreSnapshot pair on
+// VersionedPersistence is superseded by this interface for new code: it is
+// keyed by name (so a repeat save overwrites), exposes no metadata, and cannot
+// be enumerated or individually deleted.
+type SnapshotStore interface {
+	SaveSnapshot(ctx context.Context, room, label string, state []byte) (int64, error)
+	ListSnapshots(ctx context.Context, room string) ([]SnapshotInfo, error)
+	GetSnapshotState(ctx context.Context, room string, id int64) ([]byte, error)
+	DeleteSnapshot(ctx context.Context, room string, id int64) error
+}
+
+// SnapshotVersionedPersistence is a backend providing both the live update log
+// and labelled snapshots. The memory, file, and sqlite backends implement it.
+type SnapshotVersionedPersistence interface {
+	VersionedPersistence
+	SnapshotStore
+}
+
+// Compile-time assertions that the in-tree backends satisfy the snapshot
+// contract. (sqlite asserts the same in its own package.)
+var (
+	_ SnapshotVersionedPersistence = (*MemoryPersistence)(nil)
+	_ SnapshotVersionedPersistence = (*FilePersistence)(nil)
+)

--- a/persistence/snapshots_conformance.go
+++ b/persistence/snapshots_conformance.go
@@ -146,6 +146,48 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 		}
 	})
 
+	// Size must be the state length exactly, with neither a record header nor the
+	// label counted in. A backend that derives Size from a file size (the file
+	// backend does, to keep listing cheap) gets its arithmetic checked here, with
+	// a deliberately non-round length and both a long and an empty label.
+	t.Run("SizeIsExactRegardlessOfLabel", func(t *testing.T) {
+		s := factory()
+		big := bytes.Repeat([]byte("q"), 64*1024+7)
+
+		labelled, err := s.SaveSnapshot(ctx, "room", "a-deliberately-long-label", big)
+		if err != nil {
+			t.Fatalf("SaveSnapshot(labelled): %v", err)
+		}
+		unlabelled, err := s.SaveSnapshot(ctx, "room", "", big)
+		if err != nil {
+			t.Fatalf("SaveSnapshot(unlabelled): %v", err)
+		}
+
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		for _, info := range got {
+			if info.Size != int64(len(big)) {
+				t.Fatalf("id %d (label %q) Size = %d, want %d", info.ID, info.Label, info.Size, len(big))
+			}
+		}
+
+		// The payload itself must still round-trip byte-for-byte.
+		for _, id := range []int64{labelled, unlabelled} {
+			state, err := s.GetSnapshotState(ctx, "room", id)
+			if err != nil {
+				t.Fatalf("GetSnapshotState(%d): %v", id, err)
+			}
+			if !bytes.Equal(state, big) {
+				t.Fatalf("id %d state differs: got %d bytes, want %d", id, len(state), len(big))
+			}
+		}
+	})
+
 	t.Run("EmptyStateRejected", func(t *testing.T) {
 		s := factory()
 		if _, err := s.SaveSnapshot(ctx, "room", "lbl", nil); !errors.Is(err, ErrEmptySnapshot) {

--- a/persistence/snapshots_conformance.go
+++ b/persistence/snapshots_conformance.go
@@ -1,0 +1,298 @@
+package persistence
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+// RunSnapshotStoreConformance exercises the SnapshotStore contract against a
+// backend. factory must return a fresh, empty store per call.
+//
+// It lives in the non-test build (like RunConformance) so backends in other
+// packages can call it.
+func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("SaveThenListNewestFirst", func(t *testing.T) {
+		s := factory()
+		id1, err := s.SaveSnapshot(ctx, "room", "first", []byte("state-1"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(first): %v", err)
+		}
+		id2, err := s.SaveSnapshot(ctx, "room", "second", []byte("state-22"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(second): %v", err)
+		}
+		if id1 == id2 {
+			t.Fatalf("ids must be distinct, both = %d", id1)
+		}
+		if id2 <= id1 {
+			t.Fatalf("ids must increase: id1=%d id2=%d", id1, id2)
+		}
+
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len(ListSnapshots) = %d, want 2", len(got))
+		}
+		// Newest first.
+		if got[0].ID != id2 || got[1].ID != id1 {
+			t.Fatalf("order = [%d %d], want newest-first [%d %d]", got[0].ID, got[1].ID, id2, id1)
+		}
+		if got[0].Label != "second" || got[1].Label != "first" {
+			t.Fatalf("labels = [%q %q], want [second first]", got[0].Label, got[1].Label)
+		}
+		if got[0].Size != int64(len("state-22")) {
+			t.Fatalf("Size = %d, want %d", got[0].Size, len("state-22"))
+		}
+		if got[0].CreatedAt.IsZero() || got[1].CreatedAt.IsZero() {
+			t.Fatalf("CreatedAt must be stamped, got %v and %v", got[0].CreatedAt, got[1].CreatedAt)
+		}
+	})
+
+	t.Run("ListUnknownRoomEmpty", func(t *testing.T) {
+		s := factory()
+		got, err := s.ListSnapshots(ctx, "nope")
+		if err != nil {
+			t.Fatalf("ListSnapshots(unknown): %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("GetSnapshotStateRoundTrip", func(t *testing.T) {
+		s := factory()
+		want := []byte("the-state-blob")
+		id, err := s.SaveSnapshot(ctx, "room", "lbl", want)
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		got, err := s.GetSnapshotState(ctx, "room", id)
+		if err != nil {
+			t.Fatalf("GetSnapshotState: %v", err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("state = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("GetSnapshotStateUnknownIsErrSnapshotNotFound", func(t *testing.T) {
+		s := factory()
+		if _, err := s.GetSnapshotState(ctx, "room", 999); !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("err = %v, want ErrSnapshotNotFound", err)
+		}
+		// Also for a room that exists but a bogus id.
+		id, err := s.SaveSnapshot(ctx, "room", "x", []byte("s"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if _, err := s.GetSnapshotState(ctx, "room", id+12345); !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("err = %v, want ErrSnapshotNotFound", err)
+		}
+	})
+
+	t.Run("SameLabelCreatesDistinctSnapshots", func(t *testing.T) {
+		s := factory()
+		id1, err := s.SaveSnapshot(ctx, "room", "dup", []byte("a"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot #1: %v", err)
+		}
+		id2, err := s.SaveSnapshot(ctx, "room", "dup", []byte("bb"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot #2: %v", err)
+		}
+		if id1 == id2 {
+			t.Fatalf("same label must not overwrite: both ids = %d", id1)
+		}
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (same label must not overwrite)", len(got))
+		}
+		// Both states must be independently retrievable.
+		b1, err := s.GetSnapshotState(ctx, "room", id1)
+		if err != nil {
+			t.Fatalf("GetSnapshotState(id1): %v", err)
+		}
+		b2, err := s.GetSnapshotState(ctx, "room", id2)
+		if err != nil {
+			t.Fatalf("GetSnapshotState(id2): %v", err)
+		}
+		if !bytes.Equal(b1, []byte("a")) || !bytes.Equal(b2, []byte("bb")) {
+			t.Fatalf("states = %q / %q, want a / bb", b1, b2)
+		}
+	})
+
+	t.Run("EmptyLabelAllowed", func(t *testing.T) {
+		s := factory()
+		id, err := s.SaveSnapshot(ctx, "room", "", []byte("s"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(empty label): %v", err)
+		}
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != id || got[0].Label != "" {
+			t.Fatalf("got %+v, want one entry id=%d label=%q", got, id, "")
+		}
+	})
+
+	t.Run("EmptyStateRejected", func(t *testing.T) {
+		s := factory()
+		if _, err := s.SaveSnapshot(ctx, "room", "lbl", nil); !errors.Is(err, ErrEmptySnapshot) {
+			t.Fatalf("SaveSnapshot(nil) err = %v, want ErrEmptySnapshot", err)
+		}
+		if _, err := s.SaveSnapshot(ctx, "room", "lbl", []byte{}); !errors.Is(err, ErrEmptySnapshot) {
+			t.Fatalf("SaveSnapshot(empty) err = %v, want ErrEmptySnapshot", err)
+		}
+	})
+
+	t.Run("DeleteSnapshotRemovesOnlyThatOne", func(t *testing.T) {
+		s := factory()
+		keep, err := s.SaveSnapshot(ctx, "room", "keep", []byte("k"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(keep): %v", err)
+		}
+		drop, err := s.SaveSnapshot(ctx, "room", "drop", []byte("d"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(drop): %v", err)
+		}
+		if err := s.DeleteSnapshot(ctx, "room", drop); err != nil {
+			t.Fatalf("DeleteSnapshot: %v", err)
+		}
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != keep {
+			t.Fatalf("after delete got %+v, want only id=%d", got, keep)
+		}
+		if _, err := s.GetSnapshotState(ctx, "room", drop); !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("deleted snapshot err = %v, want ErrSnapshotNotFound", err)
+		}
+		if _, err := s.GetSnapshotState(ctx, "room", keep); err != nil {
+			t.Fatalf("kept snapshot must survive: %v", err)
+		}
+	})
+
+	t.Run("DeleteSnapshotIdempotent", func(t *testing.T) {
+		s := factory()
+		if err := s.DeleteSnapshot(ctx, "room", 4242); err != nil {
+			t.Fatalf("DeleteSnapshot(unknown) = %v, want nil", err)
+		}
+		id, err := s.SaveSnapshot(ctx, "room", "x", []byte("s"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if err := s.DeleteSnapshot(ctx, "room", id); err != nil {
+			t.Fatalf("DeleteSnapshot #1: %v", err)
+		}
+		if err := s.DeleteSnapshot(ctx, "room", id); err != nil {
+			t.Fatalf("DeleteSnapshot #2 (idempotent) = %v, want nil", err)
+		}
+	})
+
+	t.Run("IDsNotReusedAfterDelete", func(t *testing.T) {
+		s := factory()
+		id1, err := s.SaveSnapshot(ctx, "room", "a", []byte("a"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if err := s.DeleteSnapshot(ctx, "room", id1); err != nil {
+			t.Fatalf("DeleteSnapshot: %v", err)
+		}
+		id2, err := s.SaveSnapshot(ctx, "room", "b", []byte("b"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot after delete: %v", err)
+		}
+		if id2 == id1 {
+			t.Fatalf("id %d reused after delete", id2)
+		}
+	})
+
+	// Delete(room) is contracted to remove ALL data for a room, snapshots
+	// included. Skipped for a store that is snapshots-only.
+	t.Run("RoomDeleteRemovesSnapshots", func(t *testing.T) {
+		s := factory()
+		type roomDeleter interface {
+			Delete(ctx context.Context, room string) error
+		}
+		d, ok := s.(roomDeleter)
+		if !ok {
+			t.Skip("store does not implement Delete(ctx, room)")
+		}
+		id, err := s.SaveSnapshot(ctx, "room", "lbl", []byte("state"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if err := d.Delete(ctx, "room"); err != nil {
+			t.Fatalf("Delete(room): %v", err)
+		}
+		got, err := s.ListSnapshots(ctx, "room")
+		if err != nil {
+			t.Fatalf("ListSnapshots after Delete: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("after Delete(room) snapshots = %+v, want none", got)
+		}
+		if _, err := s.GetSnapshotState(ctx, "room", id); !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("after Delete(room) err = %v, want ErrSnapshotNotFound", err)
+		}
+	})
+
+	t.Run("RoomsAreIsolated", func(t *testing.T) {
+		s := factory()
+		idA, err := s.SaveSnapshot(ctx, "roomA", "a", []byte("aaa"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(roomA): %v", err)
+		}
+		idB, err := s.SaveSnapshot(ctx, "roomB", "b", []byte("bbb"))
+		if err != nil {
+			t.Fatalf("SaveSnapshot(roomB): %v", err)
+		}
+		// Listings must not bleed across rooms.
+		a, err := s.ListSnapshots(ctx, "roomA")
+		if err != nil {
+			t.Fatalf("ListSnapshots(roomA): %v", err)
+		}
+		if len(a) != 1 || a[0].Label != "a" {
+			t.Fatalf("roomA = %+v, want single label a", a)
+		}
+		b, err := s.ListSnapshots(ctx, "roomB")
+		if err != nil {
+			t.Fatalf("ListSnapshots(roomB): %v", err)
+		}
+		if len(b) != 1 || b[0].Label != "b" {
+			t.Fatalf("roomB = %+v, want single label b", b)
+		}
+		// State is keyed by (room, id): each room reads its own blob. IDs are only
+		// unique within a room, so ids may legitimately collide across rooms.
+		sa, err := s.GetSnapshotState(ctx, "roomA", idA)
+		if err != nil {
+			t.Fatalf("GetSnapshotState(roomA): %v", err)
+		}
+		sb, err := s.GetSnapshotState(ctx, "roomB", idB)
+		if err != nil {
+			t.Fatalf("GetSnapshotState(roomB): %v", err)
+		}
+		if !bytes.Equal(sa, []byte("aaa")) || !bytes.Equal(sb, []byte("bbb")) {
+			t.Fatalf("states = %q / %q, want aaa / bbb", sa, sb)
+		}
+		// Deleting in one room must not affect the other.
+		if err := s.DeleteSnapshot(ctx, "roomB", idB); err != nil {
+			t.Fatalf("DeleteSnapshot(roomB): %v", err)
+		}
+		if _, err := s.GetSnapshotState(ctx, "roomA", idA); err != nil {
+			t.Fatalf("roomA snapshot must survive roomB delete: %v", err)
+		}
+	})
+}

--- a/persistence/sqlite/methods.go
+++ b/persistence/sqlite/methods.go
@@ -416,3 +416,30 @@ func (s *Store) DeleteSnapshot(ctx context.Context, room string, id int64) error
 		`DELETE FROM snapshot_versions WHERE room = ? AND id = ?`, room, id)
 	return err
 }
+
+// ListRooms returns every room holding at least one update or snapshot.
+func (s *Store) ListRooms(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT room FROM updates
+		 UNION SELECT room FROM snapshots
+		 UNION SELECT room FROM snapshot_versions`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []string{}
+	for rows.Next() {
+		var room string
+		if err := rows.Scan(&room); err != nil {
+			return nil, err
+		}
+		out = append(out, room)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/persistence/sqlite/methods.go
+++ b/persistence/sqlite/methods.go
@@ -290,6 +290,7 @@ func (s *Store) Delete(ctx context.Context, room string) error {
 	for _, q := range []string{
 		`DELETE FROM updates WHERE room = ?`,
 		`DELETE FROM snapshots WHERE room = ?`,
+		`DELETE FROM snapshot_versions WHERE room = ?`,
 		`DELETE FROM checkpoints WHERE room = ?`,
 	} {
 		if _, err := tx.ExecContext(ctx, q, room); err != nil {
@@ -331,4 +332,87 @@ func (s *Store) PruneAfter(ctx context.Context, room string, target persistence.
 
 	// Phase 2: delete future updates, then clear the checkpoint.
 	return s.finishPrune(ctx, room, target)
+}
+
+// SaveSnapshot stores state as a new labelled snapshot of room and returns its
+// ID. AUTOINCREMENT guarantees the id is monotonic and never reused.
+func (s *Store) SaveSnapshot(ctx context.Context, room, label string, state []byte) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(state) == 0 {
+		return 0, persistence.ErrEmptySnapshot
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO snapshot_versions (room, label, created_at, state) VALUES (?, ?, ?, ?)`,
+		room, label, time.Now().UnixNano(), state)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// ListSnapshots returns snapshot metadata for room, newest-first. The state blob
+// is not read: only its length, so listing stays cheap for large snapshots.
+func (s *Store) ListSnapshots(ctx context.Context, room string) ([]persistence.SnapshotInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, label, created_at, length(state) FROM snapshot_versions
+		 WHERE room = ? ORDER BY id DESC`, room)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []persistence.SnapshotInfo{}
+	for rows.Next() {
+		var id, ns, size int64
+		var label string
+		if err := rows.Scan(&id, &label, &ns, &size); err != nil {
+			return nil, err
+		}
+		out = append(out, persistence.SnapshotInfo{
+			ID:        id,
+			Label:     label,
+			CreatedAt: time.Unix(0, ns).UTC(),
+			Size:      size,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetSnapshotState returns the state blob of one snapshot.
+// persistence.ErrSnapshotNotFound when (room, id) is unknown.
+func (s *Store) GetSnapshotState(ctx context.Context, room string, id int64) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var state []byte
+	err := s.db.QueryRowContext(ctx,
+		`SELECT state FROM snapshot_versions WHERE room = ? AND id = ?`, room, id).Scan(&state)
+	if err == sql.ErrNoRows {
+		return nil, persistence.ErrSnapshotNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// DeleteSnapshot removes one snapshot. Deleting an unknown snapshot is a no-op.
+func (s *Store) DeleteSnapshot(ctx context.Context, room string, id int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM snapshot_versions WHERE room = ? AND id = ?`, room, id)
+	return err
 }

--- a/persistence/sqlite/sqlite.go
+++ b/persistence/sqlite/sqlite.go
@@ -33,6 +33,14 @@ CREATE TABLE IF NOT EXISTS snapshots (
   state   BLOB    NOT NULL,
   PRIMARY KEY (room, name)
 );
+CREATE TABLE IF NOT EXISTS snapshot_versions (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  room       TEXT    NOT NULL,
+  label      TEXT    NOT NULL,
+  created_at INTEGER NOT NULL,
+  state      BLOB    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_snapshot_versions_room ON snapshot_versions (room, id DESC);
 CREATE TABLE IF NOT EXISTS checkpoints (
   room             TEXT    NOT NULL PRIMARY KEY,
   target           INTEGER NOT NULL,
@@ -208,7 +216,9 @@ func (s *Store) Reopen() (persistence.VersionedPersistence, error) {
 // Compile-time assertions that *Store satisfies the persistence contract and the
 // optional crash-safety hooks the conformance suite exercises.
 var (
-	_ persistence.VersionedPersistence = (*Store)(nil)
-	_ persistence.CrashInjector        = (*Store)(nil)
-	_ persistence.Reopener             = (*Store)(nil)
+	_ persistence.VersionedPersistence         = (*Store)(nil)
+	_ persistence.SnapshotStore                = (*Store)(nil)
+	_ persistence.SnapshotVersionedPersistence = (*Store)(nil)
+	_ persistence.CrashInjector                = (*Store)(nil)
+	_ persistence.Reopener                     = (*Store)(nil)
 )

--- a/persistence/sqlite/sqlite.go
+++ b/persistence/sqlite/sqlite.go
@@ -219,6 +219,7 @@ var (
 	_ persistence.VersionedPersistence         = (*Store)(nil)
 	_ persistence.SnapshotStore                = (*Store)(nil)
 	_ persistence.SnapshotVersionedPersistence = (*Store)(nil)
+	_ persistence.RoomLister                   = (*Store)(nil)
 	_ persistence.CrashInjector                = (*Store)(nil)
 	_ persistence.Reopener                     = (*Store)(nil)
 )

--- a/persistence/sqlite/sqlite_test.go
+++ b/persistence/sqlite/sqlite_test.go
@@ -519,3 +519,9 @@ func TestSnapshotStoreConformance_SQLite(t *testing.T) {
 		return mustOpen(t, filepath.Join(t.TempDir(), "snap.db"))
 	})
 }
+
+func TestRoomListerConformance_SQLite(t *testing.T) {
+	persistence.RunRoomListerConformance(t, func() persistence.SnapshotVersionedPersistence {
+		return mustOpen(t, filepath.Join(t.TempDir(), "rooms.db"))
+	})
+}

--- a/persistence/sqlite/sqlite_test.go
+++ b/persistence/sqlite/sqlite_test.go
@@ -513,3 +513,9 @@ func TestInMemoryMode(t *testing.T) {
 		t.Fatalf("in-memory load v=%d want 1", lr.Version)
 	}
 }
+
+func TestSnapshotStoreConformance_SQLite(t *testing.T) {
+	persistence.RunSnapshotStoreConformance(t, func() persistence.SnapshotStore {
+		return mustOpen(t, filepath.Join(t.TempDir(), "snap.db"))
+	})
+}

--- a/persistence/versioned_test.go
+++ b/persistence/versioned_test.go
@@ -22,3 +22,20 @@ func TestConformance_File(t *testing.T) {
 		return p
 	})
 }
+
+func TestSnapshotStoreConformance_Memory(t *testing.T) {
+	persistence.RunSnapshotStoreConformance(t, func() persistence.SnapshotStore {
+		return persistence.NewMemoryPersistence()
+	})
+}
+
+func TestSnapshotStoreConformance_File(t *testing.T) {
+	persistence.RunSnapshotStoreConformance(t, func() persistence.SnapshotStore {
+		dir := t.TempDir()
+		p, err := persistence.NewFilePersistence(dir)
+		if err != nil {
+			t.Fatalf("NewFilePersistence: %v", err)
+		}
+		return p
+	})
+}

--- a/persistence/versioned_test.go
+++ b/persistence/versioned_test.go
@@ -39,3 +39,20 @@ func TestSnapshotStoreConformance_File(t *testing.T) {
 		return p
 	})
 }
+
+func TestRoomListerConformance_Memory(t *testing.T) {
+	persistence.RunRoomListerConformance(t, func() persistence.SnapshotVersionedPersistence {
+		return persistence.NewMemoryPersistence()
+	})
+}
+
+func TestRoomListerConformance_File(t *testing.T) {
+	persistence.RunRoomListerConformance(t, func() persistence.SnapshotVersionedPersistence {
+		dir := t.TempDir()
+		p, err := persistence.NewFilePersistence(dir)
+		if err != nil {
+			t.Fatalf("NewFilePersistence: %v", err)
+		}
+		return p
+	})
+}

--- a/provider/websocket/coalesce.go
+++ b/provider/websocket/coalesce.go
@@ -9,15 +9,20 @@ type wsTimer interface {
 	stop()
 }
 
-// wsClock creates wsTimers. Server.clock is nil in production and resolves to
-// realClock{}; tests inject a fake for deterministic debounce behaviour.
+// wsClock creates wsTimers and reads the current time. Server.clock is nil in
+// production and resolves to realClock{}; tests inject a fake for deterministic
+// debounce and auto-version behaviour.
 type wsClock interface {
 	newTimer(d time.Duration) wsTimer
+	// now is the clock's current time, used for elapsed-interval decisions
+	// (auto-versioning) that must be deterministic under test.
+	now() time.Time
 }
 
 type realClock struct{}
 
 func (realClock) newTimer(d time.Duration) wsTimer { return &realTimer{t: time.NewTimer(d)} }
+func (realClock) now() time.Time                   { return time.Now() }
 
 type realTimer struct{ t *time.Timer }
 

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -34,6 +34,12 @@ import (
 // When s.persistence also implements CompactableAdapter, Compact is invoked
 // on room unload (including server shutdown) and, when s.CompactEvery > 0,
 // after every N persistence flushes on the coalescing path.
+//
+// When s.persistence also implements VersionableAdapter and s.AutoVersionEvery
+// > 0, SaveVersion is invoked at most once per AutoVersionEvery per room, and
+// only when the room changed since its last version, plus once on room unload if
+// it changed after that. The hook lives in store() rather than in either select
+// loop, so both the coalescing and the strict per-update paths get it.
 func (s *Server) startPersistenceWorker(r *room, name string) {
 	clock := s.clock
 	if clock == nil {
@@ -44,6 +50,19 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 		mergeFn = crdt.MergeUpdatesV1
 	}
 	enabled, window, maxWait := resolveCoalesceConfig(s.PersistCoalesceWindow, s.PersistCoalesceMaxWait)
+
+	// Auto-versioning setup, resolved BEFORE the goroutine starts. versioner is
+	// left nil when the feature is off or unsupported, which makes maybeVersion a
+	// cheap no-op on the hot path.
+	versioner, _ := s.persistence.(VersionableAdapter)
+	autoVersionEvery := s.AutoVersionEvery
+	if autoVersionEvery <= 0 {
+		versioner = nil
+	}
+	// lastVersion is stamped here, not inside the goroutine, so the interval is
+	// measured from when the worker was CREATED rather than from whenever its
+	// goroutine happened to be scheduled.
+	lastVersion := clock.now()
 
 	go func() {
 		defer close(r.persistDone)
@@ -63,6 +82,42 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 		compactor, _ := s.persistence.(CompactableAdapter)
 		compactEvery := s.CompactEvery
 		flushCount := 0
+
+		// dirtySinceVersion, like lastVersion above, is mutated only from
+		// store()/maybeVersion on THIS goroutine, so it needs no synchronisation.
+		dirtySinceVersion := false
+
+		// maybeVersion asks the adapter for a labelled version, but only when the
+		// room actually changed since the last one (dirtySinceVersion) and either
+		// the interval has elapsed or force is set (room unload). That pairing is
+		// the anti-churn guarantee: a quiet room is never versioned, and an active
+		// room yields at most one version per AutoVersionEvery.
+		//
+		// Contained by recover; errors and panics are logged and never fatal.
+		// On failure lastVersion is still advanced so a permanently failing adapter
+		// is retried once per interval rather than on every flush, while
+		// dirtySinceVersion stays set so the change is not forgotten.
+		maybeVersion := func(force bool) {
+			if versioner == nil || !dirtySinceVersion {
+				return
+			}
+			if !force && clock.now().Sub(lastVersion) < autoVersionEvery {
+				return
+			}
+			defer func() {
+				if rv := recover(); rv != nil {
+					lastVersion = clock.now()
+					log.Printf("ygo/websocket: SaveVersion panic for room %q: %v", name, rv)
+				}
+			}()
+			_, err := versioner.SaveVersion(context.Background(), name, AutoVersionLabel)
+			lastVersion = clock.now()
+			if err != nil {
+				log.Printf("ygo/websocket: SaveVersion for room %q: %v", name, err)
+				return
+			}
+			dirtySinceVersion = false
+		}
 
 		// maybeCompact calls the adapter's Compact (if any) with a background
 		// ctx, contained by recover; errors/panics are logged, never fatal.
@@ -109,8 +164,14 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			}
 			if err != nil {
 				log.Printf("ygo/websocket: StoreUpdate for room %q: %v", name, err)
+				return err
 			}
-			return err
+			// A durable write is the one signal that the room changed, and it is
+			// common to BOTH the coalescing and the strict per-update paths, so
+			// auto-versioning hooks in here rather than in either select loop.
+			dirtySinceVersion = true
+			maybeVersion(false)
+			return nil
 		}
 
 		// flush merges batch into one update and stores it. On merge failure it
@@ -167,10 +228,12 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 					ack <- ok
 				case <-r.persistStop:
 					drain()
+					maybeVersion(true)
 					maybeCompact()
 					return
 				case <-s.shutdownCh:
 					drain()
+					maybeVersion(true)
 					maybeCompact()
 					return
 				}
@@ -268,12 +331,14 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				drainBuffered()
 				flush(context.Background(), batch) // non-cancelled: survive shutdown
 				clearTimers()                      // release any pending timers before exit
+				maybeVersion(true)
 				maybeCompact()
 				return
 			case <-s.shutdownCh:
 				drainBuffered()
 				flush(context.Background(), batch)
 				clearTimers() // release any pending timers before exit
+				maybeVersion(true)
 				maybeCompact()
 				return
 			}

--- a/provider/websocket/persistence_autoversion_test.go
+++ b/provider/websocket/persistence_autoversion_test.go
@@ -1,0 +1,200 @@
+package websocket
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// versionAdapter is a recordAdapter that also implements VersionableAdapter.
+type versionAdapter struct {
+	recordAdapter
+
+	vmu    sync.Mutex
+	labels []string
+	nextID int64
+}
+
+func (a *versionAdapter) SaveVersion(_ context.Context, _ string, label string) (int64, error) {
+	a.vmu.Lock()
+	defer a.vmu.Unlock()
+	a.nextID++
+	a.labels = append(a.labels, label)
+	return a.nextID, nil
+}
+
+func (a *versionAdapter) versionCount() int {
+	a.vmu.Lock()
+	defer a.vmu.Unlock()
+	return len(a.labels)
+}
+
+func (a *versionAdapter) versionLabels() []string {
+	a.vmu.Lock()
+	defer a.vmu.Unlock()
+	return append([]string(nil), a.labels...)
+}
+
+const avWindow = 50 * time.Millisecond
+
+// newAutoVersionServer wires a coalescing server with auto-versioning enabled.
+func newAutoVersionServer(a PersistenceAdapter, fc *fakeClock, every time.Duration) *Server {
+	s := newCoalesceServer(a, fc, avWindow, 500*time.Millisecond)
+	s.AutoVersionEvery = every
+	return s
+}
+
+// flushOnce applies one edit and forces a synchronous durable flush via the
+// room's flushReq barrier, so exactly one store completes.
+//
+// The barrier is used instead of firing window timers because it is
+// deterministic across repeated flushes: the flushReq case drains persistCh
+// before flushing by contract, whereas hunting successive window timers can pick
+// up one armed by an earlier batch.
+func flushOnce(t *testing.T, r *room) {
+	t.Helper()
+	applyEdit(r, "x", 0)
+	ack := make(chan bool, 1)
+	r.flushReq <- ack
+	require.True(t, <-ack, "flush should report durable success")
+}
+
+// A flush before the interval has elapsed must NOT create a version: this is the
+// anti-churn guarantee that makes a history panel usable.
+func TestAutoVersion_NotBeforeInterval(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Minute)
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond,
+		"the edit should have been persisted")
+
+	// Clock has not advanced, so no version is due.
+	assert.Equal(t, 0, a.versionCount(), "no version before AutoVersionEvery elapses")
+}
+
+// Once the interval has elapsed, the next flush creates exactly one version.
+func TestAutoVersion_OncePerIntervalOnChange(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Minute)
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	fc.advance(2 * time.Minute)
+	flushOnce(t, r)
+
+	assert.Eventually(t, func() bool { return a.versionCount() == 1 }, time.Second, 5*time.Millisecond,
+		"a version is due once the interval elapsed and the room changed")
+	assert.Equal(t, []string{AutoVersionLabel}, a.versionLabels(),
+		"server-created versions carry AutoVersionLabel")
+
+	// A second flush immediately after must not version again: the interval
+	// restarts from the version just taken.
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.count() == 2 }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, 1, a.versionCount(), "interval restarts after a version is taken")
+
+	// After another interval, one more version.
+	fc.advance(2 * time.Minute)
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.versionCount() == 2 }, time.Second, 5*time.Millisecond,
+		"a further interval yields one more version")
+}
+
+// A quiet room must never be versioned, however much time passes. Versions track
+// change, not wall-clock.
+func TestAutoVersion_QuietRoomNeverVersioned(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Minute)
+	_, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	fc.advance(24 * time.Hour)
+	// No edits at all.
+	assert.Never(t, func() bool { return a.versionCount() > 0 }, 200*time.Millisecond, 10*time.Millisecond,
+		"a room with no changes must not be versioned")
+}
+
+// On unload, a room that changed since its last version gets one final version
+// so the end of a session is not lost.
+func TestAutoVersion_FinalVersionOnUnloadWhenDirty(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Hour) // long interval: no interval-driven version
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond)
+	require.Equal(t, 0, a.versionCount(), "interval not elapsed, so no version yet")
+
+	// Unload the room.
+	require.NoError(t, s.CloseRoom("doc1", true))
+
+	assert.Eventually(t, func() bool { return a.versionCount() == 1 }, time.Second, 5*time.Millisecond,
+		"unload should capture a final version for a dirty room")
+}
+
+// On unload, a room with no changes since its last version must NOT be versioned
+// again, otherwise every open/close cycle would add a duplicate entry.
+func TestAutoVersion_NoFinalVersionWhenClean(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Minute)
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	// Elapse the interval and flush, taking a version and clearing the dirty flag.
+	fc.advance(2 * time.Minute)
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.versionCount() == 1 }, time.Second, 5*time.Millisecond)
+
+	// Unload with no further edits.
+	require.NoError(t, s.CloseRoom("doc1", true))
+
+	assert.Never(t, func() bool { return a.versionCount() > 1 }, 200*time.Millisecond, 10*time.Millisecond,
+		"a clean room must not be versioned again on unload")
+}
+
+// Auto-versioning is opt-in: with AutoVersionEvery == 0 the adapter is never
+// asked for a version, even on unload.
+func TestAutoVersion_DisabledByDefault(t *testing.T) {
+	a := &versionAdapter{}
+	fc := newFakeClock()
+	s := newCoalesceServer(a, fc, avWindow, 500*time.Millisecond) // AutoVersionEvery unset
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	fc.advance(24 * time.Hour)
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond)
+	require.NoError(t, s.CloseRoom("doc1", true))
+
+	assert.Never(t, func() bool { return a.versionCount() > 0 }, 200*time.Millisecond, 10*time.Millisecond,
+		"auto-versioning must be off unless AutoVersionEvery > 0")
+}
+
+// An adapter that does not implement VersionableAdapter must be unaffected: the
+// server must not panic or stall when AutoVersionEvery is set.
+func TestAutoVersion_NonVersionableAdapterIgnored(t *testing.T) {
+	a := &recordAdapter{} // no SaveVersion
+	fc := newFakeClock()
+	s := newAutoVersionServer(a, fc, time.Minute)
+	r, _, err := s.getOrCreateRoom(context.Background(), "doc1")
+	require.NoError(t, err)
+
+	fc.advance(2 * time.Minute)
+	flushOnce(t, r)
+	assert.Eventually(t, func() bool { return a.count() == 1 }, time.Second, 5*time.Millisecond,
+		"persistence must work normally for a non-versionable adapter")
+	require.NoError(t, s.CloseRoom("doc1", true))
+}

--- a/provider/websocket/persistence_coalesce_test.go
+++ b/provider/websocket/persistence_coalesce_test.go
@@ -35,9 +35,31 @@ type fakeClock struct {
 
 	mu      sync.Mutex
 	pending []*fakeTimer // non-matching timers set aside by nextTimerOfDur
+	nowT    time.Time    // controllable wall clock for now()
 }
 
-func newFakeClock() *fakeClock { return &fakeClock{created: make(chan *fakeTimer, 256)} }
+func newFakeClock() *fakeClock {
+	return &fakeClock{
+		created: make(chan *fakeTimer, 256),
+		// Non-zero base so "elapsed since worker start" arithmetic is realistic.
+		nowT: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// now returns the fake wall clock.
+func (f *fakeClock) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.nowT
+}
+
+// advance moves the fake wall clock forward. It does NOT fire timers; timers are
+// driven explicitly via fakeTimer.fire().
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	f.nowT = f.nowT.Add(d)
+	f.mu.Unlock()
+}
 
 func (f *fakeClock) newTimer(d time.Duration) wsTimer {
 	t := &fakeTimer{c: make(chan time.Time, 1), dur: d}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -223,6 +223,40 @@ type CompactableAdapter interface {
 	Compact(ctx context.Context, room string) error
 }
 
+// VersionableAdapter is an optional extension to PersistenceAdapter. When the
+// adapter implements it AND Server.AutoVersionEvery > 0, the server asks it to
+// capture a labelled point-in-time version of a room's state, so an application
+// gets a user-facing version history without driving one itself.
+//
+// The distinction from CompactableAdapter matters: Compact collapses the update
+// log (a durability/space concern), while SaveVersion records a version a human
+// would want to browse and restore. An adapter typically implements this over
+// persistence.SnapshotStore.
+//
+// Cadence and the anti-churn guarantee: SaveVersion is called from the room's
+// persistence worker, at most once per AutoVersionEvery per room, and ONLY when
+// the room actually changed since the last version. A quiet room is never
+// versioned. This is deliberate: versioning per update is what makes a history
+// panel unusable. One final version is also captured on room unload if there
+// were changes after the last one, so a session's end state is not lost.
+//
+// Like Compact, SaveVersion is invoked from the room's persistence worker
+// goroutine, serialised with StoreUpdate for that room, so implementations need
+// no extra locking against concurrent writes to the same room. It is
+// best-effort: a returned error (or panic) is logged and never aborts
+// persistence. Retention (how many versions to keep) is the adapter's concern.
+//
+// It is invoked with context.Background() (not cancelled by Server.Shutdown),
+// so a slow SaveVersion delays that room's teardown, exactly as Compact does.
+type VersionableAdapter interface {
+	SaveVersion(ctx context.Context, room, label string) (int64, error)
+}
+
+// AutoVersionLabel is the label the server passes to
+// VersionableAdapter.SaveVersion for versions it creates on its own, so they can
+// be told apart from versions a user explicitly named.
+const AutoVersionLabel = "auto"
+
 // MemoryPersistence is a thread-safe in-memory PersistenceAdapter that merges
 // all updates into a single V1 snapshot per room. It is the default adapter
 // used when no external persistence is configured and is primarily useful in
@@ -662,6 +696,23 @@ type Server struct {
 	// only). Like the other config fields, set it before serving; it is read
 	// without synchronisation.
 	CompactEvery int
+
+	// AutoVersionEvery, when > 0, asks a VersionableAdapter to capture a labelled
+	// version of a room at most this often, and only when the room changed since
+	// the last version, giving a user-facing history that does not grow one entry
+	// per edit. A room with no activity is never versioned; a room that changed
+	// after its last version is versioned once more on unload so the session's
+	// end state survives.
+	//
+	// The interval is measured from the previous version (or from worker start),
+	// and is evaluated on persistence flushes rather than on a timer, so it is
+	// checked only when there is something to version. That means the actual gap
+	// between versions is AutoVersionEvery rounded up to the next flush.
+	//
+	// 0 (default) disables auto-versioning entirely. Ignored when the adapter does
+	// not implement VersionableAdapter. Set before serving; read without
+	// synchronisation.
+	AutoVersionEvery time.Duration
 
 	// clock creates timers for the persistence worker. nil in production
 	// (resolves to realClock). Tests inject a fake for deterministic debounce.


### PR DESCRIPTION
Three related additions that together let an application build a real, bounded, user-facing version history instead of hand-rolling one. Each is a separate commit and is independently revertable.

| Commit | What |
|---|---|
| 1 | `SnapshotStore`: enumerable, individually-deletable labelled snapshots |
| 2 | `RoomLister`: store-wide room enumeration |
| 3 | Auto-versioning: `VersionableAdapter` + `Server.AutoVersionEvery` |

All three are **optional extension interfaces**, following the existing `CompactableAdapter` / `CrashInjector` pattern. No existing interface gains a method, so third-party backends keep compiling, and everything is off by default.

---

## 1. `SnapshotStore` (persistence)

The existing labelled-snapshot API, `CaptureSnapshot` / `RestoreSnapshot`, is keyed by name. A snapshot could be written and read back by exact name, but never **enumerated**, never **individually deleted**, and carried **no metadata**. Repeated saves under one name silently overwrote, so two versions could not share a label.

Net effect: labelled snapshots were an unbounded, unreclaimable resource that only `Delete(room)` could clear. An application building a version history had to keep its own parallel index, and could not reconcile drift, garbage-collect orphans from a failed write, or implement retention. (`provider/websocket` never calls either method, so this half of the API was never exercised in-tree, which is likely why the missing operations went unnoticed.)

```go
type SnapshotInfo struct {
	ID        int64
	Label     string
	CreatedAt time.Time
	Size      int64
}

type SnapshotStore interface {
	SaveSnapshot(ctx context.Context, room, label string, state []byte) (int64, error)
	ListSnapshots(ctx context.Context, room string) ([]SnapshotInfo, error)
	GetSnapshotState(ctx context.Context, room string, id int64) ([]byte, error)
	DeleteSnapshot(ctx context.Context, room string, id int64) error
}
```

Design notes:

- **Not named `ListVersions`.** That name is already taken on `VersionedPersistence` for the raw update log, and Go forbids two same-named methods on one type, so the backends could not implement both. Keeping them distinct also keeps the two concepts apart: `ListVersions` is a durability concern (one entry per stored update), snapshots are the user-facing one.
- **ID-keyed, labels non-unique**, so repeated saves create distinct snapshots rather than overwriting. IDs are unique and monotonic **within a room** and never reused there, but are not guaranteed globally unique (backends may count per-room); the doc says so and warns against keying a cache on the ID alone.
- **Cheap listing**: `ListSnapshots` never reads state blobs (sqlite uses `length(state)`).
- **Newest-first**, matching the existing `ListVersions` convention.
- The name-keyed pair is untouched and still supported, marked superseded for new code.
- Deliberately out of scope: a `RestoreVersion` that replaces the **live** update log. That is not a storage operation; it has to coordinate with a running room and its connected peers, so it belongs in a separate provider-level change.

## 2. `RoomLister` (persistence)

`VersionedPersistence` could only be addressed one room at a time; there was no way to ask a store which rooms it holds. That makes store-wide retention, cleanup, migration and reconciliation impossible without an external index, with no way to detect drift against what is actually persisted.

```go
type RoomLister interface {
	ListRooms(ctx context.Context) ([]string, error)
}
```

Reports every room holding at least one update **or** at least one snapshot, so a snapshot-only room stays reclaimable. Order is unspecified by contract. The conformance suite pins two easy-to-get-wrong properties: a room with both updates and snapshots appears exactly once, and enumeration returns the **original** room name rather than a backend's on-disk encoding (the file backend hex-encodes directory names).

## 3. Auto-versioning (provider/websocket)

The server could persist updates but had no way to produce a version history, so every application had to drive one. The naive approach, a version per update, is exactly what makes a history panel unusable.

```go
type VersionableAdapter interface {
	SaveVersion(ctx context.Context, room, label string) (int64, error)
}
```

With `Server.AutoVersionEvery > 0` and an adapter that implements it, the server captures a labelled version (`AutoVersionLabel`, `"auto"`) **at most once per interval per room, and only when the room actually changed** since its last version, plus one final version on room unload if it changed after that. A quiet room is never versioned. That pairing is the anti-churn guarantee.

`persistence.LegacyAdapter` implements it over `SnapshotStore` and gains `KeepSnapshots` to bound retained versions (0 = keep all, mirroring `KeepVersions`, which is the separate update-log axis). A store lacking `SnapshotStore` returns the new `ErrSnapshotsUnsupported` rather than silently dropping versions, so a misconfiguration is visible instead of appearing to work.

Implementation notes worth a reviewer's attention:

- The hook lives in the persistence worker's `store()` helper, which **both** the coalescing and the strict per-update paths call, so **neither select loop is modified**.
- All auto-version state is owned by the worker goroutine; no synchronisation is added.
- `lastVersion` is stamped **before** the goroutine starts, so the interval is measured from worker creation rather than from whenever the goroutine was scheduled. (Doing it inside the goroutine also made the timing test race.)
- `wsClock` gains `now()` so interval decisions are deterministic under test. One existing fake implements it.
- Errors and panics from `SaveVersion` are logged and never fatal, matching `Compact`. On failure `lastVersion` still advances, so a permanently failing adapter is retried once per interval instead of on every flush, while the dirty flag stays set so the change is not forgotten.

## Bugs found and fixed by the new tests

- **sqlite `Delete(room)` leaked labelled snapshots.** `snapshot_versions` rows survived a room delete, contradicting the documented "removes all data for room (updates, snapshots, checkpoint)" contract. Memory and file were already correct. Caught by the `RoomDeleteRemovesSnapshots` conformance subtest.

## Storage changes per backend

- **memory**: `snapVersions` slice plus a per-room `nextSnapID` that is never rewound, so an ID is not reused after a delete.
- **file**: new `<root>/<roomHex>/snapversions/` directory, `<id>.bin` framed as `[8 createdAt unix-nano][4 labelLen][label][state]`, plus a `nextid` file so IDs survive restarts. The counter is bumped before the record is written, so a crash in between leaks an ID (harmless) rather than risking two snapshots sharing one.
- **sqlite**: new `snapshot_versions` table (`id INTEGER PRIMARY KEY AUTOINCREMENT`, `room`, `label`, `created_at`, `state`) with an index on `(room, id DESC)`, created via `CREATE TABLE IF NOT EXISTS` so existing databases pick it up on open with no migration step.

## Test coverage

Two new shared conformance suites, `RunSnapshotStoreConformance` and `RunRoomListerConformance`, wired into all three backends, plus adapter and provider tests.

Snapshot conformance asserts: save-then-list newest-first with correct labels/size/timestamps, unknown room empty, state round-trip, `ErrSnapshotNotFound` for unknown IDs, same label creating distinct retrievable snapshots, empty label allowed, empty state rejected with `ErrEmptySnapshot`, delete removing only the target, delete idempotency, IDs not reused after delete, `Delete(room)` clearing snapshots, and room isolation.

Auto-versioning asserts: no version before the interval elapses, exactly one per interval on change with the interval restarting after each, a quiet room never versioned, a final version on unload when dirty, **no** duplicate on unload when clean, disabled by default, and a non-versionable adapter left unaffected. The tests drive flushes through the `flushReq` durability barrier rather than chasing window timers, which keeps them reliable across repeated flushes.

## Verification

- `gofmt -l` clean
- `go vet ./...` clean
- `go test -race ./...` passes across every package
