### PR TITLE
fix(encoding,crdt): reject invalid UTF-8 where it enters a document (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,67 @@ jobs:
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
 
+  release-docs:
+    name: Release docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      # The release job publishes RELEASE_NOTES.md's top section under the tag
+      # it is given and reads the version from CHANGELOG.md's top heading. If
+      # the two files disagree about what the newest version is, one of those
+      # two reads is wrong and the mistake only surfaces at tag time.
+      - name: CHANGELOG and RELEASE_NOTES agree on the newest version
+        run: |
+          chg=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] ')
+          rel=$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+' RELEASE_NOTES.md | sed 's/^## v//')
+          if [ "$chg" != "$rel" ]; then
+            echo "::error::CHANGELOG.md leads with [$chg] but RELEASE_NOTES.md leads with v$rel. Both files are newest-first and the release job reads both, so they must name the same version."
+            exit 1
+          fi
+          echo "Both files lead with $chg."
+      # Catches the omission at review time instead of at tag time, where the
+      # only remedy is a docs-only PR to a PR-protected main before anything
+      # can ship. CONTRIBUTING's exemption is encoded as the path filter below.
+      - name: Behaviour changes carry entries
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-release-notes') }}
+        run: |
+          set -euo pipefail
+          # Fail closed. An unresolvable base or an empty diff means this step
+          # is not looking at the PR's changes, and the path filter below would
+          # then find no source files and pass — reporting green while checking
+          # nothing. That is worse than not having the check at all.
+          base="origin/$GITHUB_BASE_REF"
+          if ! git rev-parse --verify --quiet "$base" >/dev/null; then
+            echo "::error::Cannot resolve $base. The checkout needs fetch-depth: 0 for the merge-base diff below."
+            exit 1
+          fi
+          changed=$(git diff --name-only "$base...HEAD")
+          if [ -z "$changed" ]; then
+            echo "::error::Empty diff against $base. Refusing to report success without having examined any files."
+            exit 1
+          fi
+          # Library source = a non-test .go file outside examples/ and
+          # benchmarks/. Tests, testdata, markdown, CI, tooling and examples
+          # ride along with the next release and need no entry of their own.
+          # testutil/ is deliberately NOT exempt: it exports symbols, and
+          # v1.40.0 was a MINOR precisely because testutil/fuzz gained some.
+          src=$(printf '%s\n' "$changed" | grep -E '\.go$' | grep -vE '_test\.go$' | grep -vE '^(examples|benchmarks)/' || true)
+          if [ -z "$src" ]; then
+            echo "No library source changed — entries not required."
+            exit 0
+          fi
+          echo "Library source changed:"; printf '%s\n' "$src" | sed 's/^/  /'
+          missing=
+          printf '%s\n' "$changed" | grep -qx 'CHANGELOG.md' || missing="$missing CHANGELOG.md"
+          printf '%s\n' "$changed" | grep -qx 'RELEASE_NOTES.md' || missing="$missing RELEASE_NOTES.md"
+          if [ -n "$missing" ]; then
+            echo "::error::This PR changes library source but does not touch:$missing. Add an entry to each — see CONTRIBUTING.md, \"CHANGELOG and release notes\". If the change ships no behaviour at all, apply the 'no-release-notes' label to skip this check."
+            exit 1
+          fi
+          echo "Entries present in both files."
+
   conformance-fixtures:
     name: Conformance fixture drift
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,25 @@ jobs:
       - run: npm ci
         working-directory: testutil
       - run: go test -race ./...
+      # RELEASE_NOTES.md is cumulative and newest-first, so publishing the file
+      # whole made every release page repeat every earlier release's notes —
+      # v1.43.0's body carried all 10 sections. Publish only the top one.
+      #
+      # The version check is the point of the extra step: if the tag is pushed
+      # before RELEASE_NOTES.md has a section for it, the top section is the
+      # PREVIOUS release's, and publishing that silently attaches the wrong
+      # notes to the tag. Failing here is recoverable; a wrong published body
+      # on an immutable tag is not.
+      - name: Extract this version's release notes
+        run: |
+          notes="$RUNNER_TEMP/release-notes.md"
+          awk '/^## v/{n++} n==1' RELEASE_NOTES.md > "$notes"
+          heading=$(head -n 1 "$notes")
+          if [ "$heading" != "## $GITHUB_REF_NAME" ]; then
+            echo "::error file=RELEASE_NOTES.md::Top section is \"$heading\" but the tag is $GITHUB_REF_NAME. Add a \"## $GITHUB_REF_NAME\" section at the top of RELEASE_NOTES.md, then re-push the tag."
+            exit 1
+          fi
+          echo "Publishing $(wc -l < "$notes") lines of notes for $GITHUB_REF_NAME."
       - uses: softprops/action-gh-release@v2
         with:
-          body_path: RELEASE_NOTES.md
+          body_path: ${{ runner.temp }}/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,34 @@ jobs:
             exit 1
           fi
           echo "Publishing $(wc -l < "$notes") lines of notes for $GITHUB_REF_NAME."
+      # Nothing used to check CHANGELOG.md at tag time, so a release could ship
+      # with no entry at all, or with a heading date left over from whenever the
+      # PR was written — v1.44.0 was authored 08-02 and tagged 08-04, and the
+      # stale date was caught by hand. A tag is immutable, so the date it
+      # records is wrong forever; failing the job is the recoverable option.
+      #
+      # The date must be the job's UTC date or the day before. The one-day
+      # window absorbs timezone skew: a maintainer tagging in the evening west
+      # of UTC writes their local date, which is already "yesterday" in UTC.
+      - name: Verify the CHANGELOG entry for this tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          top=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] ')
+          if [ "$top" != "$version" ]; then
+            echo "::error file=CHANGELOG.md::Newest version heading is [$top] but the tag is $GITHUB_REF_NAME. CHANGELOG.md is newest-first, so add a \"## [$version]\" section at the top before tagging."
+            exit 1
+          fi
+          heading=$(grep -m1 -F "## [$version]" CHANGELOG.md)
+          today=$(date -u +%F)
+          yesterday=$(date -u -d '1 day ago' +%F)
+          case "$heading" in
+            *"$today"* | *"$yesterday"*) ;;
+            *)
+              echo "::error file=CHANGELOG.md::Heading \"$heading\" does not carry the release date. Expected $today (or $yesterday for timezone skew). Update the date, then re-push the tag."
+              exit 1
+              ;;
+          esac
+          echo "CHANGELOG heading OK: $heading"
       - uses: softprops/action-gh-release@v2
         with:
           body_path: ${{ runner.temp }}/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.44.0] — 2026-08-02
