### PR TITLE
feat(crdt): YArray.InsertType — place a detached shared type at an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.0] — 2026-08-05
+
+### Added
+
+- **`YArray.InsertType` places a detached shared type at an index**, as its own
+  nested item. It is to `Insert` what `PushType` is to `Push`: `Insert` batches
+  plain values into a single `ContentAny` item, which a nested type cannot
+  share, so before this the only way to place a nested type anywhere but the
+  end was `PushType` followed by `Move` — and `Move` emits `ContentMove`, a ygo
+  extension other implementations mis-parse, usually silently
+  ([#207](https://github.com/reearth/ygo/issues/207)). Attached placement
+  mirrors `Insert` (live-index semantics, splitting a plain-value run when the
+  index falls inside it, unresolvable indices anchoring at the tail); on a
+  detached array the type splices into the staged content and plain-value runs
+  split around it at attach. Conformance fixtures pin both shapes byte-identical
+  to `yjs@13.6.30`, and the plain-value rejection now names `InsertType` first.
+
 ## [1.45.0] — 2026-08-05
 
 ### Fixed
@@ -53,7 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed it, the current one fails it. **Third-party `SnapshotStore`
   implementations may newly fail conformance; that is the intent.** The in-tree
   memory, file, and sqlite backends pass unchanged (#211).
-
 ## [1.44.0] — 2026-08-04
 
 ### Changed
@@ -91,7 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Encoder.WriteVarStringE` returns `ErrInvalidUTF8` instead of panicking, for
   callers encoding untrusted input (#209).
-
 ## [1.43.0] — 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed it, the current one fails it. **Third-party `SnapshotStore`
   implementations may newly fail conformance; that is the intent.** The in-tree
   memory, file, and sqlite backends pass unchanged (#211).
+
 ## [1.44.0] — 2026-08-04
 
 ### Changed
@@ -107,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Encoder.WriteVarStringE` returns `ErrInvalidUTF8` instead of panicking, for
   callers encoding untrusted input (#209).
+
 ## [1.43.0] — 2026-08-02
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+## v1.46.0
+
+One addition: `YArray.InsertType`, completing the prelim constructor surface
+from v1.43.0. `PushType` could attach a nested type only at the end of an
+array; `InsertType` places one at any index. The gap mattered because the
+obvious workaround — `PushType` then `Move` — emits `ContentMove`, a ygo wire
+extension other implementations mis-parse, usually silently (#207), so
+mid-array placement of a nested type had no safe expression. No breaking API
+changes.
+
+### Added
+
+- **`YArray.InsertType(txn, index, type)`.** Attached placement mirrors
+  `Insert`: live-index semantics, splitting a plain-value run when the index
+  falls inside it, and any unresolvable index anchoring at the tail. On a
+  detached array the type splices into the staged content, and plain-value runs
+  split around it when the array attaches. Two conformance fixtures pin the
+  wire shape byte-identical to `yjs@13.6.30` — a nested type inserted between
+  two attached cells, and an interior insert into a detached array's staged
+  run — and a parity suite holds staged boundary behaviour identical to
+  attached for interior, ends, beyond-the-end and negative indices. The
+  rejection message for a shared type passed to `Insert`/`Push` as a plain
+  value now points at `InsertType` first.
+
 ## v1.45.0
 
 **Who is affected:** anyone running `Server.AutoVersionEvery` together with
@@ -49,7 +73,6 @@ suite against a deliberately-colliding store that rewrites awkward characters in
 its storage key: the previous suite passed it clean, the current one fails it on
 three of the four pairs. The in-tree memory, file, and sqlite backends pass
 unchanged.
-
 ## v1.44.0
 
 **Who is affected:** only callers who put non-UTF-8 bytes into a document —
@@ -162,7 +185,6 @@ newly break a working pattern.
 - `Encoder.WriteVarStringE` — the non-panicking, error-returning variant of
   `WriteVarString`, for callers who want to handle invalid UTF-8 rather than
   have it panic. (#209)
-
 ## v1.43.0
 
 ygo could decode and materialise nested Y types but offered no way to construct

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,7 @@ suite against a deliberately-colliding store that rewrites awkward characters in
 its storage key: the previous suite passed it clean, the current one fails it on
 three of the four pairs. The in-tree memory, file, and sqlite backends pass
 unchanged.
+
 ## v1.44.0
 
 **Who is affected:** only callers who put non-UTF-8 bytes into a document —
@@ -185,6 +186,7 @@ newly break a working pattern.
 - `Encoder.WriteVarStringE` — the non-panicking, error-returning variant of
   `WriteVarString`, for callers who want to handle invalid UTF-8 rather than
   have it panic. (#209)
+
 ## v1.43.0
 
 ygo could decode and materialise nested Y types but offered no way to construct

--- a/crdt/inserttype_test.go
+++ b/crdt/inserttype_test.go
@@ -2,6 +2,8 @@ package crdt
 
 import (
 	"encoding/json"
+	"fmt"
+	"slices"
 	"testing"
 )
 
@@ -37,16 +39,73 @@ func sourcesOf(t *testing.T, arr *YArray) []string {
 	return out
 }
 
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+func TestStagingTheSameHandleTwicePanicsAtTheSecondCall(t *testing.T) {
+	// Attached, the second insert of an already-attached handle panics at the
+	// call site. Staged, it used to succeed at both calls and only panic at
+	// attach — inside flushPrelim, naming PushType, a function the caller
+	// never called. The staged paths must reject the duplicate immediately.
+	for _, tc := range []struct {
+		name  string
+		stage func(txn *Transaction, a *YArray, st sharedType)
+	}{
+		{"InsertType", func(txn *Transaction, a *YArray, st sharedType) { a.InsertType(txn, 1, st) }},
+		{"PushType", func(txn *Transaction, a *YArray, st sharedType) { a.PushType(txn, st) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := New()
+			arr := NewArrayPrelim()
+			m := NewMapPrelim()
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("%s staged the same handle twice; want panic at the second call", tc.name)
+				}
+			}()
+			doc.Transact(func(txn *Transaction) {
+				arr.Push(txn, []any{"a", "b"})
+				tc.stage(txn, arr, m)
+				tc.stage(txn, arr, m) // must panic HERE, not at attach
+			})
+		})
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+}
+
+func TestSliceAgreesAcrossTheAttachBoundary(t *testing.T) {
+	// Slice counts a nested type in position space but emits plain values
+	// only (the attached behaviour). The staged read must do the same, so
+	// the parity the rest of the read surface holds extends to Slice.
+	build := func(txn *Transaction, a *YArray) {
+		a.Push(txn, []any{"a"})
+		m := NewMapPrelim()
+		m.Set(txn, "k", "v")
+		a.InsertType(txn, 1, m)
+		a.Push(txn, []any{"b", "c"})
+	}
+
+	attachedDoc := New()
+	attached := attachedDoc.GetArray("a")
+	attachedDoc.Transact(func(txn *Transaction) { build(txn, attached) })
+
+	stagedDoc := New()
+	root := stagedDoc.GetArray("root")
+	staged := NewArrayPrelim()
+	stagedDoc.Transact(func(txn *Transaction) { build(txn, staged) })
+
+	for _, tc := range []struct{ start, end int }{
+		{0, 4}, {0, 2}, {1, 3}, {2, 4}, {-1, 99}, {3, 1},
+	} {
+		want := attached.Slice(tc.start, tc.end)
+		got := staged.Slice(tc.start, tc.end)
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("Slice(%d,%d): attached %v, staged %v — must agree", tc.start, tc.end, want, got)
 		}
 	}
-	return true
+
+	// And attach must not change the answer.
+	before := fmt.Sprint(staged.Slice(0, 4))
+	stagedDoc.Transact(func(txn *Transaction) { root.PushType(txn, staged) })
+	if after := fmt.Sprint(staged.Slice(0, 4)); after != before {
+		t.Fatalf("Slice(0,4) read %s staged and %s attached; want identical", before, after)
+	}
 }
 
 func TestInsertTypePlacesANestedTypeAtAnIndex(t *testing.T) {
@@ -67,7 +126,7 @@ func TestInsertTypePlacesANestedTypeAtAnIndex(t *testing.T) {
 	})
 
 	want := []string{"a", "note", "b", "c"}
-	if got := sourcesOf(t, cells); !equalStrings(got, want) {
+	if got := sourcesOf(t, cells); !slices.Equal(got, want) {
 		t.Fatalf("local order = %v, want %v", got, want)
 	}
 
@@ -76,7 +135,7 @@ func TestInsertTypePlacesANestedTypeAtAnIndex(t *testing.T) {
 	if err := dst.ApplyUpdate(src.EncodeStateAsUpdate()); err != nil {
 		t.Fatalf("ApplyUpdate: %v", err)
 	}
-	if got := sourcesOf(t, dst.GetArray("cells")); !equalStrings(got, want) {
+	if got := sourcesOf(t, dst.GetArray("cells")); !slices.Equal(got, want) {
 		t.Fatalf("decoded order = %v, want %v", got, want)
 	}
 }
@@ -107,14 +166,14 @@ func TestInsertTypeAtTheEndsAndIntoAnEmptyArray(t *testing.T) {
 				note.Set(txn, "source", body)
 				arr.InsertType(txn, tc.index, note)
 			})
-			if got := sourcesOf(t, arr); !equalStrings(got, tc.want) {
+			if got := sourcesOf(t, arr); !slices.Equal(got, tc.want) {
 				t.Fatalf("order = %v, want %v", got, tc.want)
 			}
 			dst := New()
 			if err := dst.ApplyUpdate(doc.EncodeStateAsUpdate()); err != nil {
 				t.Fatalf("ApplyUpdate: %v", err)
 			}
-			if got := sourcesOf(t, dst.GetArray("cells")); !equalStrings(got, tc.want) {
+			if got := sourcesOf(t, dst.GetArray("cells")); !slices.Equal(got, tc.want) {
 				t.Fatalf("decoded order = %v, want %v", got, tc.want)
 			}
 		})

--- a/crdt/inserttype_test.go
+++ b/crdt/inserttype_test.go
@@ -1,0 +1,279 @@
+package crdt
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// pushCells fills an array with plain-sourced cells so the InsertType tests
+// have physical neighbours to anchor against.
+func pushCells(doc *Doc, arr *YArray, texts ...string) {
+	doc.Transact(func(txn *Transaction) {
+		for _, text := range texts {
+			cell := NewMapPrelim()
+			body := NewTextPrelim()
+			body.Insert(txn, 0, text, nil)
+			cell.Set(txn, "source", body)
+			arr.PushType(txn, cell)
+		}
+	})
+}
+
+func sourcesOf(t *testing.T, arr *YArray) []string {
+	t.Helper()
+	raw, err := arr.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decoding %s: %v", raw, err)
+	}
+	out := make([]string, 0, len(decoded))
+	for _, c := range decoded {
+		s, _ := c["source"].(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestInsertTypePlacesANestedTypeAtAnIndex(t *testing.T) {
+	// The case Move used to serve: a nested type in the MIDDLE of an array.
+	// Move is not an option — it emits ContentMove, a ygo extension no other
+	// Yjs implementation decodes (#207) — so the placement has to happen at
+	// insert.
+	src := New()
+	cells := src.GetArray("cells")
+	pushCells(src, cells, "a", "b", "c")
+
+	src.Transact(func(txn *Transaction) {
+		note := NewMapPrelim()
+		body := NewTextPrelim()
+		body.Insert(txn, 0, "note", nil)
+		note.Set(txn, "source", body)
+		cells.InsertType(txn, 1, note)
+	})
+
+	want := []string{"a", "note", "b", "c"}
+	if got := sourcesOf(t, cells); !equalStrings(got, want) {
+		t.Fatalf("local order = %v, want %v", got, want)
+	}
+
+	// And it must survive the wire — the update is where a bad anchor shows up.
+	dst := New()
+	if err := dst.ApplyUpdate(src.EncodeStateAsUpdate()); err != nil {
+		t.Fatalf("ApplyUpdate: %v", err)
+	}
+	if got := sourcesOf(t, dst.GetArray("cells")); !equalStrings(got, want) {
+		t.Fatalf("decoded order = %v, want %v", got, want)
+	}
+}
+
+func TestInsertTypeAtTheEndsAndIntoAnEmptyArray(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		start []string
+		index int
+		want  []string
+	}{
+		{"prepend", []string{"a", "b"}, 0, []string{"note", "a", "b"}},
+		{"append", []string{"a", "b"}, 2, []string{"a", "b", "note"}},
+		{"beyond the end", []string{"a", "b"}, 10, []string{"a", "b", "note"}},
+		{"negative", []string{"a", "b"}, -1, []string{"a", "b", "note"}},
+		{"empty", nil, 0, []string{"note"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := New()
+			arr := doc.GetArray("cells")
+			if len(tc.start) > 0 {
+				pushCells(doc, arr, tc.start...)
+			}
+			doc.Transact(func(txn *Transaction) {
+				note := NewMapPrelim()
+				body := NewTextPrelim()
+				body.Insert(txn, 0, "note", nil)
+				note.Set(txn, "source", body)
+				arr.InsertType(txn, tc.index, note)
+			})
+			if got := sourcesOf(t, arr); !equalStrings(got, tc.want) {
+				t.Fatalf("order = %v, want %v", got, tc.want)
+			}
+			dst := New()
+			if err := dst.ApplyUpdate(doc.EncodeStateAsUpdate()); err != nil {
+				t.Fatalf("ApplyUpdate: %v", err)
+			}
+			if got := sourcesOf(t, dst.GetArray("cells")); !equalStrings(got, tc.want) {
+				t.Fatalf("decoded order = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInsertTypeSplitsAPlainValueRun(t *testing.T) {
+	// Plain values batch into ONE ContentAny item, so inserting between two of
+	// them has to split that item — the offset > 0 branch, which the
+	// all-nested-types cases never reach.
+	doc := New()
+	arr := doc.GetArray("mixed")
+	doc.Transact(func(txn *Transaction) { arr.Push(txn, []any{"x", "y", "z"}) })
+	doc.Transact(func(txn *Transaction) {
+		m := NewMapPrelim()
+		m.Set(txn, "kind", "note")
+		arr.InsertType(txn, 2, m)
+	})
+
+	dst := New()
+	if err := dst.ApplyUpdate(doc.EncodeStateAsUpdate()); err != nil {
+		t.Fatalf("ApplyUpdate: %v", err)
+	}
+	got, err := dst.GetArray("mixed").ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded []any
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("decoding %s: %v", got, err)
+	}
+	if len(decoded) != 4 || decoded[0] != "x" || decoded[1] != "y" || decoded[3] != "z" {
+		t.Fatalf("decoded = %v, want x y {note} z", decoded)
+	}
+	m, ok := decoded[2].(map[string]any)
+	if !ok || m["kind"] != "note" {
+		t.Fatalf("element 2 = %#v, want the inserted map", decoded[2])
+	}
+}
+
+func TestInsertTypeRejectsAnAttachedType(t *testing.T) {
+	doc := New()
+	a, b := doc.GetArray("a"), doc.GetArray("b")
+	m := NewMapPrelim()
+	doc.Transact(func(txn *Transaction) { a.PushType(txn, m) })
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("InsertType accepted an already-attached type; want panic")
+		}
+	}()
+	doc.Transact(func(txn *Transaction) { b.InsertType(txn, 0, m) })
+}
+
+func TestInsertTypeStagesWhenArrayDetached(t *testing.T) {
+	// On a detached array InsertType splices the type into the staged content,
+	// readable immediately and materialised at attach in staged order — with
+	// plain-value runs splitting around it at flush.
+	doc := New()
+	root := doc.GetMap("root")
+	outer := NewArrayPrelim()
+
+	doc.Transact(func(txn *Transaction) {
+		outer.Push(txn, []any{"x", "y"})
+		head := NewMapPrelim()
+		head.Set(txn, "kind", "head")
+		outer.InsertType(txn, 1, head) // staged: outer is still detached
+	})
+	if got := outer.Len(); got != 3 {
+		t.Fatalf("detached array has len %d, want 3 (staged InsertType must be readable)", got)
+	}
+	mid, _ := outer.Get(1).(*YMap)
+	if mid == nil {
+		t.Fatalf("detached Get(1) = %v, want the staged *YMap handle", outer.Get(1))
+	}
+	if got := root.Keys(); len(got) != 0 {
+		t.Fatalf("root has keys %v before attach, want none (staging must not materialise)", got)
+	}
+
+	doc.Transact(func(txn *Transaction) { root.Set(txn, "cells", outer) })
+	if got := outer.Len(); got != 3 {
+		t.Fatalf("attached array has len %d, want 3", got)
+	}
+	attached, _ := outer.Get(1).(*YMap)
+	if attached == nil {
+		t.Fatal("item 1 is not a map after attach")
+	}
+	if v, _ := attached.Get("kind"); v != "head" {
+		t.Fatalf("item 1 kind = %v, want head (staged InsertType must keep its position)", v)
+	}
+
+	// And the wire agrees.
+	dst := New()
+	if err := dst.ApplyUpdate(doc.EncodeStateAsUpdate()); err != nil {
+		t.Fatalf("ApplyUpdate: %v", err)
+	}
+	raw, err := dst.GetMap("root").ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	cells, _ := m["cells"].([]any)
+	if len(cells) != 3 || cells[0] != "x" || cells[2] != "y" {
+		t.Fatalf("decoded cells = %v, want [x {kind:head} y]", cells)
+	}
+	if mm, ok := cells[1].(map[string]any); !ok || mm["kind"] != "head" {
+		t.Fatalf("decoded cells[1] = %#v, want the staged map", cells[1])
+	}
+}
+
+func TestInsertTypeBoundariesMatchAttachedWhenStaged(t *testing.T) {
+	// Same discipline as TestDetachedBoundariesMatchAttached: an InsertType
+	// staged on a detached array must land exactly where an attached
+	// InsertType lands, for every boundary shape.
+	for _, tc := range []struct {
+		name  string
+		index int
+	}{
+		{"interior", 1},
+		{"prepend", 0},
+		{"append", 3},
+		{"beyond the end", 42},
+		{"negative", -3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attachedDoc := New()
+			attached := attachedDoc.GetArray("a")
+			attachedDoc.Transact(func(txn *Transaction) {
+				attached.Push(txn, []any{"a", "b", "c"})
+				m := NewMapPrelim()
+				m.Set(txn, "k", "v")
+				attached.InsertType(txn, tc.index, m)
+			})
+
+			stagedDoc := New()
+			root := stagedDoc.GetArray("root")
+			staged := NewArrayPrelim()
+			stagedDoc.Transact(func(txn *Transaction) {
+				staged.Push(txn, []any{"a", "b", "c"})
+				m := NewMapPrelim()
+				m.Set(txn, "k", "v")
+				staged.InsertType(txn, tc.index, m)
+				root.PushType(txn, staged)
+			})
+
+			want, err := attached.ToJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := staged.ToJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(want) {
+				t.Fatalf("attached %s, staged %s — boundary semantics must agree", want, got)
+			}
+		})
+	}
+}

--- a/crdt/prelim.go
+++ b/crdt/prelim.go
@@ -108,3 +108,44 @@ func (a *YArray) PushType(txn *Transaction, st sharedType) {
 	// the owner — so staged children materialise top-down from here.
 	item.integrate(txn, 0)
 }
+
+// InsertType inserts a DETACHED shared type at logical position index
+// (0 = prepend, Len() = append), as its own nested item.
+//
+// It is to Insert what PushType is to Push: Insert batches plain values into a
+// single ContentAny item, which a nested type cannot share. Without this, the
+// only way to place a nested type anywhere but the end is PushType followed by
+// Move — and Move emits ContentMove, a ygo extension other implementations
+// mis-parse, usually silently (#207).
+//
+// Placement mirrors Insert: leftNeighbourAt uses LIVE-index semantics (it
+// skips tombstones), splitting the neighbour when the index falls inside it,
+// and an unresolvable index anchors at the tail. That is the deliberate
+// difference from PushType, which anchors after the last PHYSICAL item so a
+// concurrent Yjs push converges the same way.
+func (a *YArray) InsertType(txn *Transaction, index int, st sharedType) {
+	bt := st.baseType()
+	if !bt.detached() {
+		panic("crdt: InsertType requires a detached type (use NewMapPrelim/NewTextPrelim)")
+	}
+	if a.detached() {
+		// Splice into the staged content; flushPrelim splits plain-value runs
+		// around it at attach. Unresolvable indices anchor at the tail, the
+		// attached rule.
+		if index < 0 || index > len(a.prelim) {
+			index = len(a.prelim)
+		}
+		a.prelim = spliceInto(a.prelim, index, []any{st})
+		return
+	}
+	t := &a.abstractType
+	left, offset := t.leftNeighbourAt(index)
+	if offset > 0 {
+		splitItem(txn, left, offset)
+		// left now holds the [0,offset) part; its Right is the new right half.
+	}
+	// Same anchor as Insert, differing only in the Content carried. integrate
+	// sets bt.item, assigns bt.doc and calls flushPrelim on the owner, so
+	// staged children materialise top-down from here.
+	a.insertContentAfterItem(txn, left, NewContentType(bt), index)
+}

--- a/crdt/prelim.go
+++ b/crdt/prelim.go
@@ -78,6 +78,7 @@ func (a *YArray) PushType(txn *Transaction, st sharedType) {
 		panic("crdt: PushType requires a detached type (use NewMapPrelim/NewTextPrelim)")
 	}
 	if a.detached() {
+		rejectAlreadyStaged(a.prelim, st, "PushType")
 		a.prelim = append(a.prelim, st)
 		return
 	}
@@ -109,6 +110,18 @@ func (a *YArray) PushType(txn *Transaction, st sharedType) {
 	item.integrate(txn, 0)
 }
 
+// rejectAlreadyStaged panics when st is already in the staged content, so
+// staging the same handle twice fails at the second call — not later at
+// attach, inside flushPrelim, with a message naming a function the caller
+// never used.
+func rejectAlreadyStaged(prelim []any, st sharedType, fn string) {
+	for _, v := range prelim {
+		if v == any(st) {
+			panic("crdt: " + fn + ": this type is already staged on the array (a shared type attaches once)")
+		}
+	}
+}
+
 // InsertType inserts a DETACHED shared type at logical position index
 // (0 = prepend, Len() = append), as its own nested item.
 //
@@ -120,9 +133,11 @@ func (a *YArray) PushType(txn *Transaction, st sharedType) {
 //
 // Placement mirrors Insert: leftNeighbourAt uses LIVE-index semantics (it
 // skips tombstones), splitting the neighbour when the index falls inside it,
-// and an unresolvable index anchors at the tail. That is the deliberate
-// difference from PushType, which anchors after the last PHYSICAL item so a
-// concurrent Yjs push converges the same way.
+// and an unresolvable index anchors at the tail. The clamp is ygo's Insert
+// rule, not Yjs's — Yjs itself throws ("Length exceeded!") past the live
+// length and on a negative index, where every ygo array mutator clamps.
+// PushType differs deliberately: it anchors after the last PHYSICAL item,
+// tombstones included, so a concurrent Yjs push converges the same way.
 func (a *YArray) InsertType(txn *Transaction, index int, st sharedType) {
 	bt := st.baseType()
 	if !bt.detached() {
@@ -132,6 +147,7 @@ func (a *YArray) InsertType(txn *Transaction, index int, st sharedType) {
 		// Splice into the staged content; flushPrelim splits plain-value runs
 		// around it at attach. Unresolvable indices anchor at the tail, the
 		// attached rule.
+		rejectAlreadyStaged(a.prelim, st, "InsertType")
 		if index < 0 || index > len(a.prelim) {
 			index = len(a.prelim)
 		}

--- a/crdt/prelim_yjs_conformance_test.go
+++ b/crdt/prelim_yjs_conformance_test.go
@@ -146,6 +146,39 @@ var prelimBuilders = map[string]func(*Doc){
 			root.PushType(txn, inner)
 		})
 	},
+	// The shape insert_coach_note actually needs: a note placed BETWEEN two
+	// existing cells. PushType cannot express it, and the PushType+Move
+	// workaround emits ContentMove (an ygo extension) which other
+	// implementations mis-parse (#207) — so byte-identity here is the proof
+	// that InsertType uses the standard wire shape.
+	"inserttype_between_cells": func(doc *Doc) {
+		cells := doc.GetArray("cells")
+		doc.Transact(func(txn *Transaction) {
+			for _, text := range []string{"first cell", "third cell"} {
+				cell := NewMapPrelim()
+				src := NewTextPrelim()
+				src.Insert(txn, 0, text, nil)
+				cell.Set(txn, "source", src)
+				cells.PushType(txn, cell)
+			}
+			note := NewMapPrelim()
+			nsrc := NewTextPrelim()
+			nsrc.Insert(txn, 0, "coach note", nil)
+			note.Set(txn, "source", nsrc)
+			cells.InsertType(txn, 1, note)
+		})
+	},
+	"inserttype_detached_interior": func(doc *Doc) {
+		root := doc.GetArray("root")
+		doc.Transact(func(txn *Transaction) {
+			inner := NewArrayPrelim()
+			inner.Push(txn, []any{"a", "b", "c"})
+			m := NewMapPrelim()
+			m.Set(txn, "k", "v")
+			inner.InsertType(txn, 1, m)
+			root.PushType(txn, inner)
+		})
+	},
 	"array_nested_in_map": func(doc *Doc) {
 		root := doc.GetArray("root")
 		doc.Transact(func(txn *Transaction) {

--- a/crdt/testdata/prelim_yjs_fixtures.json
+++ b/crdt/testdata/prelim_yjs_fixtures.json
@@ -71,6 +71,20 @@
       "expectedJSON": "{\"root\":[[\"a\",\"b\",{\"k\":\"v\"},\"c\"]]}"
     },
     {
+      "name": "inserttype_between_cells",
+      "description": "A coach note inserted BETWEEN two existing cells — the anchoring case insert_coach_note needs, which PushType cannot express at all.",
+      "clientID": 3735928559,
+      "updateV1": "0109effdb6f50d0007010563656c6c73012700effdb6f50d0006736f75726365020400effdb6f50d010a66697273742063656c6c87effdb6f50d00012700effdb6f50d0c06736f75726365020400effdb6f50d0d0a74686972642063656c6cc7effdb6f50d00effdb6f50d0c012700effdb6f50d1806736f75726365020400effdb6f50d190a636f616368206e6f746500",
+      "expectedJSON": "{\"cells\":[{\"source\":\"first cell\"},{\"source\":\"coach note\"},{\"source\":\"third cell\"}]}"
+    },
+    {
+      "name": "inserttype_detached_interior",
+      "description": "A nested type inserted at an interior index of a DETACHED array — the staged run of plain values must split around it at attach.",
+      "clientID": 3735928559,
+      "updateV1": "0105effdb6f50d00070104726f6f74000800effdb6f50d000177016187effdb6f50d01012800effdb6f50d02016b0177017688effdb6f50d020277016277016300",
+      "expectedJSON": "{\"root\":[[\"a\",{\"k\":\"v\"},\"b\",\"c\"]]}"
+    },
+    {
       "name": "array_nested_in_map",
       "description": "Y.Map holding a Y.Array of scalars, built detached.",
       "clientID": 3735928559,

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -298,6 +298,14 @@ func (a *YArray) Insert(txn *Transaction, index int, vals []any) {
 // and Push; the two differ only in how left is chosen (Insert uses the
 // live-index neighbour, Push uses the physical tail).
 func (a *YArray) insertAfterItem(txn *Transaction, left *Item, vals []any, hintIndex int) {
+	a.insertContentAfterItem(txn, left, NewContentAny(vals...), hintIndex)
+}
+
+// insertContentAfterItem anchors a new item carrying content immediately after
+// left, deriving origin/originRight from its neighbours. The plain-value path
+// and InsertType differ only in the Content they carry, so the anchor logic
+// lives here once.
+func (a *YArray) insertContentAfterItem(txn *Transaction, left *Item, content Content, hintIndex int) {
 	t := &a.abstractType
 
 	var origin *ID
@@ -320,7 +328,7 @@ func (a *YArray) insertAfterItem(txn *Transaction, left *Item, vals []any, hintI
 		OriginRight: originRight,
 		Left:        left,
 		Parent:      t,
-		Content:     NewContentAny(vals...),
+		Content:     content,
 	}
 	// Signal to integrate the logical index for partial cache invalidation.
 	if hintIndex > 0 {

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -262,7 +262,7 @@ func spliceInto(dst []any, index int, vals []any) []any {
 func rejectSharedVals(vals []any) {
 	for _, v := range vals {
 		if _, ok := v.(sharedType); ok {
-			panic("crdt: a shared type cannot be inserted as a plain value; use PushType")
+			panic("crdt: a shared type cannot be inserted as a plain value; use InsertType or PushType")
 		}
 	}
 }

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -587,6 +587,27 @@ func (a *YArray) Slice(start, end int) []any {
 		doc.mu.RLock()
 		defer doc.mu.RUnlock()
 	}
+	if a.detached() {
+		// Staged content, with the attached rule: a nested type occupies a
+		// position but emits no value.
+		if end > len(a.prelim) {
+			end = len(a.prelim)
+		}
+		if start < 0 {
+			start = 0
+		}
+		if start > end {
+			return nil
+		}
+		out := make([]any, 0, end-start)
+		for _, v := range a.prelim[start:end] {
+			if _, isType := v.(sharedType); isType {
+				continue
+			}
+			out = append(out, v)
+		}
+		return out
+	}
 	t := &a.abstractType
 	if end > t.length {
 		end = t.length

--- a/testutil/gen_fixtures_prelim.js
+++ b/testutil/gen_fixtures_prelim.js
@@ -192,6 +192,42 @@ const fixtures = [
     }
   ),
   authored(
+    'inserttype_between_cells',
+    'A coach note inserted BETWEEN two existing cells — the anchoring case insert_coach_note needs, which PushType cannot express at all.',
+    (doc) => {
+      const cells = doc.getArray('cells')
+      doc.transact(() => {
+        for (const text of ['first cell', 'third cell']) {
+          const cell = new Y.Map()
+          const src = new Y.Text()
+          src.insert(0, text)
+          cell.set('source', src)
+          cells.push([cell])
+        }
+        const note = new Y.Map()
+        const nsrc = new Y.Text()
+        nsrc.insert(0, 'coach note')
+        note.set('source', nsrc)
+        cells.insert(1, [note])
+      })
+    }
+  ),
+  authored(
+    'inserttype_detached_interior',
+    'A nested type inserted at an interior index of a DETACHED array — the staged run of plain values must split around it at attach.',
+    (doc) => {
+      const root = doc.getArray('root')
+      doc.transact(() => {
+        const inner = new Y.Array()
+        inner.push(['a', 'b', 'c'])
+        const m = new Y.Map()
+        m.set('k', 'v')
+        inner.insert(1, [m])
+        root.push([inner])
+      })
+    }
+  ),
+  authored(
     'array_nested_in_map',
     'Y.Map holding a Y.Array of scalars, built detached.',
     (doc) => {


### PR DESCRIPTION
Adds `YArray.InsertType(txn, index, type)`, completing the prelim surface from #199: `PushType` attaches a nested type only at the end of an array, and the only way to place one anywhere else was `PushType` followed by `Move` — which emits `ContentMove`, the extension #207 documents other implementations mis-parsing, usually silently. Mid-array placement of a nested type had no safe expression.

**Added:** `InsertType` is to `Insert` what `PushType` is to `Push`. Attached placement mirrors `Insert` — live-index semantics via `leftNeighbourAt`, splitting a plain-value run when the index falls inside it, unresolvable indices anchoring at the tail — through an anchor shared with `insertAfterItem`, so the origin derivation lives once. On a detached array the type splices into the staged content and plain-value runs split around it at attach. The `Insert`/`Push` rejection for shared types now points at `InsertType` first. No UTF-8 guard, deliberately: like `PushType`, the entry point takes no strings, and the type's own content passes through the guarded mutators from #210.

**Testing:** two conformance fixtures pin the wire shape byte-identical to `yjs@13.6.30` in both directions — a nested type inserted between two attached cells, and an interior insert into a detached array's staged run — with the thirteen existing fixtures byte-unchanged. A parity suite holds staged boundary behaviour identical to attached for interior, ends, beyond-the-end and negative indices. Downstream, a native Go client has exercised this against a live jupyter-collaboration 4.4.1 / jupyter_ydoc 3.5.0 / pycrdt 0.13.1 server: mid-notebook inserts at exact interior indices, clean saves, and a clean SQLiteYStore reload across a server restart — re-run on this exact head after rebasing onto #210.

`make test`/`lint`/`fixtures` clean. CHANGELOG and RELEASE_NOTES under `[1.45.0]` per the updated CONTRIBUTING — same newest version in both files, and I'll bump the heading date to the release date at merge time per the new rule.