+## [1.44.0] — 2026-08-04
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Room names must be valid UTF-8.** `internal/roomname.Valid` previously
   accepted them, because ranging over a string yields `RuneError` for invalid
   bytes. Affects the HTTP and WebSocket providers alike (#209).
+- **A client whose awareness state can't be encoded as valid UTF-8 now
+  broadcasts as `null` for that client, instead of panicking the broadcast.**
+  `Awareness.EncodeUpdate` marshals state through `json.Marshal`, which
+  normally coerces invalid UTF-8 to U+FFFD — except for a `json.RawMessage`
+  value, which passes its bytes through once they pass JSON syntax
+  validation, so invalid UTF-8 inside one could still reach
+  `WriteVarString` and panic. Awareness state is ephemeral presence data,
+  not CRDT document content, so this path degrades rather than panics: one
+  peer's cursor drops instead of crashing every peer's broadcast (#209).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.44.0] — 2026-08-02
+
+### Changed
+
+- **Invalid UTF-8 is now rejected where it enters the document.** Go strings are
+  arbitrary byte sequences, but the wire format is UTF-8 and the decoder rejects
+  anything else, so a string containing invalid UTF-8 previously encoded without
+  complaint into an update that neither ygo nor Yjs could decode — a room that
+  silently stopped converging, and a stored update that could never be reloaded.
+  `YMap.Set`, `YArray.Insert`/`Push`, `YText.Insert`/`ApplyDelta`/`InsertEmbed`/
+  `Format`, the root-type accessors, the XML node-name and attribute setters and
+  `WithGUID` now panic on invalid UTF-8, naming the offending input. Values are
+  walked recursively, because V2 writes attribute and embed values through
+  `WriteAny` unsanitised where V1 routes them through `json.Marshal`.
+  `Encoder.WriteVarString` panics as a backstop for the two paths with no such
+  boundary (`RelativePosition.Tname` and `YXmlElement.NodeName` are exported
+  fields). Valid UTF-8 — including emoji, combining marks and non-Latin scripts —
+  encodes byte-identically to before (#209).
+- **Room names must be valid UTF-8.** `internal/roomname.Valid` previously
+  accepted them, because ranging over a string yields `RuneError` for invalid
+  bytes. Affects the HTTP and WebSocket providers alike (#209).
+
+### Added
+
+- `Encoder.WriteVarStringE` returns `ErrInvalidUTF8` instead of panicking, for
+  callers encoding untrusted input (#209).
+
 ## [1.43.0] — 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   complaint into an update that neither ygo nor Yjs could decode — a room that
   silently stopped converging, and a stored update that could never be reloaded.
   `YMap.Set`, `YArray.Insert`/`Push`, `YText.Insert`/`ApplyDelta`/`InsertEmbed`/
-  `Format`, the root-type accessors, the XML node-name and attribute setters and
-  `WithGUID` now panic on invalid UTF-8, naming the offending input. Values are
-  walked recursively, because V2 writes attribute and embed values through
-  `WriteAny` unsanitised where V1 routes them through `json.Marshal`.
-  `Encoder.WriteVarString` panics as a backstop for the two paths with no such
-  boundary (`RelativePosition.Tname` and `YXmlElement.NodeName` are exported
-  fields). Valid UTF-8 — including emoji, combining marks and non-Latin scripts —
-  encodes byte-identically to before (#209).
+  `Format`, the root-type accessors, the XML node-name and attribute setters,
+  `EncodeRelativePosition` and `WithGUID` now panic on invalid UTF-8, naming
+  the offending input. Values are walked recursively, because V2 writes
+  attribute and embed values through `WriteAny` unsanitised where V1 routes
+  them through `json.Marshal`. `Encoder.WriteVarString` panics as a backstop
+  for the paths with no such targeted check — `YXmlElement.NodeName` and
+  `ContentAttribute.Name` are exported fields a caller can assign directly,
+  bypassing `NewYXmlElement`/`NewContentAttribute`. Valid UTF-8 — including
+  emoji, combining marks and non-Latin scripts — encodes byte-identically to
+  before (#209).
 - **Room names must be valid UTF-8.** `internal/roomname.Valid` previously
   accepted them, because ranging over a string yields `RuneError` for invalid
   bytes. Affects the HTTP and WebSocket providers alike (#209).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,8 @@ Two files need an entry, both in your own branch. `main` is PR-protected, so any
 
 1. **`CHANGELOG.md`** — add your change under the next version's heading (e.g. `## [1.43.0] — 2026-08-14`). We do **not** use an `[Unreleased]` section: entries go directly into the version they ship in. If you don't know which version that is, ask in the PR and a maintainer will tell you — it follows from your change's API surface, not its intent (a new exported symbol is a MINOR even in a bug-fix PR).
 
+   The date is the **release** date, not the day you wrote the entry, and the release job enforces both halves: it fails if the file's newest version heading isn't the tag being pushed, or if that heading's date isn't the release date. If your PR sits for a few days, bump the date just before merging.
+
 2. **`RELEASE_NOTES.md`** — add a section for the same version, headed `## v<version>` to match the tag. `.github/workflows/release.yml` extracts the file's **top section only** and publishes it as the GitHub release body. The heading must equal the tag being pushed: if it doesn't, the release job fails rather than attaching the previous version's notes to your tag.
 
 Both files are newest-first: your new section goes at the top, above the previous release.
@@ -192,8 +194,8 @@ Before opening a PR ensure:
 - [ ] `make lint` passes with no new warnings
 - [ ] `make vet` passes (no vulnerabilities)
 - [ ] New tests are added for changed behaviour
-- [ ] `CHANGELOG.md` is updated under the next version's heading (e.g. `## [1.43.0]`) — not `[Unreleased]`
-- [ ] `RELEASE_NOTES.md` has a section for that same version
+- [ ] `CHANGELOG.md` is updated under the next version's heading (e.g. `## [1.43.0]`) — not `[Unreleased]` — carrying the release date
+- [ ] `RELEASE_NOTES.md` has a `## v<version>` section for that same version, at the top of the file
 - [ ] Wire-format changes regenerate fixtures (`make fixtures`) and update `TestCompat_` tests
 - [ ] Doc comments updated for any changed public API
 - [ ] PR description links the related issue (`Closes #NNN`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,8 @@ Both files are newest-first: your new section goes at the top, above the previou
 
 **Exemption.** A PR that changes no library behaviour — documentation, tests, CI, tooling, benchmarks — needs neither entry, and does not get a release of its own. Those changes ride along with whatever release comes next. If you are unsure whether your PR qualifies, assume it does not and add the entries; an unnecessary entry is trivial to drop in review, a missing one blocks a tag.
 
+The **Release docs** CI job enforces both files, and decides the exemption by path: a changed non-test `.go` file outside `examples/` and `benchmarks/` requires entries, and everything else does not. `testutil/` is deliberately *not* exempt — it exports symbols, and v1.40.0 was a MINOR because `testutil/fuzz` gained some. The path rule can only approximate "changes behaviour", so if you touch such a file and genuinely ship none — a comment, a purely internal rename — apply the **`no-release-notes`** label to skip the check. The job also fails if `CHANGELOG.md` and `RELEASE_NOTES.md` name different newest versions, since the release job reads both.
+
 ## Pull Request Checklist
 
 Before opening a PR ensure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Two files need an entry, both in your own branch. `main` is PR-protected, so any
 
 1. **`CHANGELOG.md`** — add your change under the next version's heading (e.g. `## [1.43.0] — 2026-08-14`). We do **not** use an `[Unreleased]` section: entries go directly into the version they ship in. If you don't know which version that is, ask in the PR and a maintainer will tell you — it follows from your change's API surface, not its intent (a new exported symbol is a MINOR even in a bug-fix PR).
 
-2. **`RELEASE_NOTES.md`** — add a section for the same version. The release workflow publishes this file verbatim as the GitHub release body (`body_path: RELEASE_NOTES.md` in `.github/workflows/release.yml`), so a version missing from it ships with empty release notes.
+2. **`RELEASE_NOTES.md`** — add a section for the same version, headed `## v<version>` to match the tag. `.github/workflows/release.yml` extracts the file's **top section only** and publishes it as the GitHub release body. The heading must equal the tag being pushed: if it doesn't, the release job fails rather than attaching the previous version's notes to your tag.
 
 Both files are newest-first: your new section goes at the top, above the previous release.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,14 +49,14 @@ CI-gating benchmark, `BenchmarkEncodeStateAsUpdateV1`, measured **+8.63%**
 `buildTextDoc(1000)` performs 1000 one-character inserts, each in its own
 transaction, so the encoded document is 1000 items each holding a one-byte
 string — maximum validation call count, with no string length at all to
-amortize each call's fixed overhead over. A separate, ad hoc comparison (not
-committed to the repo, not reproducible from source as-is) encoding the same
-total byte count as a single bulk insert instead of 1000 tiny ones measured
-roughly +3.5%. Allocations are unchanged in both cases. `ApplyUpdateV1`
-(decode), the heavier path at roughly 115µs, moves only about +1.2%, since
-the decode side already validated UTF-8 before this release. This is not
-rounded down to "negligible": it is a real, measured cost, worst on documents
-built from many tiny string items.
+amortize each call's fixed overhead over. `BenchmarkEncodeStateAsUpdateV1_Bulk`,
+also committed, encodes the same total byte count built as a single bulk
+insert instead of 1000 tiny ones — the shape most real documents actually
+have — and measured **+2.86%** (n=10). Allocations are unchanged in both
+cases. `ApplyUpdateV1` (decode), the heavier path at roughly 115µs, moves
+only about +1.2%, since the decode side already validated UTF-8 before this
+release. This is not rounded down to "negligible": it is a real, measured
+cost, worst on documents built from many tiny string items.
 
 **Why we're paying it:** most of this cost buys defence-in-depth rather than
 closing a real gap. Every string in a document tree already passes either a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,19 +44,25 @@ relay identifier.
 
 **Performance:** encoding is slower, because `Encoder.WriteVarString` now runs
 a `utf8.ValidString` pass over every string on every encode. The committed,
-CI-gating benchmark, `BenchmarkEncodeStateAsUpdateV1`, measured **+8.63%**
-(n=10). That benchmark is a worst case rather than a typical one:
-`buildTextDoc(1000)` performs 1000 one-character inserts, each in its own
-transaction, so the encoded document is 1000 items each holding a one-byte
-string — maximum validation call count, with no string length at all to
-amortize each call's fixed overhead over. `BenchmarkEncodeStateAsUpdateV1_Bulk`,
-also committed, encodes the same total byte count built as a single bulk
-insert instead of 1000 tiny ones — the shape most real documents actually
-have — and measured **+2.86%** (n=10). Allocations are unchanged in both
-cases. `ApplyUpdateV1` (decode), the heavier path at roughly 115µs, moves
-only about +1.2%, since the decode side already validated UTF-8 before this
-release. This is not rounded down to "negligible": it is a real, measured
-cost, worst on documents built from many tiny string items.
+CI-gating benchmark, `BenchmarkEncodeStateAsUpdateV1`, measured **+7.45%**
+(n=10, quiet machine). This benchmark's result is noticeably sensitive to
+what else is running on the machine at the time — repeated n=10 runs have
+landed anywhere from roughly flat to the high single digits depending on
+background load — so +7.45% should be read as a representative order of
+magnitude rather than a precise constant; treat it as "mid-single-digit to
+high-single-digit percent," not a number good to two decimal places. That
+benchmark is also a worst case rather than a typical one: `buildTextDoc(1000)`
+performs 1000 one-character inserts, each in its own transaction, so the
+encoded document is 1000 items each holding a one-byte string — maximum
+validation call count, with no string length at all to amortize each call's
+fixed overhead over. `BenchmarkEncodeStateAsUpdateV1_Bulk`, also committed,
+encodes the same total byte count built as a single bulk insert instead of
+1000 tiny ones — the shape most real documents actually have — and measured
+**+2.86%** (n=10). Allocations are unchanged in both cases. `ApplyUpdateV1`
+(decode), the heavier path at roughly 115µs, moves only about +1.2%, since
+the decode side already validated UTF-8 before this release. This is not
+rounded down to "negligible": it is a real, measured cost, worst on documents
+built from many tiny string items.
 
 **Why we're paying it:** most of this cost buys defence-in-depth rather than
 closing a real gap. Every string in a document tree already passes either a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,30 +42,37 @@ else in this change coerces; this is the sole, deliberate exception, guarding
 a live goroutine against an application's own string rather than a wire or
 relay identifier.
 
-**Performance:** encoding is roughly 3-5% slower depending on document shape,
-because `Encoder.WriteVarString` now runs a `utf8.ValidString` pass over every
-string on every encode. The worst case is a document built from very many
-tiny string items (our CI benchmark, which does 1000 one-character inserts in
-1000 separate transactions, showed +5.48%, with one sample run as high as
-+8.63% at the top of its run-to-run variance) because per-string call
-overhead dominates and there's no length to amortize the scan over. A more
-realistic shape — fewer, larger strings — showed +3.55%. Allocations are
-unchanged in both shapes. `ApplyUpdateV1` (decode), the heavier path at
-roughly 115µs, moves only about +1.2%, since the decode side already
-validated UTF-8 before this release. This is not rounded down to
-"negligible": it is a real, measured cost.
+**Performance:** encoding is slower, because `Encoder.WriteVarString` now runs
+a `utf8.ValidString` pass over every string on every encode. The committed,
+CI-gating benchmark, `BenchmarkEncodeStateAsUpdateV1`, measured **+8.63%**
+(n=10). That benchmark is a worst case rather than a typical one:
+`buildTextDoc(1000)` performs 1000 one-character inserts, each in its own
+transaction, so the encoded document is 1000 items each holding a one-byte
+string — maximum validation call count, with no string length at all to
+amortize each call's fixed overhead over. A separate, ad hoc comparison (not
+committed to the repo, not reproducible from source as-is) encoding the same
+total byte count as a single bulk insert instead of 1000 tiny ones measured
+roughly +3.5%. Allocations are unchanged in both cases. `ApplyUpdateV1`
+(decode), the heavier path at roughly 115µs, moves only about +1.2%, since
+the decode side already validated UTF-8 before this release. This is not
+rounded down to "negligible": it is a real, measured cost, worst on documents
+built from many tiny string items.
 
 **Why we're paying it:** most of this cost buys defence-in-depth rather than
 closing a real gap. Every string in a document tree already passes either a
 mutator boundary check (the new validation added in this release) or the
 validating decoder (`ReadVarString` has always rejected invalid UTF-8 on the
-read side). The encode-time check added here uniquely covers only strings
-assigned directly to exported struct fields that bypass the mutator API —
-and of those, `RelativePosition.Tname` already had its own targeted check
-before this release. We are knowingly paying the ~3-5% so that
-`YXmlElement.NodeName` and `ContentAttribute.Name` — both reachable by direct
-field assignment, not just through a constructor — cannot silently produce an
-update no decoder will accept.
+read side). The encode-time check added here uniquely covers strings
+assigned directly to exported struct fields that bypass the mutator API. For
+`RelativePosition.Tname` this release adds a targeted check at
+`EncodeRelativePosition`, so a caller building `RelativePosition{Tname: bad}`
+by hand — there is no constructor to intercept it — gets a panic naming the
+field rather than the encoder's generic one. `YXmlElement.NodeName` and
+`ContentAttribute.Name` are the fields left relying on the generic
+`Encoder.WriteVarString` backstop alone: both are exported and directly
+assignable, bypassing `NewYXmlElement`/`NewContentAttribute`. We are
+knowingly paying the encode-time cost so that none of these three paths can
+silently produce an update no decoder will accept.
 
 **This change deliberately reverses a documented decision.** Commit
 `c3ba5ff` (2026-05-19, issue #77) added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,103 @@
+## v1.44.0
+
+**Who is affected:** only callers who put non-UTF-8 bytes into a document —
+a Go `string` holding an invalid UTF-8 byte sequence, passed to `YMap.Set`,
+`YArray.Insert`/`Push`, `YText.Insert`/`ApplyDelta`/`InsertEmbed`/`Format`, a
+root-type accessor, an XML node-name/attribute setter, or `WithGUID`. Most
+callers are not doing this — Go string literals and anything read from JSON,
+HTTP bodies, or ordinary text sources are valid UTF-8 already. If you build
+strings from raw byte slices, non-UTF-8-safe truncation, or another encoding
+without converting, you may be affected.
+
+**What changes:** those calls now **panic**, naming the offending input, where
+previously they succeeded and produced an update that encoded without
+complaint but that neither ygo nor Yjs could decode — a room that silently
+stopped converging and a stored update that could never be reloaded. A panic
+on write is a large behavior change but it replaces silent, hard-to-diagnose
+corruption with an immediate, attributable failure at the point the bad
+string was introduced, instead of downstream at decode time (or never, if the
+divergence went unnoticed).
+
+**How to prepare:**
+- **Pre-check** with `utf8.ValidString` (standard library `unicode/utf8`)
+  before passing a string into any of the calls above, if you can't already
+  guarantee the string is valid UTF-8.
+- **Recover**, if you'd rather catch the panic at a call boundary than
+  pre-check every string (e.g., wrapping a batch-import path that processes
+  many documents and should skip/report a bad one rather than crash the
+  whole batch).
+- **Use `Encoder.WriteVarStringE`** if you're working at the encoding layer
+  directly (not through the CRDT mutator API): it returns `ErrInvalidUTF8`
+  instead of panicking, for callers encoding untrusted input themselves.
+
+**The one place ygo repairs instead of rejecting:** the WebSocket provider's
+auth reply path (`encodeAuthMessage` in `provider/websocket/peer.go`) coerces
+an app-supplied diagnostic string — an `OnTokenAuth` hook's error text, or the
+`"read-write"`/`"readonly"` scope label — with `strings.ToValidUTF8` rather
+than panicking. That string runs on a live connection goroutine at a point
+where crashing the goroutine over a malformed error message from the
+application layer would be worse than the alternative: replacing invalid runs
+with U+FFFD and keeping the connection and the diagnostic readable. Nowhere
+else in this change coerces; this is the sole, deliberate exception, guarding
+a live goroutine against an application's own string rather than a wire or
+relay identifier.
+
+**Performance:** encoding is roughly 3-5% slower depending on document shape,
+because `Encoder.WriteVarString` now runs a `utf8.ValidString` pass over every
+string on every encode. The worst case is a document built from very many
+tiny string items (our CI benchmark, which does 1000 one-character inserts in
+1000 separate transactions, showed +5.48%, with one sample run as high as
++8.63% at the top of its run-to-run variance) because per-string call
+overhead dominates and there's no length to amortize the scan over. A more
+realistic shape — fewer, larger strings — showed +3.55%. Allocations are
+unchanged in both shapes. `ApplyUpdateV1` (decode), the heavier path at
+roughly 115µs, moves only about +1.2%, since the decode side already
+validated UTF-8 before this release. This is not rounded down to
+"negligible": it is a real, measured cost.
+
+**Why we're paying it:** most of this cost buys defence-in-depth rather than
+closing a real gap. Every string in a document tree already passes either a
+mutator boundary check (the new validation added in this release) or the
+validating decoder (`ReadVarString` has always rejected invalid UTF-8 on the
+read side). The encode-time check added here uniquely covers only strings
+assigned directly to exported struct fields that bypass the mutator API —
+and of those, `RelativePosition.Tname` already had its own targeted check
+before this release. We are knowingly paying the ~3-5% so that
+`YXmlElement.NodeName` and `ContentAttribute.Name` — both reachable by direct
+field assignment, not just through a constructor — cannot silently produce an
+update no decoder will accept.
+
+**This change deliberately reverses a documented decision.** Commit
+`c3ba5ff` (2026-05-19, issue #77) added
+`TestUnit_VarString_AsymmetricUTF8Contract`, codifying "write trusts, read
+validates" — deliberately asymmetric, on the reasoning that adding write-side
+validation would break callers passing pre-encoded data through the varstring
+path. That asymmetry is now reversed: `WriteVarString` validates. The
+reasoning that changed is this — a caller with genuinely pre-encoded binary
+data was never using the varstring wire format correctly in the first place;
+`WriteVarBytes` is the correct call for that, because a varstring is UTF-8 by
+wire definition, not an arbitrary-bytes container. What such a caller
+produces today, by routing binary through `WriteVarString`, is an update that
+no decoder — ygo's own `ReadVarString`, or Yjs's — will accept. Validating on
+write closes a contract that was already broken in practice; it does not
+newly break a working pattern.
+
+### Changed
+
+- **Invalid UTF-8 is now rejected where it enters the document**, across
+  `YMap`, `YArray`, `YText`, the XML types, `RelativePosition`, and
+  `Doc.WithGUID`. See the upgrade impact above. (#209)
+- **Room names must be valid UTF-8.** `internal/roomname.Valid` previously
+  accepted invalid UTF-8, because ranging over a Go string yields
+  `utf8.RuneError` for bad bytes rather than failing outright. Affects both
+  the HTTP and WebSocket providers. (#209)
+
+### Added
+
+- `Encoder.WriteVarStringE` — the non-panicking, error-returning variant of
+  `WriteVarString`, for callers who want to handle invalid UTF-8 rather than
+  have it panic. (#209)
+
 ## v1.43.0
 
 ygo could decode and materialise nested Y types but offered no way to construct

--- a/awareness/awareness.go
+++ b/awareness/awareness.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/reearth/ygo/encoding"
 )
@@ -483,9 +484,30 @@ func (a *Awareness) EncodeUpdate(clientIDs []uint64) []byte {
 			enc.WriteVarString("null")
 		} else {
 			b, err := json.Marshal(cs.State)
-			if err != nil {
+			switch {
+			case err != nil:
 				enc.WriteVarString("null")
-			} else {
+			case !utf8.Valid(b):
+				// json.Marshal coerces invalid UTF-8 in an ordinary Go string
+				// to U+FFFD, but it passes a json.RawMessage value through
+				// once its bytes pass JSON *syntax* validation — a
+				// syntactically valid JSON string token can still contain
+				// invalid UTF-8 in its content, and that content sails
+				// through untouched. Left alone, that reaches
+				// WriteVarString, which panics.
+				//
+				// This deliberately differs from the panic-at-the-mutator
+				// policy used for document content (CRDT struct/YText/YMap
+				// data): awareness state is ephemeral presence information,
+				// not persisted CRDT content, and EncodeUpdate runs on a
+				// broadcast goroutine serving every connected peer at once.
+				// Dropping one client's cursor as "null" is a peer losing a
+				// presence indicator for a moment; panicking here would take
+				// down the broadcast for every peer over one client's bad
+				// input. Do not "fix" this to panic — that would trade a
+				// minor, contained degradation for a shared-goroutine crash.
+				enc.WriteVarString("null")
+			default:
 				enc.WriteVarString(string(b))
 			}
 		}

--- a/awareness/awareness_test.go
+++ b/awareness/awareness_test.go
@@ -2,6 +2,7 @@ package awareness_test
 
 import (
 	"context"
+	"encoding/json"
 	"runtime"
 	"testing"
 	"time"
@@ -1043,4 +1044,63 @@ func TestUnit_RemoveExpired_FiresOnUpdate(t *testing.T) {
 	a.OnUpdate(func(awareness.UpdateEvent) { upd++ })
 	a.RemoveExpired(0) // everything older than 0 => expire client 99
 	require.Equal(t, 1, upd)
+}
+
+// ---------------------------------------------------------------------------
+// #209 addendum — json.RawMessage bypasses json.Marshal's UTF-8 coercion
+// ---------------------------------------------------------------------------
+
+// TestUnit_EncodeUpdate_InvalidUTF8RawMessage_EncodesAsNull proves that a
+// client state holding a json.RawMessage with invalid UTF-8 bytes does not
+// panic EncodeUpdate. json.Marshal ordinarily replaces invalid UTF-8 with
+// U+FFFD, but that coercion happens while encoding a Go string; a
+// json.RawMessage is emitted as-is once it passes JSON *syntax* validation,
+// so a syntactically valid JSON string token (quotes and all) whose byte
+// content isn't valid UTF-8 sails through json.Marshal untouched and reaches
+// WriteVarString still broken. That client's entry must degrade to the wire
+// string "null" instead, exactly like the json.Marshal-error path three
+// lines above it. A normal state encoded alongside it in the same call must
+// be completely unaffected.
+func TestUnit_EncodeUpdate_InvalidUTF8RawMessage_EncodesAsNull(t *testing.T) {
+	// A syntactically valid JSON string ("...") whose content is the single
+	// invalid UTF-8 byte 0xFF. json.Compact accepts this (it only checks JSON
+	// structure), so json.Marshal passes it through rather than erroring or
+	// substituting U+FFFD.
+	invalidJSONString := json.RawMessage("\"\xff\"")
+
+	bad := awareness.New(1)
+	bad.SetLocalState(map[string]any{"cursor": invalidJSONString})
+
+	good := awareness.New(2)
+	good.SetLocalState(map[string]any{"name": "bob"})
+
+	// Fold client 2's state into client 1's awareness so a single
+	// EncodeUpdate call covers both the invalid-UTF-8 RawMessage state and
+	// an ordinary state, proving one does not affect the other.
+	require.NoError(t, bad.ApplyUpdate(good.EncodeUpdate(nil), nil))
+
+	var enc []byte
+	require.NotPanics(t, func() {
+		enc = bad.EncodeUpdate([]uint64{1, 2})
+	}, "invalid UTF-8 inside a json.RawMessage state must not panic the encoder")
+	require.NotEmpty(t, enc)
+
+	dec := encoding.NewDecoder(enc)
+	n, err := dec.ReadVarUint()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), n)
+
+	seen := map[uint64]string{}
+	for i := uint64(0); i < n; i++ {
+		id, err := dec.ReadVarUint()
+		require.NoError(t, err)
+		_, err = dec.ReadVarUint() // clock
+		require.NoError(t, err)
+		s, err := dec.ReadVarString()
+		require.NoError(t, err)
+		seen[id] = s
+	}
+
+	assert.Equal(t, "null", seen[1], "state with invalid-UTF-8 RawMessage must encode as null")
+	assert.JSONEq(t, `{"name":"bob"}`, seen[2], "a normal state alongside it must be unaffected")
 }

--- a/crdt/bench_test.go
+++ b/crdt/bench_test.go
@@ -11,6 +11,15 @@ import (
 // buildTextDoc creates a doc whose "text" YText contains n single-character
 // inserts (one transaction per character, simulating keystroke-by-keystroke
 // typing). The returned YText handle is safe to use outside Transact.
+//
+// This n-items-of-one-byte shape is a deliberate WORST CASE for any cost that
+// scales with item count or per-string overhead (encoding, decoding,
+// validation): maximum item/call count, with no string length to amortise a
+// call's fixed overhead over. It is not representative of real documents,
+// which tend to hold far fewer, much longer strings. Read a percentage off a
+// benchmark built on this helper with that in mind, and prefer
+// buildTextDocBulk below — which builds the same total byte count as a
+// single bulk insert — wherever a realistic-shape comparison is needed.
 func buildTextDoc(n int) (*Doc, *YText) { //nolint:unparam
 	doc := newTestDoc(1)
 	txt := doc.GetText("text")
@@ -147,6 +156,31 @@ func BenchmarkApplyUpdateV1(b *testing.B) {
 	}
 }
 
+// BenchmarkApplyUpdateV1_Bulk is the realistic-shape counterpart to
+// BenchmarkApplyUpdateV1 above: it applies an update built from the same
+// total byte count (1000 bytes of YText content), but built as a single bulk
+// insert in one transaction rather than 1000 one-character inserts in 1000
+// separate transactions. BenchmarkApplyUpdateV1's thousand-tiny-items shape
+// is a deliberate worst case for per-string validation work — maximum
+// validation call count, with no string length at all to amortise each
+// call's fixed overhead over — not representative of real documents, which
+// tend to hold far fewer, much longer strings. This benchmark measures that
+// more typical shape instead.
+func BenchmarkApplyUpdateV1_Bulk(b *testing.B) {
+	b.ReportAllocs()
+
+	src, _ := buildTextDocBulk(1000)
+	update := EncodeStateAsUpdateV1(src, nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst := newTestDoc(2)
+		if err := ApplyUpdateV1(dst, update, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // BenchmarkEncodeStateAsUpdateV2 encodes a ~1000-character document in the V2
 // column-oriented format.
 func BenchmarkEncodeStateAsUpdateV2(b *testing.B) {
@@ -160,12 +194,58 @@ func BenchmarkEncodeStateAsUpdateV2(b *testing.B) {
 	}
 }
 
+// BenchmarkEncodeStateAsUpdateV2_Bulk is the realistic-shape counterpart to
+// BenchmarkEncodeStateAsUpdateV2 above: it encodes a document holding the
+// same total byte count (1000 bytes of YText content), but built as a
+// single bulk insert in one transaction rather than 1000 one-character
+// inserts in 1000 separate transactions. BenchmarkEncodeStateAsUpdateV2's
+// thousand-tiny-items shape is a deliberate worst case for per-string
+// validation work — maximum validation call count, with no string length at
+// all to amortise each call's fixed overhead over — not representative of
+// real documents, which tend to hold far fewer, much longer strings. This
+// benchmark measures that more typical shape instead.
+func BenchmarkEncodeStateAsUpdateV2_Bulk(b *testing.B) {
+	b.ReportAllocs()
+
+	doc, _ := buildTextDocBulk(1000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = EncodeStateAsUpdateV2(doc, nil)
+	}
+}
+
 // BenchmarkApplyUpdateV2 applies a pre-encoded V2 update (~1000 characters)
 // to a fresh document on every iteration.
 func BenchmarkApplyUpdateV2(b *testing.B) {
 	b.ReportAllocs()
 
 	src, _ := buildTextDoc(1000)
+	update := EncodeStateAsUpdateV2(src, nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst := newTestDoc(2)
+		if err := ApplyUpdateV2(dst, update, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkApplyUpdateV2_Bulk is the realistic-shape counterpart to
+// BenchmarkApplyUpdateV2 above: it applies an update built from the same
+// total byte count (1000 bytes of YText content), but built as a single bulk
+// insert in one transaction rather than 1000 one-character inserts in 1000
+// separate transactions. BenchmarkApplyUpdateV2's thousand-tiny-items shape
+// is a deliberate worst case for per-string validation work — maximum
+// validation call count, with no string length at all to amortise each
+// call's fixed overhead over — not representative of real documents, which
+// tend to hold far fewer, much longer strings. This benchmark measures that
+// more typical shape instead.
+func BenchmarkApplyUpdateV2_Bulk(b *testing.B) {
+	b.ReportAllocs()
+
+	src, _ := buildTextDocBulk(1000)
 	update := EncodeStateAsUpdateV2(src, nil)
 
 	b.ResetTimer()

--- a/crdt/bench_test.go
+++ b/crdt/bench_test.go
@@ -22,6 +22,20 @@ func buildTextDoc(n int) (*Doc, *YText) { //nolint:unparam
 	return doc, txt
 }
 
+// buildTextDocBulk creates a doc whose "text" YText holds the same total
+// byte count as buildTextDoc(n), but inserted as a single n-byte string in
+// one transaction instead of n one-character inserts in n separate
+// transactions. It is the realistic-shape counterpart used by
+// BenchmarkEncodeStateAsUpdateV1_Bulk below.
+func buildTextDocBulk(n int) (*Doc, *YText) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("text")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, strings.Repeat("a", n), nil)
+	})
+	return doc, txt
+}
+
 // BenchmarkYText_Insert measures the cost of appending a single character to a
 // YText that already contains b.N-1 characters — i.e. each iteration extends a
 // growing document by one keystroke.
@@ -88,6 +102,27 @@ func BenchmarkEncodeStateAsUpdateV1(b *testing.B) {
 	b.ReportAllocs()
 
 	doc, _ := buildTextDoc(1000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = EncodeStateAsUpdateV1(doc, nil)
+	}
+}
+
+// BenchmarkEncodeStateAsUpdateV1_Bulk is the realistic-shape counterpart to
+// BenchmarkEncodeStateAsUpdateV1 above: it encodes a document holding the
+// same total byte count (1000 bytes of YText content), but built as a
+// single bulk insert in one transaction rather than 1000 one-character
+// inserts in 1000 separate transactions. BenchmarkEncodeStateAsUpdateV1's
+// thousand-tiny-items shape is a deliberate worst case for per-string
+// validation work — maximum validation call count, with no string length at
+// all to amortise each call's fixed overhead over — not representative of
+// real documents, which tend to hold far fewer, much longer strings. This
+// benchmark measures that more typical shape instead.
+func BenchmarkEncodeStateAsUpdateV1_Bulk(b *testing.B) {
+	b.ReportAllocs()
+
+	doc, _ := buildTextDocBulk(1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -87,7 +87,12 @@ func WithAutoLoad(v bool) DocOption { return func(d *Doc) { d.autoLoad = v } }
 func WithShouldLoad(v bool) DocOption { return func(d *Doc) { d.shouldLoad = v } }
 
 // WithCollectionID sets an optional subdocument collection identifier.
-func WithCollectionID(id string) DocOption { return func(d *Doc) { d.collectionID = id } }
+func WithCollectionID(id string) DocOption {
+	return func(d *Doc) {
+		checkUTF8("WithCollectionID", "id", id)
+		d.collectionID = id
+	}
+}
 
 // defaultMaxPendingItems is the default cap on items parked in the per-doc
 // pending queue waiting for out-of-order dependencies. Matches the per-update

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -73,7 +73,10 @@ func WithGC(gc bool) DocOption {
 // WithGUID sets the document's subdocument identifier. When a Doc is embedded
 // inside another Doc via ContentDoc, the GUID identifies it across peers.
 func WithGUID(guid string) DocOption {
-	return func(d *Doc) { d.guid = guid }
+	return func(d *Doc) {
+		checkUTF8("WithGUID", "guid", guid)
+		d.guid = guid
+	}
 }
 
 // WithAutoLoad marks a subdocument to be auto-loaded by remote peers. Default false.
@@ -357,6 +360,7 @@ func (d *Doc) getArrayLocked(name string) *YArray {
 // It takes the document lock — inside a Transact callback use txn.GetArray
 // instead (see Transact and GetText for the locking contract; issue #138).
 func (d *Doc) GetArray(name string) *YArray {
+	checkUTF8("Doc.GetArray", "name", name)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.getArrayLocked(name)
@@ -388,6 +392,7 @@ func (d *Doc) getMapLocked(name string) *YMap {
 // It takes the document lock — inside a Transact callback use txn.GetMap
 // instead (see Transact and GetText for the locking contract; issue #138).
 func (d *Doc) GetMap(name string) *YMap {
+	checkUTF8("Doc.GetMap", "name", name)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.getMapLocked(name)
@@ -425,6 +430,7 @@ func (d *Doc) getTextLocked(name string) *YText {
 //	txt := doc.GetText("t")
 //	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
 func (d *Doc) GetText(name string) *YText {
+	checkUTF8("Doc.GetText", "name", name)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.getTextLocked(name)
@@ -841,6 +847,7 @@ func (d *Doc) getXmlFragmentLocked(name string) *YXmlFragment {
 // txn.GetXmlFragment instead (see Transact and GetText for the locking
 // contract; issue #138).
 func (d *Doc) GetXmlFragment(name string) *YXmlFragment {
+	checkUTF8("Doc.GetXmlFragment", "name", name)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.getXmlFragmentLocked(name)

--- a/crdt/idmap.go
+++ b/crdt/idmap.go
@@ -3,6 +3,7 @@ package crdt
 import (
 	"fmt"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/reearth/ygo/encoding"
 )
@@ -47,8 +48,15 @@ func validateAnyValue(v any) error {
 }
 
 // NewContentAttribute validates value against the encodable lib0 domain and
-// returns the attribute. Containers are validated recursively.
+// returns the attribute. Containers are validated recursively. name must be
+// valid UTF-8 (it is written to the wire via WriteVarString in
+// writeIDMap/attrKey); ErrInvalidUTF8 is crdt's re-export of
+// encoding.ErrInvalidUTF8, so errors.Is matches whichever sentinel a caller
+// compares against.
 func NewContentAttribute(name string, value any) (*ContentAttribute, error) {
+	if !utf8.ValidString(name) {
+		return nil, ErrInvalidUTF8
+	}
 	if err := validateAnyValue(value); err != nil {
 		return nil, err
 	}

--- a/crdt/prelim_test.go
+++ b/crdt/prelim_test.go
@@ -631,10 +631,8 @@ func FuzzPrelimNestedRoundTrip(f *testing.F) {
 		if n < 0 || n > 32 {
 			t.Skip()
 		}
-		// Constrain to valid UTF-8. Go strings may hold arbitrary bytes, but
-		// ygo's varstring encoding rejects non-UTF-8 on decode — a pre-existing
-		// property unrelated to prelim construction, and letting it through
-		// would make this target test string encoding instead of wire ordering.
+		// Skip non-UTF-8 inputs: ygo rejects them at the mutator boundary by design
+		// (#209), so feeding them here would assert the guard, not the round trip.
 		if !utf8.ValidString(text) || !utf8.ValidString(kind) {
 			t.Skip()
 		}

--- a/crdt/relative_position.go
+++ b/crdt/relative_position.go
@@ -191,6 +191,13 @@ func ToAbsolutePosition(doc *Doc, rp RelativePosition) (AbsolutePosition, bool) 
 //
 // followed by VarInt(assoc).
 func EncodeRelativePosition(rp RelativePosition) []byte {
+	// Tname is an exported field on an exported struct, so a caller can build
+	// RelativePosition{Tname: bad} directly — there is no constructor to
+	// guard it at the point of the mistake. Encoder.WriteVarString would
+	// still catch it below, but that generic panic doesn't name the field;
+	// this check exists purely for a clearer message (#209).
+	checkUTF8("EncodeRelativePosition", "Tname", rp.Tname)
+
 	enc := encoding.NewEncoder()
 	switch {
 	case rp.Item != nil:

--- a/crdt/transaction.go
+++ b/crdt/transaction.go
@@ -95,6 +95,7 @@ func (t *Transaction) assertLive(method string) {
 // GetText returns the named root YText, creating it if it does not exist.
 // Safe to call inside the Transact callback; see the section comment above.
 func (t *Transaction) GetText(name string) *YText {
+	checkUTF8("Transaction.GetText", "name", name)
 	t.assertLive("GetText")
 	return t.doc.getTextLocked(name)
 }
@@ -102,6 +103,7 @@ func (t *Transaction) GetText(name string) *YText {
 // GetMap returns the named root YMap, creating it if it does not exist.
 // Safe to call inside the Transact callback; see the section comment above.
 func (t *Transaction) GetMap(name string) *YMap {
+	checkUTF8("Transaction.GetMap", "name", name)
 	t.assertLive("GetMap")
 	return t.doc.getMapLocked(name)
 }
@@ -109,6 +111,7 @@ func (t *Transaction) GetMap(name string) *YMap {
 // GetArray returns the named root YArray, creating it if it does not exist.
 // Safe to call inside the Transact callback; see the section comment above.
 func (t *Transaction) GetArray(name string) *YArray {
+	checkUTF8("Transaction.GetArray", "name", name)
 	t.assertLive("GetArray")
 	return t.doc.getArrayLocked(name)
 }
@@ -117,6 +120,7 @@ func (t *Transaction) GetArray(name string) *YArray {
 // not exist. Safe to call inside the Transact callback; see the section
 // comment above.
 func (t *Transaction) GetXmlFragment(name string) *YXmlFragment {
+	checkUTF8("Transaction.GetXmlFragment", "name", name)
 	t.assertLive("GetXmlFragment")
 	return t.doc.getXmlFragmentLocked(name)
 }

--- a/crdt/utf8.go
+++ b/crdt/utf8.go
@@ -1,0 +1,54 @@
+package crdt
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// checkUTF8 panics if s is not valid UTF-8. op names the calling method and
+// what names the offending input, so the failure points at a call site rather
+// than at the encoder (#209).
+func checkUTF8(op, what, s string) {
+	if !utf8.ValidString(s) {
+		panic(fmt.Sprintf("crdt: %s: %s: invalid UTF-8", op, what))
+	}
+}
+
+// checkAnyUTF8 walks v and panics on the first invalid string it finds.
+//
+// It mirrors the string-bearing cases of encoding.Encoder.WriteAny — string,
+// []any, and map[string]any (keys AND values). Every other case WriteAny
+// handles (nil, bool, the integer and float types, BigInt, []byte) carries no
+// text. TestUnit_CheckAnyUTF8_CoversWriteAnyStringCases guards the pairing.
+//
+// Note this deliberately does not match named map/slice types: WriteAny does
+// not either, so such a value fails at encode for its own reasons.
+func checkAnyUTF8(op, what string, v any) {
+	switch t := v.(type) {
+	case string:
+		checkUTF8(op, what, t)
+	case []any:
+		for i, e := range t {
+			checkAnyUTF8(op, fmt.Sprintf("%s[%d]", what, i), e)
+		}
+	case map[string]any:
+		for k, e := range t {
+			checkUTF8(op, fmt.Sprintf("%s key %q", what, k), k)
+			checkAnyUTF8(op, fmt.Sprintf("%s[%q]", what, k), e)
+		}
+	}
+}
+
+// checkAttrsUTF8 validates formatting attribute keys and values.
+//
+// Attributes is a named map type, so it does not match checkAnyUTF8's
+// map[string]any case; its entries are walked explicitly. This matters because
+// V1 writes attribute values through json.Marshal (which sanitises) while V2
+// writes them through WriteAny (which does not) — validating only keys would
+// leave a version-dependent failure.
+func checkAttrsUTF8(op string, attrs Attributes) {
+	for k, v := range attrs {
+		checkUTF8(op, fmt.Sprintf("attribute key %q", k), k)
+		checkAnyUTF8(op, fmt.Sprintf("attribute %q", k), v)
+	}
+}

--- a/crdt/utf8.go
+++ b/crdt/utf8.go
@@ -3,7 +3,16 @@ package crdt
 import (
 	"fmt"
 	"unicode/utf8"
+
+	"github.com/reearth/ygo/encoding"
 )
+
+// ErrInvalidUTF8 is crdt's re-export of encoding.ErrInvalidUTF8, for entry
+// points (like NewContentAttribute) whose signature already returns an error
+// rather than panicking. It is the SAME sentinel value as encoding's, not an
+// independent one, so errors.Is matches regardless of which package's name
+// callers compare against.
+var ErrInvalidUTF8 = encoding.ErrInvalidUTF8
 
 // checkUTF8 panics if s is not valid UTF-8. op names the calling method and
 // what names the offending input, so the failure points at a call site rather

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -1,0 +1,70 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnit_YMap_Set_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	t.Run("key", func(t *testing.T) {
+		doc := New()
+		m := doc.GetMap("m")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { m.Set(txn, bad, "v") })
+		})
+		require.Empty(t, m.Keys(), "document must be untouched after a rejected call")
+	})
+	t.Run("value", func(t *testing.T) {
+		doc := New()
+		m := doc.GetMap("m")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { m.Set(txn, "k", bad) })
+		})
+		require.Empty(t, m.Keys())
+	})
+	t.Run("nested value", func(t *testing.T) {
+		doc := New()
+		m := doc.GetMap("m")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) {
+				m.Set(txn, "k", map[string]any{"inner": []any{bad}})
+			})
+		})
+		require.Empty(t, m.Keys())
+	})
+}
+
+func TestUnit_YArray_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	t.Run("Push validates before mutating", func(t *testing.T) {
+		doc := New()
+		a := doc.GetArray("a")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { a.Push(txn, []any{"ok", bad}) })
+		})
+		require.Zero(t, a.Len(), "the valid leading value must not be committed")
+	})
+	t.Run("Insert", func(t *testing.T) {
+		doc := New()
+		a := doc.GetArray("a")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { a.Insert(txn, 0, []any{bad}) })
+		})
+		require.Zero(t, a.Len())
+	})
+}
+
+func TestUnit_YMapYArray_ValidUnicodeStillWorks(t *testing.T) {
+	doc := New()
+	m := doc.GetMap("m")
+	a := doc.GetArray("a")
+	require.NotPanics(t, func() {
+		doc.Transact(func(txn *Transaction) {
+			m.Set(txn, "🔑", map[string]any{"n": []any{"héllo", "😀"}})
+			a.Push(txn, []any{"ok", "wörld"})
+		})
+	})
+	require.Equal(t, 2, a.Len())
+}

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -163,6 +163,30 @@ func TestUnit_YText_RejectsInvalidUTF8(t *testing.T) {
 	})
 }
 
+// TestUnit_YText_ApplyDelta_ValidatesWholeSliceBeforeApplying guards the
+// documented all-or-nothing contract on YText.ApplyDelta (see its doc
+// comment): the ENTIRE delta slice must be validated before ANY op is
+// applied, because Transact releases the doc lock on panic but does not roll
+// back mutations already made. A delta whose first op is valid and whose
+// second op is invalid must panic AND leave the document completely
+// untouched — if validation happened op-by-op inside the apply loop instead,
+// the first (valid) Insert would already have committed, with observers
+// having already fired, before the panic on the second op.
+func TestUnit_YText_ApplyDelta_ValidatesWholeSliceBeforeApplying(t *testing.T) {
+	bad := string([]byte{0xff})
+	d := New()
+	txt := d.GetText("t")
+	requirePanicsWithInvalidUTF8(t, func() {
+		d.Transact(func(txn *Transaction) {
+			txt.ApplyDelta(txn, []Delta{
+				{Op: DeltaOpInsert, Insert: "hello"},
+				{Op: DeltaOpInsert, Insert: bad},
+			})
+		})
+	})
+	require.Empty(t, txt.ToString(), "the valid leading op must not be committed")
+}
+
 // TestUnit_YMap_Set_Detached_ValidUTF8MaterialisesOnAttach is the companion
 // positive case: a detached map built with valid (including decomposed
 // combining-mark) content must still stage correctly and materialise
@@ -204,8 +228,14 @@ func TestUnit_Doc_RootNamesRejectInvalidUTF8(t *testing.T) {
 	t.Run("WithGUID", func(t *testing.T) {
 		requirePanicsWithInvalidUTF8(t, func() { New(WithGUID(bad)) })
 	})
+	t.Run("WithCollectionID", func(t *testing.T) {
+		requirePanicsWithInvalidUTF8(t, func() { New(WithCollectionID(bad)) })
+	})
 	t.Run("valid unicode name still works", func(t *testing.T) {
 		require.NotPanics(t, func() { New().GetText("документ 📄") })
+	})
+	t.Run("valid unicode collection id still works", func(t *testing.T) {
+		require.NotPanics(t, func() { New(WithCollectionID("документ 📄")) })
 	})
 }
 

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -182,3 +182,26 @@ func TestUnit_YMap_Set_Detached_ValidUTF8MaterialisesOnAttach(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, combining, v)
 }
+
+// TestUnit_Doc_RootNamesRejectInvalidUTF8 guards the worst case in the whole
+// UTF-8 plan: a bad ROOT TYPE NAME poisons the entire document (it's encoded
+// on every update touching that root), not just one value. Covers all four
+// root accessors plus the subdocument GUID (WithGUID).
+func TestUnit_Doc_RootNamesRejectInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	doc := New()
+	for name, fn := range map[string]func(){
+		"GetArray":       func() { doc.GetArray(bad) },
+		"GetMap":         func() { doc.GetMap(bad) },
+		"GetText":        func() { doc.GetText(bad) },
+		"GetXmlFragment": func() { doc.GetXmlFragment(bad) },
+	} {
+		t.Run(name, func(t *testing.T) { requirePanicsWithInvalidUTF8(t, fn) })
+	}
+	t.Run("WithGUID", func(t *testing.T) {
+		requirePanicsWithInvalidUTF8(t, func() { New(WithGUID(bad)) })
+	})
+	t.Run("valid unicode name still works", func(t *testing.T) {
+		require.NotPanics(t, func() { New().GetText("документ 📄") })
+	})
+}

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -57,14 +57,68 @@ func TestUnit_YArray_RejectsInvalidUTF8(t *testing.T) {
 }
 
 func TestUnit_YMapYArray_ValidUnicodeStillWorks(t *testing.T) {
+	// "héllo" uses precomposed U+00E9; combining is a decomposed sequence
+	// ("e" + U+0301 COMBINING ACUTE ACCENT) — two valid-UTF-8 byte shapes for
+	// what looks like the same character, both of which must pass unchanged.
+	combining := "e" + "́"
 	doc := New()
 	m := doc.GetMap("m")
 	a := doc.GetArray("a")
 	require.NotPanics(t, func() {
 		doc.Transact(func(txn *Transaction) {
-			m.Set(txn, "🔑", map[string]any{"n": []any{"héllo", "😀"}})
+			m.Set(txn, "🔑", map[string]any{"n": []any{"héllo", "😀", combining}})
 			a.Push(txn, []any{"ok", "wörld"})
 		})
 	})
 	require.Equal(t, 2, a.Len())
+}
+
+// TestUnit_YMap_Set_Detached_RejectsInvalidUTF8 closes a coverage gap: the
+// tests above all use doc.GetMap, which attaches immediately, so t.detached()
+// is never true and nothing would fail if the checks were ever moved past
+// the `if t.detached()` branch in YMap.Set. NewMapPrelim (v1.43.0's public
+// prelim constructor) is the real, documented way to reach that branch — it
+// stages content, and the wire only sees it once the type attaches — so a
+// regression here would ship invalid UTF-8 in the staged/attach path.
+func TestUnit_YMap_Set_Detached_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	doc := New()
+
+	t.Run("key", func(t *testing.T) {
+		m := NewMapPrelim()
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { m.Set(txn, bad, "v") })
+		})
+		require.Empty(t, m.Keys(), "detached map must be untouched after a rejected call")
+	})
+	t.Run("value", func(t *testing.T) {
+		m := NewMapPrelim()
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { m.Set(txn, "k", bad) })
+		})
+		require.Empty(t, m.Keys())
+	})
+}
+
+// TestUnit_YMap_Set_Detached_ValidUTF8MaterialisesOnAttach is the companion
+// positive case: a detached map built with valid (including decomposed
+// combining-mark) content must still stage correctly and materialise
+// unchanged once attached — proving the new checks do not break the staged
+// path they guard.
+func TestUnit_YMap_Set_Detached_ValidUTF8MaterialisesOnAttach(t *testing.T) {
+	combining := "e" + "́"
+	doc := New()
+	parent := doc.GetMap("parent") // hoisted: GetMap locks the doc, Transact holds that lock
+
+	child := NewMapPrelim()
+	doc.Transact(func(txn *Transaction) {
+		child.Set(txn, "🔑", combining)
+		parent.Set(txn, "child", child)
+	})
+
+	// child is the same *YMap; item.integrate attached it in place.
+	require.Equal(t, []string{"🔑"}, child.Keys())
+	v, ok := child.Get("🔑")
+	require.True(t, ok)
+	require.Equal(t, combining, v)
 }

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -205,3 +205,39 @@ func TestUnit_Doc_RootNamesRejectInvalidUTF8(t *testing.T) {
 		require.NotPanics(t, func() { New().GetText("документ 📄") })
 	})
 }
+
+// TestUnit_Transaction_RootNamesRejectInvalidUTF8 covers the OTHER root-name
+// entry point: Transaction.GetText/GetMap/GetArray/GetXmlFragment. These are
+// the documented, recommended way to resolve a root type from INSIDE a
+// Transact callback (Doc.GetText et al. would self-deadlock there — see
+// GetText's doc comment and issue #138) — so this path sees more use inside
+// transactions than Doc.GetX, not less. Each must panic independently of
+// Doc.GetX's checks, since Transaction.GetX calls the lock-free
+// t.doc.get*Locked helper directly rather than going through Doc.GetX.
+//
+// These necessarily run inside a Transact callback (that's the only place a
+// *Transaction exists), which doubles as proof the panic propagates cleanly
+// out of Transact without deadlocking (Transact has been panic-safe since
+// v1.1.1).
+func TestUnit_Transaction_RootNamesRejectInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	for name, fn := range map[string]func(*Transaction){
+		"GetText":        func(txn *Transaction) { txn.GetText(bad) },
+		"GetMap":         func(txn *Transaction) { txn.GetMap(bad) },
+		"GetArray":       func(txn *Transaction) { txn.GetArray(bad) },
+		"GetXmlFragment": func(txn *Transaction) { txn.GetXmlFragment(bad) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc := New()
+			requirePanicsWithInvalidUTF8(t, func() {
+				doc.Transact(func(txn *Transaction) { fn(txn) })
+			})
+		})
+	}
+	t.Run("valid unicode name still works", func(t *testing.T) {
+		doc := New()
+		require.NotPanics(t, func() {
+			doc.Transact(func(txn *Transaction) { txn.GetText("документ 📄") })
+		})
+	})
+}

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -241,3 +241,107 @@ func TestUnit_Transaction_RootNamesRejectInvalidUTF8(t *testing.T) {
 		})
 	})
 }
+
+// TestUnit_YXml_RejectsInvalidUTF8 guards the three XML entry points that
+// write a caller-supplied string to the wire: the node name passed to
+// NewYXmlElement, and the attribute key/value pairs passed to SetAttribute
+// and SetAttributeValue. NodeName is also an exported field a caller can
+// assign directly, bypassing NewYXmlElement entirely — that path is NOT
+// guarded here; Encoder.WriteVarString (Task 1) is the deliberate backstop
+// for it, since adding a setter or reflection here would be chasing an
+// unreachable corner for a struct field Yjs itself exposes as public.
+func TestUnit_YXml_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	t.Run("NewYXmlElement node name", func(t *testing.T) {
+		requirePanicsWithInvalidUTF8(t, func() { NewYXmlElement(bad) })
+	})
+	t.Run("SetAttribute key and value", func(t *testing.T) {
+		doc := New()
+		frag := doc.GetXmlFragment("f")
+		el := NewYXmlElement("div")
+		doc.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, bad, "v") })
+		})
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, "k", bad) })
+		})
+		_, ok := el.GetAttribute("k")
+		require.False(t, ok, "no attribute may be committed by a rejected call")
+	})
+	t.Run("SetAttributeValue nested", func(t *testing.T) {
+		doc := New()
+		frag := doc.GetXmlFragment("f2")
+		el := NewYXmlElement("div")
+		doc.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) {
+				el.SetAttributeValue(txn, "k", []any{bad})
+			})
+		})
+	})
+}
+
+// TestUnit_YXmlElement_SetAttribute_Detached_RejectsInvalidUTF8 closes the
+// same coverage gap Task 3 hit for YMap.Set: SetAttributeValue has an early
+// `if t.detached()` branch that buffers into prelimAttrs, and Task 3's own
+// history shows validation placed AFTER such a branch lets bad input sail
+// through the buffer and materialise unvalidated at attach. Exercise the
+// detached path directly (an element that was never inserted into a
+// fragment) for both SetAttribute and SetAttributeValue, on both key and
+// value.
+func TestUnit_YXmlElement_SetAttribute_Detached_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	doc := New()
+
+	t.Run("SetAttribute key", func(t *testing.T) {
+		el := NewYXmlElement("div")
+		require.True(t, el.detached())
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, bad, "v") })
+		})
+		_, ok := el.GetAttribute(bad)
+		require.False(t, ok, "detached element must be untouched after a rejected call")
+	})
+	t.Run("SetAttribute value", func(t *testing.T) {
+		el := NewYXmlElement("div")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, "k", bad) })
+		})
+		_, ok := el.GetAttribute("k")
+		require.False(t, ok)
+	})
+	t.Run("SetAttributeValue nested value", func(t *testing.T) {
+		el := NewYXmlElement("div")
+		requirePanicsWithInvalidUTF8(t, func() {
+			doc.Transact(func(txn *Transaction) {
+				el.SetAttributeValue(txn, "k", []any{bad})
+			})
+		})
+		_, ok := el.GetAttribute("k")
+		require.False(t, ok)
+	})
+}
+
+// TestUnit_YXml_ValidUnicodeStillWorks is the positive companion: emoji,
+// non-Latin scripts and combining marks must still work as node names and
+// attribute keys/values, both attached and detached.
+func TestUnit_YXml_ValidUnicodeStillWorks(t *testing.T) {
+	combining := "e" + "́"
+	require.NotPanics(t, func() { NewYXmlElement("документ📄") })
+
+	doc := New()
+	frag := doc.GetXmlFragment("f")
+	el := NewYXmlElement("タイトル")
+	require.NotPanics(t, func() {
+		doc.Transact(func(txn *Transaction) {
+			frag.InsertElement(txn, 0, el)
+			el.SetAttribute(txn, "🔑", "wörld")
+			el.SetAttributeValue(txn, "n", combining)
+		})
+	})
+	v, ok := el.GetAttribute("🔑")
+	require.True(t, ok)
+	require.Equal(t, "wörld", v)
+}

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -100,6 +100,66 @@ func TestUnit_YMap_Set_Detached_RejectsInvalidUTF8(t *testing.T) {
 	})
 }
 
+func TestUnit_YText_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+	newDoc := func() (*Doc, *YText) {
+		d := New()
+		return d, d.GetText("t")
+	}
+
+	t.Run("Insert content", func(t *testing.T) {
+		d, txt := newDoc()
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) { txt.Insert(txn, 0, bad, nil) })
+		})
+		require.Empty(t, txt.ToString())
+	})
+	t.Run("Insert attrs value", func(t *testing.T) {
+		d, txt := newDoc()
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) {
+				txt.Insert(txn, 0, "ok", Attributes{"bold": bad})
+			})
+		})
+		require.Empty(t, txt.ToString())
+	})
+	t.Run("Format attribute key", func(t *testing.T) {
+		d, txt := newDoc()
+		d.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "hello", nil) })
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) { txt.Format(txn, 0, 5, Attributes{bad: "x"}) })
+		})
+	})
+	t.Run("InsertEmbed value", func(t *testing.T) {
+		d, txt := newDoc()
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) {
+				txt.InsertEmbed(txn, 0, map[string]any{"src": bad}, nil)
+			})
+		})
+	})
+	t.Run("ApplyDelta insert", func(t *testing.T) {
+		d, txt := newDoc()
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) {
+				txt.ApplyDelta(txn, []Delta{{Op: DeltaOpInsert, Insert: bad}})
+			})
+		})
+		require.Empty(t, txt.ToString())
+	})
+	t.Run("ApplyDelta attributes", func(t *testing.T) {
+		d, txt := newDoc()
+		requirePanicsWithInvalidUTF8(t, func() {
+			d.Transact(func(txn *Transaction) {
+				txt.ApplyDelta(txn, []Delta{{
+					Op: DeltaOpInsert, Insert: "ok", Attributes: Attributes{"b": bad},
+				}})
+			})
+		})
+		require.Empty(t, txt.ToString())
+	})
+}
+
 // TestUnit_YMap_Set_Detached_ValidUTF8MaterialisesOnAttach is the companion
 // positive case: a detached map built with valid (including decomposed
 // combining-mark) content must still stage correctly and materialise

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -357,6 +357,48 @@ func TestUnit_YXmlElement_SetAttribute_Detached_RejectsInvalidUTF8(t *testing.T)
 	})
 }
 
+// TestUnit_YXmlElement_SetAttribute_PanicNamesCallSite guards the seam
+// extracted between SetAttribute and SetAttributeValue: both now delegate to
+// an unexported setAttributeValue(op, ...), and the panic must always name
+// whichever exported method the caller actually invoked, not the shared
+// helper. Previously SetAttribute validated its string value itself and then
+// handed off to SetAttributeValue, which validated it a second time.
+func TestUnit_YXmlElement_SetAttribute_PanicNamesCallSite(t *testing.T) {
+	bad := string([]byte{0xff})
+	newAttachedElement := func() (*Doc, *YXmlElement) {
+		doc := New()
+		frag := doc.GetXmlFragment("f")
+		el := NewYXmlElement("div")
+		doc.Transact(func(txn *Transaction) { frag.InsertElement(txn, 0, el) })
+		return doc, el
+	}
+
+	t.Run("SetAttribute bad key", func(t *testing.T) {
+		doc, el := newAttachedElement()
+		requirePanicsWithMessage(t, "crdt: YXmlElement.SetAttribute: key: invalid UTF-8", func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, bad, "v") })
+		})
+	})
+	t.Run("SetAttribute bad value", func(t *testing.T) {
+		doc, el := newAttachedElement()
+		requirePanicsWithMessage(t, "crdt: YXmlElement.SetAttribute: value: invalid UTF-8", func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttribute(txn, "k", bad) })
+		})
+	})
+	t.Run("SetAttributeValue bad key", func(t *testing.T) {
+		doc, el := newAttachedElement()
+		requirePanicsWithMessage(t, "crdt: YXmlElement.SetAttributeValue: key: invalid UTF-8", func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttributeValue(txn, bad, "v") })
+		})
+	})
+	t.Run("SetAttributeValue bad value", func(t *testing.T) {
+		doc, el := newAttachedElement()
+		requirePanicsWithMessage(t, "crdt: YXmlElement.SetAttributeValue: value: invalid UTF-8", func() {
+			doc.Transact(func(txn *Transaction) { el.SetAttributeValue(txn, "k", bad) })
+		})
+	})
+}
+
 // TestUnit_YXml_ValidUnicodeStillWorks is the positive companion: emoji,
 // non-Latin scripts and combining marks must still work as node names and
 // attribute keys/values, both attached and detached.

--- a/crdt/utf8_boundary_test.go
+++ b/crdt/utf8_boundary_test.go
@@ -1,9 +1,12 @@
 package crdt
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/encoding"
 )
 
 func TestUnit_YMap_Set_RejectsInvalidUTF8(t *testing.T) {
@@ -344,4 +347,49 @@ func TestUnit_YXml_ValidUnicodeStillWorks(t *testing.T) {
 	v, ok := el.GetAttribute("🔑")
 	require.True(t, ok)
 	require.Equal(t, "wörld", v)
+}
+
+// TestUnit_Attribution_RejectsInvalidUTF8 covers NewContentAttribute, the last
+// entry point with no panic — its signature already returns an error, so the
+// governing rule for this plan (use an error wherever one already exists;
+// panic only where adding one would expand the API) applies here instead of
+// checkUTF8's panic.
+func TestUnit_Attribution_RejectsInvalidUTF8(t *testing.T) {
+	bad := string([]byte{0xff})
+
+	// The signature already carries an error, so use it — no panic here.
+	got, err := NewContentAttribute(bad, "v")
+	require.ErrorIs(t, err, encoding.ErrInvalidUTF8)
+	require.Nil(t, got)
+
+	// Must variant panics, as it does for every other error.
+	requirePanicsWithInvalidUTF8Any(t, func() { MustContentAttribute(bad, "v") })
+
+	ok, err := NewContentAttribute("valid", "v")
+	require.NoError(t, err)
+	require.NotNil(t, ok)
+}
+
+// TestUnit_EncodeRelativePosition_RejectsInvalidTname guards the other path
+// with no input boundary to guard: Tname is an exported field on an exported
+// struct, so a caller can build RelativePosition{Tname: bad} as a literal —
+// there is no constructor to intercept it. Validation lives at the encode
+// entry point instead.
+func TestUnit_EncodeRelativePosition_RejectsInvalidTname(t *testing.T) {
+	rp := RelativePosition{Tname: string([]byte{0xff})}
+	requirePanicsWithInvalidUTF8(t, func() { EncodeRelativePosition(rp) })
+}
+
+// requirePanicsWithInvalidUTF8Any is requirePanicsWithInvalidUTF8's sibling
+// for panics that carry an error value rather than a string.
+// MustContentAttribute does `panic(err)` with the raw error value, not a
+// string, so the string-typed helper above does not apply here.
+func requirePanicsWithInvalidUTF8Any(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected a panic")
+		require.Contains(t, fmt.Sprint(r), "invalid UTF-8")
+	}()
+	fn()
 }

--- a/crdt/utf8_regression_test.go
+++ b/crdt/utf8_regression_test.go
@@ -55,6 +55,13 @@ func TestInteg_ValidUnicode_RoundTripsUnchanged(t *testing.T) {
 			got := New()
 			require.NoError(t, tc.apply(got, tc.enc()))
 			require.Equal(t, txt.ToString(), got.GetText("t").ToString())
+
+			wantJSON, err := m.ToJSON()
+			require.NoError(t, err)
+			gotJSON, err := got.GetMap("m").ToJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, string(wantJSON), string(gotJSON),
+				"YMap must round-trip its multi-byte key and nested unicode value unchanged")
 		})
 	}
 }

--- a/crdt/utf8_regression_test.go
+++ b/crdt/utf8_regression_test.go
@@ -1,0 +1,60 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The four shapes measured on the issue: each silently produced an update that
+// no decoder would accept, in both V1 and V2. Each must now fail at the call.
+func TestInteg_InvalidUTF8_NeverReachesTheWire(t *testing.T) {
+	bad := string([]byte{0xff, 0xfe})
+	cases := map[string]func(){
+		"YText content": func() {
+			d := New()
+			txt := d.GetText("t")
+			d.Transact(func(txn *Transaction) { txt.Insert(txn, 0, bad, nil) })
+		},
+		"YMap value": func() {
+			d := New()
+			m := d.GetMap("m")
+			d.Transact(func(txn *Transaction) { m.Set(txn, "k", bad) })
+		},
+		"YMap key": func() {
+			d := New()
+			m := d.GetMap("m")
+			d.Transact(func(txn *Transaction) { m.Set(txn, bad, "v") })
+		},
+		"root type name": func() { New().GetText(bad) },
+	}
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) { requirePanicsWithInvalidUTF8(t, build) })
+	}
+}
+
+// Everything a real document contains must round-trip unchanged in V1 and V2.
+func TestInteg_ValidUnicode_RoundTripsUnchanged(t *testing.T) {
+	doc := New(WithClientID(4242))
+	txt := doc.GetText("t")
+	m := doc.GetMap("m")
+	doc.Transact(func(txn *Transaction) {
+		txt.Insert(txn, 0, "héllo 😀 wörld á", nil)
+		m.Set(txn, "🔑", map[string]any{"n": []any{"ok", "ünïcode"}})
+	})
+
+	for _, tc := range []struct {
+		name  string
+		enc   func() []byte
+		apply func(*Doc, []byte) error
+	}{
+		{"V1", doc.EncodeStateAsUpdate, func(d *Doc, u []byte) error { return ApplyUpdateV1(d, u, nil) }},
+		{"V2", func() []byte { return EncodeStateAsUpdateV2(doc, nil) }, func(d *Doc, u []byte) error { return ApplyUpdateV2(d, u, nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := New()
+			require.NoError(t, tc.apply(got, tc.enc()))
+			require.Equal(t, txt.ToString(), got.GetText("t").ToString())
+		})
+	}
+}

--- a/crdt/utf8_test.go
+++ b/crdt/utf8_test.go
@@ -1,0 +1,115 @@
+package crdt
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnit_CheckUTF8_PanicMessageNamesLocation(t *testing.T) {
+	require.PanicsWithValue(t, `crdt: YMap.Set: key: invalid UTF-8`,
+		func() { checkUTF8("YMap.Set", "key", string([]byte{0xff})) })
+	require.NotPanics(t, func() { checkUTF8("YMap.Set", "key", "fine 😀") })
+}
+
+func TestUnit_CheckAnyUTF8_WalksNestedShapes(t *testing.T) {
+	bad := string([]byte{0xff})
+	for name, v := range map[string]any{
+		"plain string":  bad,
+		"slice element": []any{"ok", bad},
+		"map value":     map[string]any{"k": bad},
+		"map key":       map[string]any{bad: "ok"},
+		"nested deep":   []any{map[string]any{"a": []any{"ok", bad}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			requirePanicsWithInvalidUTF8(t, func() { checkAnyUTF8("op", "value", v) })
+		})
+	}
+}
+
+func TestUnit_CheckAnyUTF8_IgnoresNonStringValues(t *testing.T) {
+	for name, v := range map[string]any{
+		"int": 42, "float": 1.5, "bool": true, "nil": nil,
+		"bytes": []byte{0xff, 0xfe}, // []byte is length-prefixed, not UTF-8
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() { checkAnyUTF8("op", "value", v) })
+		})
+	}
+}
+
+// helper, defined in this file
+func requirePanicsWithInvalidUTF8(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected a panic")
+		require.Contains(t, r.(string), "invalid UTF-8")
+	}()
+	fn()
+}
+
+func TestUnit_CheckAnyUTF8_ReportsIndexAndKey(t *testing.T) {
+	bad := string([]byte{0xff})
+	requirePanicsWithMessage(t, `crdt: op: value[1]: invalid UTF-8`,
+		func() { checkAnyUTF8("op", "value", []any{"ok", bad}) })
+	requirePanicsWithMessage(t, `crdt: op: value["k"]: invalid UTF-8`,
+		func() { checkAnyUTF8("op", "value", map[string]any{"k": bad}) })
+}
+
+func requirePanicsWithMessage(t *testing.T, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected a panic")
+		require.Equal(t, want, r)
+	}()
+	fn()
+}
+
+func TestUnit_CheckAttrsUTF8_PanicsOnInvalidKey(t *testing.T) {
+	bad := string([]byte{0xff})
+	requirePanicsWithMessage(t, fmt.Sprintf("crdt: YText.Format: attribute key %q: invalid UTF-8", bad),
+		func() { checkAttrsUTF8("YText.Format", Attributes{bad: "ok"}) })
+}
+
+func TestUnit_CheckAttrsUTF8_PanicsOnInvalidValue(t *testing.T) {
+	bad := string([]byte{0xff})
+	requirePanicsWithMessage(t, `crdt: YText.ApplyDelta: attribute "k": invalid UTF-8`,
+		func() { checkAttrsUTF8("YText.ApplyDelta", Attributes{"k": bad}) })
+}
+
+func TestUnit_CheckAttrsUTF8_WalksNestedValue(t *testing.T) {
+	bad := string([]byte{0xff})
+	requirePanicsWithInvalidUTF8(t, func() {
+		checkAttrsUTF8("YText.Insert", Attributes{"k": []any{"ok", bad}})
+	})
+}
+
+func TestUnit_CheckAttrsUTF8_IgnoresValidAttrs(t *testing.T) {
+	require.NotPanics(t, func() {
+		checkAttrsUTF8("YText.Format", Attributes{"bold": true, "color": "red", "size": 12})
+	})
+}
+
+// Guards the walker against WriteAny growing a new string-bearing case.
+func TestUnit_CheckAnyUTF8_CoversWriteAnyStringCases(t *testing.T) {
+	src, err := os.ReadFile("../encoding/encoder.go")
+	require.NoError(t, err)
+	body := string(src)
+	start := strings.Index(body, "func (e *Encoder) WriteAny(")
+	require.Greater(t, start, -1)
+	end := strings.Index(body[start:], "\n}\n")
+	require.Greater(t, end, -1)
+	cases := body[start : start+end]
+
+	// Only these three carry text. If a new one appears, extend checkAnyUTF8.
+	for _, want := range []string{"case string:", "case []any:", "case map[string]any:"} {
+		require.Contains(t, cases, want)
+	}
+	require.Equal(t, 19, strings.Count(cases, "\tcase "),
+		"WriteAny's type switch changed — re-check whether the new case carries strings, then update this count")
+}

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // arraySub pairs a unique subscription ID with a YArrayEvent callback.
@@ -268,6 +269,9 @@ func rejectSharedVals(vals []any) {
 
 // Insert inserts vals at logical position index (0 = prepend, Len() = append).
 func (a *YArray) Insert(txn *Transaction, index int, vals []any) {
+	for i, v := range vals {
+		checkAnyUTF8("YArray.Insert", fmt.Sprintf("value[%d]", i), v)
+	}
 	rejectSharedVals(vals)
 	if a.detached() {
 		// Any unresolvable index anchors at the tail, exactly as
@@ -335,6 +339,9 @@ func (a *YArray) insertAfterItem(txn *Transaction, left *Item, vals []any, hintI
 // a Yjs peer would order the two results differently — a convergence divergence
 // surfaced by the #70 cross-impl fuzz oracle.
 func (a *YArray) Push(txn *Transaction, vals []any) {
+	for i, v := range vals {
+		checkAnyUTF8("YArray.Push", fmt.Sprintf("value[%d]", i), v)
+	}
 	rejectSharedVals(vals)
 	if a.detached() {
 		a.prelim = append(a.prelim, vals...)

--- a/crdt/ymap.go
+++ b/crdt/ymap.go
@@ -171,6 +171,9 @@ func extractMapValue(item *Item) any {
 // Set writes value under key. If a live entry already exists for key, it is
 // deleted and the new item becomes the winner.
 func (m *YMap) Set(txn *Transaction, key string, value any) {
+	checkUTF8("YMap.Set", "key", key)
+	checkAnyUTF8("YMap.Set", "value", value)
+
 	t := &m.abstractType
 
 	// Detached: stage the entry (see prelim). Re-setting a key overwrites in

--- a/crdt/ytext.go
+++ b/crdt/ytext.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -315,6 +316,8 @@ func (txt *YText) Len() int { return txt.length }
 // Keys whose requested value already matches the current state produce no
 // markers (empty diff = no work).
 func (txt *YText) Insert(txn *Transaction, index int, text string, attrs Attributes) {
+	checkUTF8("YText.Insert", "text", text)
+	checkAttrsUTF8("YText.Insert", attrs)
 	if text == "" {
 		return
 	}
@@ -536,6 +539,8 @@ func (txt *YText) currentAttributesAt(anchor *Item) Attributes {
 //
 // Added in v1.12.0 (#76).
 func (txt *YText) InsertEmbed(txn *Transaction, index int, embed any, attrs Attributes) {
+	checkAnyUTF8("YText.InsertEmbed", "embed", embed)
+	checkAttrsUTF8("YText.InsertEmbed", attrs)
 	if txt.detached() {
 		attrs := cloneAttributes(attrs)
 		txt.buffer(func(txn *Transaction) { txt.InsertEmbed(txn, index, embed, attrs) })
@@ -782,6 +787,7 @@ func (txt *YText) cleanupDanglingFormatsInRegion(txn *Transaction, startAnchor *
 // removal marker before the source marker when both share the same origin.
 // Full concurrent attribute removal is tracked as a follow-up improvement.
 func (txt *YText) Format(txn *Transaction, index, length int, attrs Attributes) {
+	checkAttrsUTF8("YText.Format", attrs)
 	if len(attrs) == 0 || length <= 0 {
 		return
 	}
@@ -1280,6 +1286,15 @@ func (txt *YText) Observe(fn func(YTextEvent)) func() {
 // The cursor starts at position 0. ApplyDelta must be called from inside a
 // Transact callback.
 func (txt *YText) ApplyDelta(txn *Transaction, delta []Delta) {
+	// Validate the ENTIRE slice before applying ANY of it. Transact is
+	// panic-safe (releases the lock) but does not roll back, so validating
+	// op-by-op inside the loop below would let delta[0], delta[1], ... commit
+	// before a panic on delta[2] — a partial write with observers already
+	// fired (#209).
+	for i, d := range delta {
+		checkAnyUTF8("YText.ApplyDelta", fmt.Sprintf("delta[%d].Insert", i), d.Insert)
+		checkAttrsUTF8("YText.ApplyDelta", d.Attributes)
+	}
 	if txt.detached() {
 		delta := cloneDelta(delta)
 		txt.buffer(func(txn *Transaction) { txt.ApplyDelta(txn, delta) })

--- a/crdt/yxml.go
+++ b/crdt/yxml.go
@@ -321,17 +321,26 @@ func (e *YXmlElement) InsertText(txn *Transaction, index int, txt *YXmlText) {
 // SetAttributeValue; Yjs stores attribute values typed, and y-prosemirror
 // round-trips them typed.
 func (e *YXmlElement) SetAttribute(txn *Transaction, key, value string) {
-	checkUTF8("YXmlElement.SetAttribute", "key", key)
-	checkUTF8("YXmlElement.SetAttribute", "value", value)
-	e.SetAttributeValue(txn, key, value)
+	e.setAttributeValue("YXmlElement.SetAttribute", txn, key, value)
 }
 
 // SetAttributeValue sets the XML attribute key to an arbitrary scalar value
 // (string, number, bool, …), preserving the value type on the wire exactly as
 // Yjs's YXmlElement.setAttribute does.
 func (e *YXmlElement) SetAttributeValue(txn *Transaction, key string, value any) {
-	checkUTF8("YXmlElement.SetAttributeValue", "key", key)
-	checkAnyUTF8("YXmlElement.SetAttributeValue", "value", value)
+	e.setAttributeValue("YXmlElement.SetAttributeValue", txn, key, value)
+}
+
+// setAttributeValue is the shared implementation behind SetAttribute and
+// SetAttributeValue. op names whichever exported method the caller actually
+// invoked, so validation runs exactly once (SetAttribute previously validated
+// its string value, then handed off to SetAttributeValue which validated it
+// again) while the panic still points at the call site the caller used. For a
+// plain string value, checkAnyUTF8 immediately delegates to checkUTF8 — same
+// message, same behaviour as calling checkUTF8 directly.
+func (e *YXmlElement) setAttributeValue(op string, txn *Transaction, key string, value any) {
+	checkUTF8(op, "key", key)
+	checkAnyUTF8(op, "value", value)
 	t := &e.abstractType
 	if t.detached() {
 		// Store the wire-normalised value (int -> int64, the same transform

--- a/crdt/yxml.go
+++ b/crdt/yxml.go
@@ -321,6 +321,8 @@ func (e *YXmlElement) InsertText(txn *Transaction, index int, txt *YXmlText) {
 // SetAttributeValue; Yjs stores attribute values typed, and y-prosemirror
 // round-trips them typed.
 func (e *YXmlElement) SetAttribute(txn *Transaction, key, value string) {
+	checkUTF8("YXmlElement.SetAttribute", "key", key)
+	checkUTF8("YXmlElement.SetAttribute", "value", value)
 	e.SetAttributeValue(txn, key, value)
 }
 
@@ -328,6 +330,8 @@ func (e *YXmlElement) SetAttribute(txn *Transaction, key, value string) {
 // (string, number, bool, …), preserving the value type on the wire exactly as
 // Yjs's YXmlElement.setAttribute does.
 func (e *YXmlElement) SetAttributeValue(txn *Transaction, key string, value any) {
+	checkUTF8("YXmlElement.SetAttributeValue", "key", key)
+	checkAnyUTF8("YXmlElement.SetAttributeValue", "value", value)
 	t := &e.abstractType
 	if t.detached() {
 		// Store the wire-normalised value (int -> int64, the same transform
@@ -562,6 +566,7 @@ func (t *YXmlText) toXMLLocked() string {
 // NewYXmlElement creates a standalone YXmlElement ready to be inserted into a
 // YXmlFragment or another YXmlElement.
 func NewYXmlElement(nodeName string) *YXmlElement {
+	checkUTF8("NewYXmlElement", "nodeName", nodeName)
 	e := &YXmlElement{NodeName: nodeName}
 	e.itemMap = make(map[string]*Item)
 	e.owner = e

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"unicode/utf8"
 )
 
 // ErrVarIntOutOfRange is returned by WriteVarIntE when the magnitude of v
@@ -95,10 +96,37 @@ func (e *Encoder) WriteVarInt(v int64) {
 	}
 }
 
-// WriteVarString encodes s as VarUint(byteLength) followed by raw UTF-8 bytes.
-func (e *Encoder) WriteVarString(s string) {
+// WriteVarStringE is the error-returning variant of WriteVarString. Returns
+// ErrInvalidUTF8 if s is not valid UTF-8, writing nothing in that case.
+//
+// Go strings are arbitrary byte sequences, but the wire format is UTF-8 and
+// ReadVarString (like lib0's TextDecoder with fatal:true) rejects anything
+// else. Without this check an encoder can produce an update that no decoder,
+// ygo's or Yjs's, will accept (#209).
+//
+// Successful encoding is byte-identical to the previous unvalidated behaviour.
+func (e *Encoder) WriteVarStringE(s string) error {
+	if !utf8.ValidString(s) {
+		return ErrInvalidUTF8
+	}
 	e.WriteVarUint(uint64(len(s)))
 	e.buf = append(e.buf, s...)
+	return nil
+}
+
+// WriteVarString encodes s as VarUint(byteLength) followed by raw UTF-8 bytes.
+//
+// Panics if s is not valid UTF-8. Callers who need to surface that as a value
+// should use WriteVarStringE. Most invalid input is rejected earlier, at the
+// crdt mutator that accepted it; this is the net for paths with no such
+// boundary (exported struct fields a caller can assign directly).
+func (e *Encoder) WriteVarString(s string) {
+	if err := e.WriteVarStringE(s); err != nil {
+		// Self-contained message, matching WriteVarInt's style. Do not
+		// interpolate err: ErrInvalidUTF8's text already begins with
+		// "encoding:", which would double the package prefix.
+		panic("encoding: WriteVarString: input is not valid UTF-8")
+	}
 }
 
 // WriteVarBytes encodes b as VarUint(len) followed by raw bytes.

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -1,0 +1,46 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #209 — Encoder.WriteVarString appended a Go string's bytes without
+// validating them, while ReadVarString rejects invalid UTF-8. That let a
+// caller encode an update that no decoder (ygo's or Yjs's) could read.
+// These tests pin the encoder-level net: WriteVarStringE returns
+// ErrInvalidUTF8 on invalid input, and WriteVarString panics.
+
+func TestUnit_Encoder_WriteVarStringE_RejectsInvalidUTF8(t *testing.T) {
+	e := NewEncoder()
+	err := e.WriteVarStringE(string([]byte{0xff, 0xfe}))
+	require.ErrorIs(t, err, ErrInvalidUTF8)
+	require.Empty(t, e.Bytes(), "nothing may be written when validation fails")
+}
+
+func TestUnit_Encoder_WriteVarStringE_EncodedSurrogateIsInvalid(t *testing.T) {
+	// ED A0 80 is U+D800 encoded as UTF-8: the class JS produces. lib0's
+	// TextDecoder rejects it, so we must too.
+	e := NewEncoder()
+	require.ErrorIs(t, e.WriteVarStringE(string([]byte{0xED, 0xA0, 0x80})), ErrInvalidUTF8)
+}
+
+func TestUnit_Encoder_WriteVarString_PanicsOnInvalidUTF8(t *testing.T) {
+	e := NewEncoder()
+	require.PanicsWithValue(t,
+		"encoding: WriteVarString: input is not valid UTF-8",
+		func() { e.WriteVarString(string([]byte{0xff})) })
+}
+
+func TestUnit_Encoder_WriteVarStringE_ValidIsByteIdentical(t *testing.T) {
+	for _, s := range []string{"", "hello", "héllo wörld", "😀 emoji", "á combining"} {
+		want := NewEncoder()
+		want.WriteVarUint(uint64(len(s)))
+		want.WriteRaw([]byte(s))
+
+		got := NewEncoder()
+		require.NoError(t, got.WriteVarStringE(s))
+		require.Equal(t, want.Bytes(), got.Bytes(), "input %q", s)
+	}
+}

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -767,23 +767,33 @@ func TestUnit_Any_FloatSpecials(t *testing.T) {
 	})
 }
 
-// Asymmetric UTF-8 contract: WriteVarString trusts the caller (Go strings
-// can legally contain invalid UTF-8 byte sequences). ReadVarString is the
-// validation gate. Document this so future contributors don't add
-// validation to WriteVarString and break callers passing pre-encoded data.
-func TestUnit_VarString_AsymmetricUTF8Contract(t *testing.T) {
+// #209 — WriteVarString used to trust the caller (Go strings can legally
+// contain invalid UTF-8 byte sequences) while ReadVarString rejected
+// malformed input on the way back in. That asymmetry let a caller produce
+// an update that no decoder, ygo's or Yjs's, could read. WriteVarString now
+// validates and panics symmetrically with ReadVarString's rejection;
+// WriteVarStringE is the non-panicking variant for callers that need to
+// surface the failure as a value. See encoder_test.go for the dedicated
+// WriteVarStringE/WriteVarString coverage.
+func TestUnit_VarString_SymmetricUTF8Contract(t *testing.T) {
 	invalid := string([]byte{0xff, 0xfe, 0xfd}) // not valid UTF-8
 
-	// Write trusts the caller — no validation, no panic.
+	// Write now validates and panics, matching Read's rejection.
 	enc := encoding.NewEncoder()
-	assert.NotPanics(t, func() { enc.WriteVarString(invalid) })
+	assert.PanicsWithValue(t,
+		"encoding: WriteVarString: input is not valid UTF-8",
+		func() { enc.WriteVarString(invalid) })
 
-	// Read validates and rejects.
-	dec := encoding.NewDecoder(enc.Bytes())
+	// A pre-encoded payload containing invalid UTF-8 (e.g. from another,
+	// non-validating implementation) is still rejected on read.
+	raw := encoding.NewEncoder()
+	raw.WriteVarUint(uint64(len(invalid)))
+	raw.WriteRaw([]byte(invalid))
+	dec := encoding.NewDecoder(raw.Bytes())
 	_, err := dec.ReadVarString()
 	require.Error(t, err)
 	assert.ErrorIs(t, err, encoding.ErrInvalidUTF8,
-		"asymmetric contract: write trusts, read validates")
+		"read must still reject invalid UTF-8 regardless of its source")
 }
 
 // G4: WriteAny must accept Go unsigned integer types (uint, uint8-32, uint64

--- a/internal/roomname/roomname.go
+++ b/internal/roomname/roomname.go
@@ -2,17 +2,27 @@
 // HTTP and WebSocket providers so both enforce identical limits (issue #50).
 package roomname
 
+import "unicode/utf8"
+
 // Valid reports whether name is a safe, non-empty room identifier. The rule
 // (originally the WebSocket provider's isValidRoomName) rejects: the empty
 // string, names longer than 255 bytes, the path-traversal names "." and "..",
-// and any name containing a control character (rune < 0x20). All other
-// printable content — including spaces and Unicode — is permitted, matching the
-// permissive behaviour of the y-websocket JS server.
+// any name containing a control character (rune < 0x20), and any name that is
+// not valid UTF-8 (it would be unencodable on the wire — issue #209). All
+// other printable content — including spaces and Unicode — is permitted,
+// matching the permissive behaviour of the y-websocket JS server.
 func Valid(name string) bool {
 	if len(name) == 0 || len(name) > 255 {
 		return false
 	}
 	if name == "." || name == ".." {
+		return false
+	}
+	if !utf8.ValidString(name) {
+		// Ranging over a string below yields utf8.RuneError (U+FFFD) for
+		// invalid bytes, which is above the control-character floor, so
+		// without this explicit check invalid UTF-8 would slip through the
+		// loop and later panic WriteVarString on the wire.
 		return false
 	}
 	for _, r := range name {

--- a/internal/roomname/roomname_test.go
+++ b/internal/roomname/roomname_test.go
@@ -30,3 +30,18 @@ func TestValid(t *testing.T) {
 		}
 	}
 }
+
+// TestUnit_Valid_RejectsInvalidUTF8 guards issue #209: ranging over a string
+// yields utf8.RuneError (U+FFFD) for invalid bytes, which is above the
+// control-character floor, so the old rule accepted these. Room names reach
+// the wire (WriteVarString, which now rejects invalid UTF-8) and the Redis
+// relay, so Valid must reject them outright rather than let them panic a
+// connection goroutine later.
+func TestUnit_Valid_RejectsInvalidUTF8(t *testing.T) {
+	if Valid(string([]byte{0xff, 0xfe})) {
+		t.Fatal("invalid UTF-8 room name must be rejected")
+	}
+	if !Valid("документ 📄") {
+		t.Fatal("valid Unicode room names must still be accepted")
+	}
+}

--- a/provider/websocket/peer.go
+++ b/provider/websocket/peer.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -265,7 +266,21 @@ func (p *peer) safeTokenAuth(hook func(string, string) (ConnectionConfig, error)
 
 // encodeAuthMessage builds a tag-2 auth reply: VarUint(msgAuth) VarUint(sub)
 // VarString(s). docName framing (if enabled) is applied later in writeToConn.
+//
+// s is app-supplied (an OnTokenAuth hook's error text via authErr.Error(), or
+// the "read-write"/"readonly" scope label) and this runs on a live connection
+// goroutine. WriteVarString now panics on invalid UTF-8 (#209/Task 1), but an
+// application returning a malformed error string is not this library's fault
+// to crash a goroutine over, nor severe enough to warrant dropping the peer's
+// connection the way a genuine protocol violation would. So this is the one
+// place in the UTF-8 validation work that COERCES instead of rejecting:
+// strings.ToValidUTF8 repairs the string in place (U+FFFD for bad runs),
+// keeping the diagnostic readable and the connection alive. Do not "fix" this
+// inconsistency with roomname.Valid's reject-outright rule — that guards a
+// wire/relay identifier, this guards a live goroutine against an
+// application's own string.
 func encodeAuthMessage(subType uint64, s string) []byte {
+	s = strings.ToValidUTF8(s, "�")
 	return encoding.EncodeBytes(func(enc *encoding.Encoder) {
 		enc.WriteVarUint(msgAuth)
 		enc.WriteVarUint(subType)

--- a/provider/websocket/peer_test.go
+++ b/provider/websocket/peer_test.go
@@ -5,8 +5,8 @@
 package websocket
 
 import (
+	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -19,26 +19,47 @@ import (
 // live connection goroutine. Task 1 made WriteVarString panic on invalid
 // UTF-8, so encodeAuthMessage must coerce before encoding rather than let a
 // malformed app error string panic the goroutine and drop the peer.
+//
+// The contract under test is the varstring payload, checked by decoding it
+// back. Do not assert utf8.Valid over the whole framed message: the length
+// varuint is not UTF-8 and legitimately carries continuation-range bytes
+// once the payload reaches 128 bytes (0x80 0x01), so such an assertion
+// fails on a perfectly decodable message. The long case below is that shape.
 func TestUnit_EncodeAuthMessage_CoercesInvalidUTF8(t *testing.T) {
-	// An app hook returning a malformed error string must not panic the
-	// connection goroutine.
-	var out []byte
-	require.NotPanics(t, func() {
-		out = encodeAuthMessage(authTypePermissionDenied, "denied "+string([]byte{0xff}))
-	})
-	require.True(t, utf8.Valid(out), "framed message must be decodable")
+	cases := []struct {
+		name string
+		s    string
+	}{
+		// One-byte length varuint.
+		{"short", "denied " + string([]byte{0xff})},
+		// A realistic long app error string, forcing a multi-byte length
+		// varuint in the framing.
+		{"long multi-byte length varuint", "denied " + strings.Repeat("x", 200) + string([]byte{0xff})},
+	}
 
-	// The payload itself must also round-trip through the decoder: prove
-	// this isn't just an accident of the varuint framing bytes happening to
-	// be valid UTF-8 on their own.
-	dec := encoding.NewDecoder(out)
-	msgType, err := dec.ReadVarUint()
-	require.NoError(t, err)
-	require.Equal(t, msgAuth, msgType)
-	subType, err := dec.ReadVarUint()
-	require.NoError(t, err)
-	require.Equal(t, authTypePermissionDenied, subType)
-	s, err := dec.ReadVarString()
-	require.NoError(t, err, "coerced payload must itself be valid UTF-8")
-	require.Contains(t, s, "denied ")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// An app hook returning a malformed error string must not panic
+			// the connection goroutine.
+			var out []byte
+			require.NotPanics(t, func() {
+				out = encodeAuthMessage(authTypePermissionDenied, tc.s)
+			})
+			require.NotEmpty(t, out)
+
+			// The payload must round-trip through the decoder, which rejects
+			// invalid UTF-8 — that is the coercion's actual guarantee.
+			dec := encoding.NewDecoder(out)
+			msgType, err := dec.ReadVarUint()
+			require.NoError(t, err)
+			require.Equal(t, msgAuth, msgType)
+			subType, err := dec.ReadVarUint()
+			require.NoError(t, err)
+			require.Equal(t, authTypePermissionDenied, subType)
+			s, err := dec.ReadVarString()
+			require.NoError(t, err, "coerced payload must itself be valid UTF-8")
+			require.Contains(t, s, "denied ")
+			require.NotContains(t, s, string([]byte{0xff}))
+		})
+	}
 }

--- a/provider/websocket/peer_test.go
+++ b/provider/websocket/peer_test.go
@@ -1,0 +1,44 @@
+// Package websocket - internal test for encodeAuthMessage's UTF-8 coercion
+// (#209). This lives in the internal (package websocket) test set because
+// encodeAuthMessage is unexported and not reachable from package
+// websocket_test.
+package websocket
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/encoding"
+)
+
+// TestUnit_EncodeAuthMessage_CoercesInvalidUTF8 guards issue #209.
+// encodeAuthMessage's s argument is app-supplied (an OnTokenAuth hook's
+// error text, or the "read-write"/"readonly" scope label) and runs on a
+// live connection goroutine. Task 1 made WriteVarString panic on invalid
+// UTF-8, so encodeAuthMessage must coerce before encoding rather than let a
+// malformed app error string panic the goroutine and drop the peer.
+func TestUnit_EncodeAuthMessage_CoercesInvalidUTF8(t *testing.T) {
+	// An app hook returning a malformed error string must not panic the
+	// connection goroutine.
+	var out []byte
+	require.NotPanics(t, func() {
+		out = encodeAuthMessage(authTypePermissionDenied, "denied "+string([]byte{0xff}))
+	})
+	require.True(t, utf8.Valid(out), "framed message must be decodable")
+
+	// The payload itself must also round-trip through the decoder: prove
+	// this isn't just an accident of the varuint framing bytes happening to
+	// be valid UTF-8 on their own.
+	dec := encoding.NewDecoder(out)
+	msgType, err := dec.ReadVarUint()
+	require.NoError(t, err)
+	require.Equal(t, msgAuth, msgType)
+	subType, err := dec.ReadVarUint()
+	require.NoError(t, err)
+	require.Equal(t, authTypePermissionDenied, subType)
+	s, err := dec.ReadVarString()
+	require.NoError(t, err, "coerced payload must itself be valid UTF-8")
+	require.Contains(t, s, "denied ")
+}


### PR DESCRIPTION
Closes #209.

## The problem

Go strings are arbitrary byte sequences, but the Yjs wire format is UTF-8 and our decoder rejects anything else — `ReadVarString` returns `ErrInvalidUTF8`, matching lib0's `TextDecoder` with `fatal: true`. `WriteVarString` did not validate. So a caller could build an ordinary document, encode it successfully, and produce an update that **neither ygo nor Yjs can decode** — with no error at the point of the mistake.

Measured on `main` before this branch, all four shapes silently produced an undecodable update in **both V1 and V2**:

| Entry point | Result |
|---|---|
| `YText.Insert` content | encodes; re-apply fails `ErrInvalidUTF8` |
| `YMap.Set` value | encodes; re-apply fails |
| `YMap.Set` key | encodes; re-apply fails |
| `Doc.GetText(name)` root name | encodes; re-apply fails |

On a server that is a room which silently stops converging for every peer, and a persisted update that can never be reloaded. A bad root type name poisons the whole document rather than one value.

## What changed

Rejection happens at the mutator that receives the string, so the failure names the caller's line. `Encoder.WriteVarString` panics underneath as a backstop for the paths that have no constructor to guard.

Guarded: `YMap.Set`; `YArray.Insert`/`Push`; `YText.Insert`/`ApplyDelta`/`InsertEmbed`/`Format`; `Doc.GetArray`/`GetMap`/`GetText`/`GetXmlFragment`; `Transaction.GetArray`/`GetMap`/`GetText`/`GetXmlFragment`; `WithGUID`; `WithCollectionID`; `NewYXmlElement`; `YXmlElement.SetAttribute`/`SetAttributeValue`; `EncodeRelativePosition`; and `internal/roomname.Valid`.

Two details worth calling out:

- **`YText.ApplyDelta` is a second `ContentString` creation site** that bypasses `Insert` entirely. Guarding `Insert` alone would have left the hole open.
- **Attribute and embed *values* are walked recursively, not just keys.** V1 routes them through `json.Marshal` (which sanitises); V2 writes them through `WriteAny` raw. Validating only keys would have left a version-dependent corruption where the same document is fine in V1 and broken in V2.

Values are walked with a recursive helper mirroring `WriteAny`'s three string-bearing cases (`string`, `[]any`, `map[string]any` — keys and values), with a test asserting the two stay in sync.

## Policy, and its two deliberate exceptions

**Panic** for document content, at the mutator. **Return an error** where the signature already carries one — `NewContentAttribute` returns `ErrInvalidUTF8` rather than panicking, and `crdt.ErrInvalidUTF8` is a true alias of the `encoding` sentinel so `errors.Is` matches across packages.

**Degrade, never crash**, for app-supplied non-document data on a background or connection goroutine. Two places:

- `provider/websocket` coerces app-supplied auth diagnostic strings with `strings.ToValidUTF8`. Killing a peer's connection because an application returned a malformed error string is disproportionate.
- An awareness state that cannot be encoded as valid UTF-8 now broadcasts as `null` for that client, routed into the function's pre-existing "cannot represent this state" branch. This one was found late: `json.Marshal` coerces invalid UTF-8 to U+FFFD *except* for `json.RawMessage`, which it passes through verbatim — so a `RawMessage` in awareness state panicked a broadcast goroutine. Losing one peer's cursor beats taking down everyone's presence.

Both carry comments explaining why they differ, so the asymmetry does not read as an oversight to be "fixed".

## This reverses a documented decision

Commit c3ba5ff (2026-05-19, #77) added `TestUnit_VarString_AsymmetricUTF8Contract`, codifying "write trusts, read validates" and explicitly justifying it: *"don't add write-side validation and break callers passing pre-encoded data."* That test is renamed and inverted here.

The reversal is deliberate. A varstring is UTF-8 by wire definition; a caller with genuinely pre-encoded binary should use `WriteVarBytes`. What such a caller produces today is an update no decoder accepts. A review traced every one of the 22 non-test `WriteVarString` call sites and found no caller relying on the old behaviour — inbound payloads are `ReadVarString` output and therefore already valid by construction.

## Performance

Encoding costs more, because `utf8.ValidString` now runs over every string on every encode. The cost is shape-dependent, so both benchmarks are committed:

| Benchmark | Shape | Delta |
|---|---|---|
| `BenchmarkEncodeStateAsUpdateV1` | 1000 items × 1 byte (worst case) | **+7.45%** (n=10) |
| `BenchmarkEncodeStateAsUpdateV1_Bulk` | same bytes, one bulk insert (realistic) | **+2.86%** |
| `BenchmarkApplyUpdateV1` | decode | +1.2% |

Allocations are unchanged in every case. The first benchmark is a deliberate worst case — `buildTextDoc(1000)` performs 1000 one-character inserts across 1000 transactions, maximising per-string calls with no amortisation — which is why the `_Bulk` counterpart was added rather than citing an unreproducible ad hoc number. That benchmark moves by several points between runs under machine load; +7.45% is a quiet-machine measurement.

Accepted knowingly: the encode-time pass is largely redundant, since every string in a tree already passed a mutator guard or the validating decoder. It uniquely covers `YXmlElement.NodeName` and `ContentAttribute.Name`, which are exported fields with no constructor to intercept.

## Verification

- `make fixtures` regenerated against `yjs@13.6.30` with **zero drift** — valid UTF-8 encodes byte-identically. This is the load-bearing check for a library whose purpose is byte-level wire compatibility.
- `go test -race ./...` green across all 17 packages.
- Rejected calls leave the document **completely untouched**: `Transact` releases the lock on panic but does not roll back, so every guarded method validates all input before mutating anything. `ApplyDelta` validates the whole delta slice up front, with a multi-op test that fails if validation moves into the apply loop.
- Regression tests cover all four originally-measured shapes in V1 and V2; each was verified to fail with its guard removed.
- `crdt`/`encoding`/`sync`/`awareness` remain stdlib-only.

## Semver

`Encoder.WriteVarStringE` and `crdt.ErrInvalidUTF8` are new exported symbols → **MINOR, v1.44.0**. Filed under **Changed**, not Fixed: code that today silently produces a corrupt update will now panic. That is the intent, but it is a behaviour change and the release notes say so directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)