### PR TITLE
fix(persistence): label-scoped snapshot retention + conformance coverage for encoded room names (#211, #212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.45.0] — 2026-08-05
+
+### Fixed
+
+- **Auto-captured versions no longer evict deliberately-named snapshots.**
+  `LegacyAdapter`'s snapshot retention kept the newest `KeepSnapshots` for a room
+  with no regard for how each was created, so with `Server.AutoVersionEvery`
+  enabled a snapshot named `"before-migration"` was silently deleted once
+  `KeepSnapshots` newer auto versions existed — at a 15-minute interval with
+  keep-50, roughly half a day of continuous editing. The two classes have
+  opposite retention needs: auto versions are numerous and individually
+  disposable, which is the point of bounding them, while a named snapshot is an
+  explicit user act. Retention is now scoped to the label class, so an auto save
+  only trims auto versions and a named save only trims that same name (#212).
+
+### Added
+
+- **`LegacyAdapter.TrimSnapshots(ctx, room, label) (int, error)`** applies the
+  same label-scoped retention on demand, for callers that write snapshots
+  through `SnapshotStore.SaveSnapshot` directly rather than via `SaveVersion`.
+  That path was never trimmed at all — retention only ever ran from
+  `SaveVersion`, so with auto-versioning off `KeepSnapshots` had no effect — and
+  it still is not trimmed unless this is called. It reports how many snapshots
+  it deleted, attempts every surplus snapshot even when one delete fails, and
+  joins the failures rather than stopping at the first (#212).
+
+### Changed
+
+- **`KeepSnapshots` is now a per-label bound rather than a per-room one**, so a
+  deployment using varied labels retains more snapshots after upgrading than
+  before. There is deliberately no per-room total cap: capping the total is what
+  evicts named snapshots in the first place. The doc comment now states the full
+  scope, including that direct `SnapshotStore` writes are never trimmed and that
+  an application letting end users name snapshots has user-driven growth (#212).
+- **The `SnapshotStore` conformance suite now exercises room names that need
+  encoding.** It previously used the literal `"room"` for every call site, so no
+  implementation was ever checked against a name needing escaping on the
+  snapshot path — where the per-room counter object embeds the room name and IDs
+  are often recovered by parsing them back out of an object name, so a collision
+  silently maps one room's IDs onto another's instead of failing, and a wrong ID
+  decides which state a user restores. The core round-trip now runs under a name
+  set shared with the room-lister suite (which gains `"../escape"` and a
+  decomposed counterpart to the existing precomposed Unicode name), and the
+  cross-room isolation case runs over name pairs that collide under naive
+  encoding. Verified against a deliberately-colliding store: the previous suite
+  passed it, the current one fails it. **Third-party `SnapshotStore`
+  implementations may newly fail conformance; that is the intent.** The in-tree
+  memory, file, and sqlite backends pass unchanged (#211).
+
 ## [1.44.0] — 2026-08-04
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,55 @@
+## v1.45.0
+
+**Who is affected:** anyone running `Server.AutoVersionEvery` together with
+`LegacyAdapter.KeepSnapshots > 0` while also letting users name snapshots — and
+anyone maintaining their own `SnapshotStore` implementation.
+
+**The fix.** Snapshot retention kept the newest `KeepSnapshots` per room without
+regard to how each snapshot was created, so auto-captured versions evicted ones
+a user had deliberately named. A snapshot named `"before-migration"` vanished
+once `KeepSnapshots` newer auto versions existed: at a 15-minute interval with
+keep-50, about half a day of continuous editing, silently and with no way to
+protect it. Auto versions are cheap, numerous and individually disposable, which
+is the whole point of bounding them; a named snapshot is an explicit user act and
+the thing they would most object to losing. Retention is now scoped to the label
+class, so the two kinds bound themselves separately.
+
+**What changes for you.** `KeepSnapshots` becomes a per-label bound rather than a
+per-room one, so a room's total is now `distinct labels × KeepSnapshots` and a
+deployment using varied labels will retain more than before. If you relied on it
+as a hard per-room cap you no longer have one — deliberately, because capping the
+total is what evicts named snapshots. If your application lets end users name
+snapshots, that growth is user-driven: enumerate labels from `ListSnapshots` and
+call the new `TrimSnapshots` per label if you need a ceiling.
+
+**New:** `LegacyAdapter.TrimSnapshots(ctx, room, label) (int, error)` runs the
+same retention on demand. Snapshots written straight through
+`SnapshotStore.SaveSnapshot` were never trimmed — retention only ever ran from
+`SaveVersion`, so with auto-versioning off `KeepSnapshots` did nothing at all —
+and they still are not unless you call this. It returns how many it deleted, and
+attempts every surplus snapshot even when one delete fails rather than stopping
+at the first.
+
+**If you implement `SnapshotStore`:** the conformance suite is stricter, and your
+implementation may newly fail it. That is the intent. It used to pass the literal
+`"room"` everywhere, so nothing checked a name needing escaping on the snapshot
+path — and that path has more name-derived surface than the update path: the
+per-room counter object embeds the room name, and IDs are often recovered by
+parsing them back out of an object name. A room name carrying your delimiter
+therefore corrupts ID handling silently rather than failing, and a wrong ID is
+not cosmetic, since IDs address which state a user restores. This is not
+hypothetical — we hit it downstream while implementing `SnapshotStore` on GCS,
+where an id-parsing scheme that looked correct mapped some ids onto others.
+
+The suite now runs its core round-trip under `"with/slash"`, `"with:colon"`,
+`"with space"`, precomposed *and* decomposed Unicode, and `"../escape"`, and
+checks cross-room isolation for name pairs that collide under naive encoding
+(`a/b` vs `a:b`, `a/b` vs `a%2Fb`, `a b` vs `a+b`, NFC vs NFD). We verified the
+suite against a deliberately-colliding store that rewrites awkward characters in
+its storage key: the previous suite passed it clean, the current one fails it on
+three of the four pairs. The in-tree memory, file, and sqlite backends pass
+unchanged.
+
 ## v1.44.0
 
 **Who is affected:** only callers who put non-UTF-8 bytes into a document —

--- a/persistence/adapter.go
+++ b/persistence/adapter.go
@@ -35,28 +35,16 @@ type LegacyAdapter struct {
 	// KeepSnapshots bounds retained labelled snapshots PER LABEL when the
 	// websocket server asks the adapter to save a version (see the provider's
 	// VersionableAdapter / AutoVersionEvery). 0 (default) keeps every version,
-	// matching KeepVersions. Set > 0 to trim each label class to its newest
-	// KeepSnapshots, so an always-connected document cannot grow an unbounded
-	// auto-version history.
+	// matching KeepVersions.
 	//
-	// The scope is spelled out because none of it is guessable:
+	// Two things that are not guessable from the name. It is per label, not per
+	// room, so a room's total is unbounded — see TrimSnapshots, which also
+	// applies it on demand. And it is applied only by those two, so snapshots
+	// written straight to SnapshotStore.SaveSnapshot are never trimmed: with
+	// auto-versioning off and no TrimSnapshots call, this field does nothing.
 	//
-	//   - Per LABEL, not per room. An auto-version save cannot evict a snapshot
-	//     a user named. A room's TOTAL is therefore
-	//     (distinct labels x KeepSnapshots) and is NOT bounded — bounding the
-	//     total is exactly what evicts named snapshots. A caller needing a hard
-	//     per-room cap must enumerate labels from ListSnapshots and call
-	//     TrimSnapshots for each; if an application lets end users name
-	//     snapshots, that growth is user-driven.
-	//   - Applied by SaveVersion after each save, best-effort with errors
-	//     swallowed, and by TrimSnapshots when called directly, which returns
-	//     them.
-	//   - Snapshots written straight to SnapshotStore.SaveSnapshot are NEVER
-	//     trimmed: the adapter does not see those writes. With auto-versioning
-	//     off and no TrimSnapshots call, this field has no effect at all.
-	//
-	// Note this is retention over VERSIONS (SnapshotStore entries), which is a
-	// different axis from KeepVersions' retention over the raw update log.
+	// Retention over VERSIONS (SnapshotStore entries), a different axis from
+	// KeepVersions' retention over the raw update log.
 	KeepSnapshots int
 }
 
@@ -152,37 +140,31 @@ func (a *LegacyAdapter) SaveVersion(ctx context.Context, room, label string) (in
 	if err != nil {
 		return 0, err
 	}
-	// Best-effort, and scoped to the label just written so an auto version
-	// cannot evict one a user named — see the doc above for why a retention
-	// failure is not propagated.
+	// Scoped to the label just written; see above for why failures are swallowed.
 	_, _ = a.TrimSnapshots(ctx, room, label)
 	return id, nil
 }
 
 // TrimSnapshots deletes the oldest snapshots of room labelled label beyond
-// KeepSnapshots, and reports how many it deleted.
+// KeepSnapshots, reporting how many it deleted.
 //
-// Retention is scoped to the LABEL CLASS: a call with the server's auto-version
-// label never deletes a snapshot a user named, and a named save never disturbs
-// the auto history. The label is a parameter rather than something the adapter
-// infers because this package deliberately does not import provider/websocket,
-// so it cannot know which label means "automatic" — and scoping to the label
-// the caller just wrote needs no such knowledge.
+// Retention is per label: an auto-version save never evicts a snapshot a user
+// named. The label is a parameter because this package does not import
+// provider/websocket and so cannot know which label means "automatic".
 //
-// KeepSnapshots <= 0 keeps everything and returns (0, nil). Note this is the
-// opposite of some other Yjs ports, where a keep of 0 deletes every version.
+// Returns ErrSnapshotsUnsupported if the store is not a SnapshotStore. That is
+// checked before KeepSnapshots, so retention being disabled cannot mask a
+// misconfigured store. Otherwise KeepSnapshots <= 0 keeps everything and
+// returns (0, nil) — the opposite of some Yjs ports, where keep 0 deletes
+// every version.
 //
-// Because the bound is per class, a room's TOTAL snapshot count is
-// (distinct labels x KeepSnapshots) and is NOT itself bounded. A caller needing
-// a hard per-room cap must enumerate the labels from ListSnapshots and trim
-// each one; bounding the total is what evicts named snapshots, which is the
-// behaviour this scoping exists to prevent.
+// The per-label bound leaves a room's total unbounded at
+// (distinct labels x KeepSnapshots); bounding the total is what evicts named
+// snapshots. For a hard per-room cap, enumerate labels and trim each.
 //
-// Every surplus snapshot is attempted even if an earlier delete fails: the
-// count is how many were actually deleted, and the error joins each failure.
-// DeleteSnapshot is contractually idempotent (deleting an unknown snapshot
-// returns nil), so a concurrent trim of the same class cannot make this report
-// a spurious failure.
+// Every surplus snapshot is attempted even if one delete fails, and the error
+// joins the failures. DeleteSnapshot is contractually idempotent, so a
+// concurrent trim of the same class cannot report a spurious failure.
 func (a *LegacyAdapter) TrimSnapshots(ctx context.Context, room, label string) (int, error) {
 	ss, ok := a.store.(SnapshotStore)
 	if !ok {
@@ -195,8 +177,8 @@ func (a *LegacyAdapter) TrimSnapshots(ctx context.Context, room, label string) (
 	if err != nil {
 		return 0, err
 	}
-	// ListSnapshots is newest-first by contract, so filtering preserves that
-	// order and everything at or past KeepSnapshots within the class is surplus.
+	// Newest-first by contract, so filtering preserves order: everything at or
+	// past KeepSnapshots in the class is surplus.
 	var class []SnapshotInfo
 	for _, sn := range snaps {
 		if sn.Label == label {

--- a/persistence/adapter.go
+++ b/persistence/adapter.go
@@ -32,11 +32,28 @@ type LegacyAdapter struct {
 	// retention policy; set before serving.
 	KeepVersions int
 
-	// KeepSnapshots bounds retained labelled snapshots when the websocket server
-	// asks the adapter to save a version (see the provider's VersionableAdapter /
-	// AutoVersionEvery). 0 (default) keeps every version, matching KeepVersions.
-	// Set > 0 to trim to the newest KeepSnapshots after each save, so an
-	// always-connected document cannot grow an unbounded history.
+	// KeepSnapshots bounds retained labelled snapshots PER LABEL when the
+	// websocket server asks the adapter to save a version (see the provider's
+	// VersionableAdapter / AutoVersionEvery). 0 (default) keeps every version,
+	// matching KeepVersions. Set > 0 to trim each label class to its newest
+	// KeepSnapshots, so an always-connected document cannot grow an unbounded
+	// auto-version history.
+	//
+	// The scope is spelled out because none of it is guessable:
+	//
+	//   - Per LABEL, not per room. An auto-version save cannot evict a snapshot
+	//     a user named. A room's TOTAL is therefore
+	//     (distinct labels x KeepSnapshots) and is NOT bounded — bounding the
+	//     total is exactly what evicts named snapshots. A caller needing a hard
+	//     per-room cap must enumerate labels from ListSnapshots and call
+	//     TrimSnapshots for each; if an application lets end users name
+	//     snapshots, that growth is user-driven.
+	//   - Applied by SaveVersion after each save, best-effort with errors
+	//     swallowed, and by TrimSnapshots when called directly, which returns
+	//     them.
+	//   - Snapshots written straight to SnapshotStore.SaveSnapshot are NEVER
+	//     trimmed: the adapter does not see those writes. With auto-versioning
+	//     off and no TrimSnapshots call, this field has no effect at all.
 	//
 	// Note this is retention over VERSIONS (SnapshotStore entries), which is a
 	// different axis from KeepVersions' retention over the raw update log.

--- a/persistence/adapter.go
+++ b/persistence/adapter.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 // LegacyAdapter adapts a VersionedPersistence to the provider/websocket
@@ -134,23 +135,70 @@ func (a *LegacyAdapter) SaveVersion(ctx context.Context, room, label string) (in
 	if err != nil {
 		return 0, err
 	}
-	a.trimSnapshots(ctx, ss, room)
+	// Best-effort, and scoped to the label just written so an auto version
+	// cannot evict one a user named — see the doc above for why a retention
+	// failure is not propagated.
+	_, _ = a.TrimSnapshots(ctx, room, label)
 	return id, nil
 }
 
-// trimSnapshots deletes the oldest snapshots beyond KeepSnapshots. Best-effort:
-// see the SaveVersion doc for why errors are swallowed.
-func (a *LegacyAdapter) trimSnapshots(ctx context.Context, ss SnapshotStore, room string) {
+// TrimSnapshots deletes the oldest snapshots of room labelled label beyond
+// KeepSnapshots, and reports how many it deleted.
+//
+// Retention is scoped to the LABEL CLASS: a call with the server's auto-version
+// label never deletes a snapshot a user named, and a named save never disturbs
+// the auto history. The label is a parameter rather than something the adapter
+// infers because this package deliberately does not import provider/websocket,
+// so it cannot know which label means "automatic" — and scoping to the label
+// the caller just wrote needs no such knowledge.
+//
+// KeepSnapshots <= 0 keeps everything and returns (0, nil). Note this is the
+// opposite of some other Yjs ports, where a keep of 0 deletes every version.
+//
+// Because the bound is per class, a room's TOTAL snapshot count is
+// (distinct labels x KeepSnapshots) and is NOT itself bounded. A caller needing
+// a hard per-room cap must enumerate the labels from ListSnapshots and trim
+// each one; bounding the total is what evicts named snapshots, which is the
+// behaviour this scoping exists to prevent.
+//
+// Every surplus snapshot is attempted even if an earlier delete fails: the
+// count is how many were actually deleted, and the error joins each failure.
+// DeleteSnapshot is contractually idempotent (deleting an unknown snapshot
+// returns nil), so a concurrent trim of the same class cannot make this report
+// a spurious failure.
+func (a *LegacyAdapter) TrimSnapshots(ctx context.Context, room, label string) (int, error) {
+	ss, ok := a.store.(SnapshotStore)
+	if !ok {
+		return 0, ErrSnapshotsUnsupported
+	}
 	if a.KeepSnapshots <= 0 {
-		return
+		return 0, nil
 	}
 	snaps, err := ss.ListSnapshots(ctx, room)
-	if err != nil || len(snaps) <= a.KeepSnapshots {
-		return
+	if err != nil {
+		return 0, err
 	}
-	// ListSnapshots is newest-first, so everything at or past KeepSnapshots is
-	// surplus.
-	for _, sn := range snaps[a.KeepSnapshots:] {
-		_ = ss.DeleteSnapshot(ctx, room, sn.ID)
+	// ListSnapshots is newest-first by contract, so filtering preserves that
+	// order and everything at or past KeepSnapshots within the class is surplus.
+	var class []SnapshotInfo
+	for _, sn := range snaps {
+		if sn.Label == label {
+			class = append(class, sn)
+		}
 	}
+	if len(class) <= a.KeepSnapshots {
+		return 0, nil
+	}
+	var (
+		deleted int
+		errs    []error
+	)
+	for _, sn := range class[a.KeepSnapshots:] {
+		if derr := ss.DeleteSnapshot(ctx, room, sn.ID); derr != nil {
+			errs = append(errs, fmt.Errorf("delete snapshot %d: %w", sn.ID, derr))
+			continue
+		}
+		deleted++
+	}
+	return deleted, errors.Join(errs...)
 }

--- a/persistence/adapter_version_test.go
+++ b/persistence/adapter_version_test.go
@@ -131,3 +131,70 @@ func TestLegacyAdapterSaveVersion_UnsupportedStoreErrors(t *testing.T) {
 	assert.ErrorIs(t, err, persistence.ErrSnapshotsUnsupported,
 		"a store without SnapshotStore must report the misconfiguration")
 }
+
+// An auto-captured version must never evict a snapshot a user deliberately
+// named: the two classes have opposite retention needs, and the named one is
+// exactly what a user would be most upset to lose (issue #212).
+func TestLegacyAdapterSaveVersion_AutoDoesNotEvictNamed(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+	a.KeepSnapshots = 2
+
+	seedRoom(t, store, "room", 1)
+
+	named, err := a.SaveVersion(ctx, "room", "before-migration")
+	require.NoError(t, err)
+
+	// Enough auto versions to bury the named one under the old newest-N rule.
+	for i := 0; i < 5; i++ {
+		_, err := a.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+	}
+
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+
+	var labels []string
+	found := false
+	autos := 0
+	for _, sn := range snaps {
+		labels = append(labels, sn.Label)
+		if sn.ID == named {
+			found = true
+		}
+		if sn.Label == "auto" {
+			autos++
+		}
+	}
+	assert.True(t, found, "named snapshot must survive auto-version retention; labels = %v", labels)
+	assert.Equal(t, 2, autos, "the auto class must still be bounded by KeepSnapshots")
+}
+
+// KeepSnapshots bounds each label class independently.
+func TestLegacyAdapterTrimSnapshots_PerLabelBound(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+	a.KeepSnapshots = 2
+
+	seedRoom(t, store, "room", 1)
+	for i := 0; i < 4; i++ {
+		_, err := a.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+	}
+	for i := 0; i < 4; i++ {
+		_, err := a.SaveVersion(ctx, "room", "manual")
+		require.NoError(t, err)
+	}
+
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	counts := map[string]int{}
+	for _, sn := range snaps {
+		counts[sn.Label]++
+	}
+	assert.Equal(t, 2, counts["auto"], "auto class bounded")
+	assert.Equal(t, 2, counts["manual"], "manual class bounded independently")
+	assert.Len(t, snaps, 4, "room total is the sum of the bounded classes")
+}

--- a/persistence/adapter_version_test.go
+++ b/persistence/adapter_version_test.go
@@ -3,6 +3,7 @@ package persistence_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,7 +157,7 @@ func TestLegacyAdapterSaveVersion_AutoDoesNotEvictNamed(t *testing.T) {
 	snaps, err := store.ListSnapshots(ctx, "room")
 	require.NoError(t, err)
 
-	var labels []string
+	labels := make([]string, 0, len(snaps))
 	found := false
 	autos := 0
 	for _, sn := range snaps {
@@ -274,12 +275,16 @@ func TestLegacyAdapterTrimSnapshots_UnsupportedStore(t *testing.T) {
 	ctx := context.Background()
 	inner := persistence.NewMemoryPersistence()
 
+	// Subtests rather than a bare loop: keep=0 is the case that regresses if the
+	// guards are reordered, and it must still be reported even when keep=1 fails.
 	for _, keep := range []int{0, 1} {
-		a := persistence.NewLegacyAdapter(bareStore{VersionedPersistence: inner})
-		a.KeepSnapshots = keep
-		n, err := a.TrimSnapshots(ctx, "room", "auto")
-		assert.ErrorIs(t, err, persistence.ErrSnapshotsUnsupported,
-			"KeepSnapshots=%d must still report the misconfiguration", keep)
-		assert.Zero(t, n)
+		t.Run(fmt.Sprintf("keep=%d", keep), func(t *testing.T) {
+			a := persistence.NewLegacyAdapter(bareStore{VersionedPersistence: inner})
+			a.KeepSnapshots = keep
+			n, err := a.TrimSnapshots(ctx, "room", "auto")
+			require.ErrorIs(t, err, persistence.ErrSnapshotsUnsupported,
+				"KeepSnapshots=%d must still report the misconfiguration", keep)
+			assert.Zero(t, n)
+		})
 	}
 }

--- a/persistence/adapter_version_test.go
+++ b/persistence/adapter_version_test.go
@@ -134,9 +134,8 @@ func TestLegacyAdapterSaveVersion_UnsupportedStoreErrors(t *testing.T) {
 		"a store without SnapshotStore must report the misconfiguration")
 }
 
-// An auto-captured version must never evict a snapshot a user deliberately
-// named: the two classes have opposite retention needs, and the named one is
-// exactly what a user would be most upset to lose (issue #212).
+// An auto-captured version must never evict a snapshot a user named: the two
+// classes have opposite retention needs (issue #212).
 func TestLegacyAdapterSaveVersion_AutoDoesNotEvictNamed(t *testing.T) {
 	ctx := context.Background()
 	store := persistence.NewMemoryPersistence()
@@ -148,7 +147,7 @@ func TestLegacyAdapterSaveVersion_AutoDoesNotEvictNamed(t *testing.T) {
 	named, err := a.SaveVersion(ctx, "room", "before-migration")
 	require.NoError(t, err)
 
-	// Enough auto versions to bury the named one under the old newest-N rule.
+	// Enough to bury the named one under the old newest-N rule.
 	for i := 0; i < 5; i++ {
 		_, err := a.SaveVersion(ctx, "room", "auto")
 		require.NoError(t, err)
@@ -201,9 +200,8 @@ func TestLegacyAdapterTrimSnapshots_PerLabelBound(t *testing.T) {
 	assert.Len(t, snaps, 4, "room total is the sum of the bounded classes")
 }
 
-// failingDeleteStore wraps a real store and fails exactly one DeleteSnapshot, to
-// prove a single failure neither aborts the remaining deletes nor is silently
-// dropped by the error-returning entry point.
+// failingDeleteStore fails exactly one DeleteSnapshot, so a single failure can be
+// shown to neither abort the remaining deletes nor be dropped.
 type failingDeleteStore struct {
 	persistence.SnapshotVersionedPersistence
 	failID int64
@@ -216,15 +214,14 @@ func (f *failingDeleteStore) DeleteSnapshot(ctx context.Context, room string, id
 	return f.SnapshotVersionedPersistence.DeleteSnapshot(ctx, room, id)
 }
 
-// TrimSnapshots reports what it did: the count is the number actually deleted,
-// and a failure is joined rather than swallowed the way SaveVersion's internal
-// best-effort call does.
+// The count is what was actually deleted, and a failure is joined rather than
+// swallowed the way SaveVersion's internal call does.
 func TestLegacyAdapterTrimSnapshots_ReportsCountAndJoinsErrors(t *testing.T) {
 	ctx := context.Background()
 	inner := persistence.NewMemoryPersistence()
 	seedRoom(t, inner, "room", 1)
 
-	// Four snapshots, KeepSnapshots=1 leaves three surplus; one delete fails.
+	// Four snapshots, keep 1 leaves three surplus; the middle delete fails.
 	base := persistence.NewLegacyAdapter(inner)
 	var ids []int64
 	for i := 0; i < 4; i++ {
@@ -247,8 +244,7 @@ func TestLegacyAdapterTrimSnapshots_ReportsCountAndJoinsErrors(t *testing.T) {
 	assert.Len(t, snaps, 2, "the newest kept, plus the one whose delete failed")
 }
 
-// KeepSnapshots <= 0 keeps everything — deliberately the opposite of some other
-// Yjs ports, where a keep of 0 deletes every version.
+// KeepSnapshots <= 0 keeps everything, the opposite of some Yjs ports.
 func TestLegacyAdapterTrimSnapshots_ZeroKeepsEverything(t *testing.T) {
 	ctx := context.Background()
 	store := persistence.NewMemoryPersistence()
@@ -268,15 +264,14 @@ func TestLegacyAdapterTrimSnapshots_ZeroKeepsEverything(t *testing.T) {
 	assert.Len(t, snaps, 3)
 }
 
-// The unsupported-store check must precede the KeepSnapshots short-circuit, so a
-// direct caller learns the store is misconfigured instead of getting a nil error
-// that looks like "nothing to trim".
+// The unsupported-store check must precede the KeepSnapshots short-circuit, or a
+// direct caller gets a nil error that reads as "nothing to trim".
 func TestLegacyAdapterTrimSnapshots_UnsupportedStore(t *testing.T) {
 	ctx := context.Background()
 	inner := persistence.NewMemoryPersistence()
 
-	// Subtests rather than a bare loop: keep=0 is the case that regresses if the
-	// guards are reordered, and it must still be reported even when keep=1 fails.
+	// Subtests, not a bare loop: keep=0 is the case that regresses on reorder and
+	// must report independently of keep=1.
 	for _, keep := range []int{0, 1} {
 		t.Run(fmt.Sprintf("keep=%d", keep), func(t *testing.T) {
 			a := persistence.NewLegacyAdapter(bareStore{VersionedPersistence: inner})

--- a/persistence/adapter_version_test.go
+++ b/persistence/adapter_version_test.go
@@ -2,6 +2,7 @@ package persistence_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -197,4 +198,88 @@ func TestLegacyAdapterTrimSnapshots_PerLabelBound(t *testing.T) {
 	assert.Equal(t, 2, counts["auto"], "auto class bounded")
 	assert.Equal(t, 2, counts["manual"], "manual class bounded independently")
 	assert.Len(t, snaps, 4, "room total is the sum of the bounded classes")
+}
+
+// failingDeleteStore wraps a real store and fails exactly one DeleteSnapshot, to
+// prove a single failure neither aborts the remaining deletes nor is silently
+// dropped by the error-returning entry point.
+type failingDeleteStore struct {
+	persistence.SnapshotVersionedPersistence
+	failID int64
+}
+
+func (f *failingDeleteStore) DeleteSnapshot(ctx context.Context, room string, id int64) error {
+	if id == f.failID {
+		return errors.New("boom")
+	}
+	return f.SnapshotVersionedPersistence.DeleteSnapshot(ctx, room, id)
+}
+
+// TrimSnapshots reports what it did: the count is the number actually deleted,
+// and a failure is joined rather than swallowed the way SaveVersion's internal
+// best-effort call does.
+func TestLegacyAdapterTrimSnapshots_ReportsCountAndJoinsErrors(t *testing.T) {
+	ctx := context.Background()
+	inner := persistence.NewMemoryPersistence()
+	seedRoom(t, inner, "room", 1)
+
+	// Four snapshots, KeepSnapshots=1 leaves three surplus; one delete fails.
+	base := persistence.NewLegacyAdapter(inner)
+	var ids []int64
+	for i := 0; i < 4; i++ {
+		id, err := base.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	store := &failingDeleteStore{SnapshotVersionedPersistence: inner, failID: ids[1]}
+	a := persistence.NewLegacyAdapter(store)
+	a.KeepSnapshots = 1
+
+	n, err := a.TrimSnapshots(ctx, "room", "auto")
+	require.Error(t, err, "the failed delete must be reported, not swallowed")
+	assert.Contains(t, err.Error(), "boom")
+	assert.Equal(t, 2, n, "the other two surplus snapshots must still be deleted")
+
+	snaps, err := inner.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	assert.Len(t, snaps, 2, "the newest kept, plus the one whose delete failed")
+}
+
+// KeepSnapshots <= 0 keeps everything — deliberately the opposite of some other
+// Yjs ports, where a keep of 0 deletes every version.
+func TestLegacyAdapterTrimSnapshots_ZeroKeepsEverything(t *testing.T) {
+	ctx := context.Background()
+	store := persistence.NewMemoryPersistence()
+	a := persistence.NewLegacyAdapter(store)
+	// KeepSnapshots left at its 0 default.
+	seedRoom(t, store, "room", 1)
+	for i := 0; i < 3; i++ {
+		_, err := a.SaveVersion(ctx, "room", "auto")
+		require.NoError(t, err)
+	}
+
+	n, err := a.TrimSnapshots(ctx, "room", "auto")
+	require.NoError(t, err)
+	assert.Zero(t, n, "KeepSnapshots=0 must delete nothing")
+	snaps, err := store.ListSnapshots(ctx, "room")
+	require.NoError(t, err)
+	assert.Len(t, snaps, 3)
+}
+
+// The unsupported-store check must precede the KeepSnapshots short-circuit, so a
+// direct caller learns the store is misconfigured instead of getting a nil error
+// that looks like "nothing to trim".
+func TestLegacyAdapterTrimSnapshots_UnsupportedStore(t *testing.T) {
+	ctx := context.Background()
+	inner := persistence.NewMemoryPersistence()
+
+	for _, keep := range []int{0, 1} {
+		a := persistence.NewLegacyAdapter(bareStore{VersionedPersistence: inner})
+		a.KeepSnapshots = keep
+		n, err := a.TrimSnapshots(ctx, "room", "auto")
+		assert.ErrorIs(t, err, persistence.ErrSnapshotsUnsupported,
+			"KeepSnapshots=%d must still report the misconfiguration", keep)
+		assert.Zero(t, n)
+	}
 }

--- a/persistence/conformance_names.go
+++ b/persistence/conformance_names.go
@@ -1,16 +1,12 @@
 package persistence
 
 // conformanceRoomNames is the room-name set both RunRoomListerConformance and
-// RunSnapshotStoreConformance probe, kept in one place so the two suites cannot
-// drift apart. They had: the room suite exercised odd names while the snapshot
-// suite used the literal "room" for all of its call sites, so no implementation
-// was ever checked against a name needing escaping on the snapshot path — where
-// IDs are often recovered by parsing them back out of an object name, and a
-// name containing the implementation's delimiter silently maps one room's IDs
-// onto another's rather than failing loudly (issue #211).
+// RunSnapshotStoreConformance probe, shared so the two cannot drift apart again:
+// the room suite exercised awkward names while the snapshot suite used the
+// literal "room" everywhere (issue #211).
 //
 // A backend may encode these however it likes on disk, but every operation must
-// round-trip the ORIGINAL name and must keep distinct names distinct.
+// round-trip the ORIGINAL name and keep distinct names distinct.
 var conformanceRoomNames = []string{
 	"plain",
 	"with/slash",
@@ -19,13 +15,12 @@ var conformanceRoomNames = []string{
 	// Precomposed (NFC).
 	"\u00fc\u00f1\u00ef\u00e7\u00f6d\u00e9",
 	// The same glyphs decomposed (NFD): distinct bytes that collide if a backend
-	// lets a normalizing filesystem name the object (HFS+ normalizes to NFD),
-	// conflating two different rooms. Escapes on both entries deliberately — as
-	// literals the two lines are indistinguishable in every editor and diff, and
-	// tooling may silently normalize one into the other, destroying the only
-	// thing this pair tests.
+	// lets a normalizing filesystem name the object (HFS+ normalizes to NFD).
+	// Escaped on both entries because as literals they are indistinguishable in
+	// any editor or diff, and tooling that normalized one into the other would
+	// silently destroy the only thing the pair tests.
 	"u\u0308n\u0303i\u0308c\u0327o\u0308de\u0301",
-	// roomname.Valid rejects exactly "." and "..", but accepts this, so a
-	// backend that uses raw names as path segments traverses out of its root.
+	// roomname.Valid rejects exactly "." and "..", but accepts this, so a backend
+	// using raw names as path segments traverses out of its root.
 	"../escape",
 }

--- a/persistence/conformance_names.go
+++ b/persistence/conformance_names.go
@@ -1,0 +1,31 @@
+package persistence
+
+// conformanceRoomNames is the room-name set both RunRoomListerConformance and
+// RunSnapshotStoreConformance probe, kept in one place so the two suites cannot
+// drift apart. They had: the room suite exercised odd names while the snapshot
+// suite used the literal "room" for all of its call sites, so no implementation
+// was ever checked against a name needing escaping on the snapshot path — where
+// IDs are often recovered by parsing them back out of an object name, and a
+// name containing the implementation's delimiter silently maps one room's IDs
+// onto another's rather than failing loudly (issue #211).
+//
+// A backend may encode these however it likes on disk, but every operation must
+// round-trip the ORIGINAL name and must keep distinct names distinct.
+var conformanceRoomNames = []string{
+	"plain",
+	"with/slash",
+	"with:colon",
+	"with space",
+	// Precomposed (NFC).
+	"\u00fc\u00f1\u00ef\u00e7\u00f6d\u00e9",
+	// The same glyphs decomposed (NFD): distinct bytes that collide if a backend
+	// lets a normalizing filesystem name the object (HFS+ normalizes to NFD),
+	// conflating two different rooms. Escapes on both entries deliberately — as
+	// literals the two lines are indistinguishable in every editor and diff, and
+	// tooling may silently normalize one into the other, destroying the only
+	// thing this pair tests.
+	"u\u0308n\u0303i\u0308c\u0327o\u0308de\u0301",
+	// roomname.Valid rejects exactly "." and "..", but accepts this, so a
+	// backend that uses raw names as path segments traverses out of its root.
+	"../escape",
+}

--- a/persistence/rooms_conformance.go
+++ b/persistence/rooms_conformance.go
@@ -122,7 +122,7 @@ func RunRoomListerConformance(t *testing.T, factory func() SnapshotVersionedPers
 		// Backends may encode room names on disk (the file backend hex-encodes
 		// them); enumeration must return the ORIGINAL name, not the encoded form.
 		p := factory()
-		names := []string{"plain", "with/slash", "with:colon", "üñïçödé", "with space"}
+		names := conformanceRoomNames
 		updates, _ := genUpdates(t, 1)
 		for _, n := range names {
 			if _, err := p.AppendUpdate(ctx, n, updates[0]); err != nil {

--- a/persistence/snapshots_conformance.go
+++ b/persistence/snapshots_conformance.go
@@ -16,11 +16,10 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 	t.Helper()
 	ctx := context.Background()
 
-	// Parameterised over conformanceRoomNames: the room name reaches the
-	// snapshot path's name-derived surface (the per-room counter object embeds
-	// it, and IDs are often recovered by parsing them back out of an object
-	// name), so an awkward name can corrupt ID handling rather than fail
-	// loudly. See conformance_names.go and issue #211.
+	// Parameterised over conformanceRoomNames. The snapshot path derives object
+	// names from the room name and often recovers IDs by parsing them back out,
+	// so an awkward name corrupts ID handling silently rather than failing, and
+	// a wrong ID decides which state a user restores (issue #211).
 	t.Run("SaveThenListNewestFirst", func(t *testing.T) {
 		for _, room := range conformanceRoomNames {
 			t.Run(room, func(t *testing.T) {
@@ -308,35 +307,23 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 		}
 	})
 
-	// Parameterised over pairs of DISTINCT rooms whose names collide under a
-	// naive encoding. This is the case that catches the sharp edge in #211:
-	// snapshot IDs are often recovered by parsing them back out of an object
-	// name, so two rooms collapsing to one key silently maps one room's IDs
-	// onto the other's instead of failing, and a wrong ID decides which state a
-	// user restores.
+	// Parameterised over pairs of DISTINCT rooms that collide under a naive
+	// encoding — the case that catches #211, where two rooms collapsing to one
+	// key maps one room's IDs onto the other's.
 	t.Run("RoomsAreIsolated", func(t *testing.T) {
 		pairs := []struct {
 			name string
 			a, b string
 		}{
-			// Both separators mapped to the same replacement character.
-			{"separator", "a/b", "a:b"},
-			// Percent-encoding applied to one name but not the other.
-			{"percent", "a/b", "a%2Fb"},
-			// Space encoded as "+".
-			{"space-plus", "a b", "a+b"},
-			// NFC vs NFD: distinct bytes that collide if the backend lets a
-			// normalizing filesystem name the object. Escaped deliberately —
-			// see conformance_names.go.
+			{"separator", "a/b", "a:b"},  // both separators to one character
+			{"percent", "a/b", "a%2Fb"},  // percent-encoding applied unevenly
+			{"space-plus", "a b", "a+b"}, // space encoded as +
+			// NFC vs NFD; escaped for the reason given in conformance_names.go.
 			{"unicode-normalization", "\u00fc\u00f1\u00ef", "u\u0308n\u0303i\u0308"},
 		}
 		for _, p := range pairs {
 			t.Run(p.name, func(t *testing.T) {
-				// The pair must be two DIFFERENT rooms or this case asserts
-				// nothing. Cheap insurance: the normalization pair in
-				// particular is two visually identical literals, and an editor
-				// or tool that normalizes the file would collapse them into one
-				// string, leaving a test that passes while checking nothing.
+				// Two identical names would make this case assert nothing.
 				if p.a == p.b {
 					t.Fatalf("pair %q is the same room twice (%q) — the names were normalized away", p.name, p.a)
 				}
@@ -364,10 +351,9 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 				if len(b) != 1 || b[0].Label != "b" {
 					t.Fatalf("room %q = %+v, want single label b", p.b, b)
 				}
-				// State is keyed by (room, id): each room reads its own blob. IDs
-				// are only unique within a room, so ids may legitimately collide
-				// across rooms — do NOT assert the other room's id is missing,
-				// that would fail on a correct backend.
+				// Keyed by (room, id): each room reads its own blob. IDs are only
+				// unique within a room, so do NOT assert the other room's id is
+				// missing — that would fail on a correct backend.
 				sa, err := s.GetSnapshotState(ctx, p.a, idA)
 				if err != nil {
 					t.Fatalf("GetSnapshotState(%q): %v", p.a, err)

--- a/persistence/snapshots_conformance.go
+++ b/persistence/snapshots_conformance.go
@@ -308,50 +308,85 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 		}
 	})
 
+	// Parameterised over pairs of DISTINCT rooms whose names collide under a
+	// naive encoding. This is the case that catches the sharp edge in #211:
+	// snapshot IDs are often recovered by parsing them back out of an object
+	// name, so two rooms collapsing to one key silently maps one room's IDs
+	// onto the other's instead of failing, and a wrong ID decides which state a
+	// user restores.
 	t.Run("RoomsAreIsolated", func(t *testing.T) {
-		s := factory()
-		idA, err := s.SaveSnapshot(ctx, "roomA", "a", []byte("aaa"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(roomA): %v", err)
+		pairs := []struct {
+			name string
+			a, b string
+		}{
+			// Both separators mapped to the same replacement character.
+			{"separator", "a/b", "a:b"},
+			// Percent-encoding applied to one name but not the other.
+			{"percent", "a/b", "a%2Fb"},
+			// Space encoded as "+".
+			{"space-plus", "a b", "a+b"},
+			// NFC vs NFD: distinct bytes that collide if the backend lets a
+			// normalizing filesystem name the object. Escaped deliberately —
+			// see conformance_names.go.
+			{"unicode-normalization", "\u00fc\u00f1\u00ef", "u\u0308n\u0303i\u0308"},
 		}
-		idB, err := s.SaveSnapshot(ctx, "roomB", "b", []byte("bbb"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(roomB): %v", err)
-		}
-		// Listings must not bleed across rooms.
-		a, err := s.ListSnapshots(ctx, "roomA")
-		if err != nil {
-			t.Fatalf("ListSnapshots(roomA): %v", err)
-		}
-		if len(a) != 1 || a[0].Label != "a" {
-			t.Fatalf("roomA = %+v, want single label a", a)
-		}
-		b, err := s.ListSnapshots(ctx, "roomB")
-		if err != nil {
-			t.Fatalf("ListSnapshots(roomB): %v", err)
-		}
-		if len(b) != 1 || b[0].Label != "b" {
-			t.Fatalf("roomB = %+v, want single label b", b)
-		}
-		// State is keyed by (room, id): each room reads its own blob. IDs are only
-		// unique within a room, so ids may legitimately collide across rooms.
-		sa, err := s.GetSnapshotState(ctx, "roomA", idA)
-		if err != nil {
-			t.Fatalf("GetSnapshotState(roomA): %v", err)
-		}
-		sb, err := s.GetSnapshotState(ctx, "roomB", idB)
-		if err != nil {
-			t.Fatalf("GetSnapshotState(roomB): %v", err)
-		}
-		if !bytes.Equal(sa, []byte("aaa")) || !bytes.Equal(sb, []byte("bbb")) {
-			t.Fatalf("states = %q / %q, want aaa / bbb", sa, sb)
-		}
-		// Deleting in one room must not affect the other.
-		if err := s.DeleteSnapshot(ctx, "roomB", idB); err != nil {
-			t.Fatalf("DeleteSnapshot(roomB): %v", err)
-		}
-		if _, err := s.GetSnapshotState(ctx, "roomA", idA); err != nil {
-			t.Fatalf("roomA snapshot must survive roomB delete: %v", err)
+		for _, p := range pairs {
+			t.Run(p.name, func(t *testing.T) {
+				// The pair must be two DIFFERENT rooms or this case asserts
+				// nothing. Cheap insurance: the normalization pair in
+				// particular is two visually identical literals, and an editor
+				// or tool that normalizes the file would collapse them into one
+				// string, leaving a test that passes while checking nothing.
+				if p.a == p.b {
+					t.Fatalf("pair %q is the same room twice (%q) — the names were normalized away", p.name, p.a)
+				}
+				s := factory()
+				idA, err := s.SaveSnapshot(ctx, p.a, "a", []byte("aaa"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(%q): %v", p.a, err)
+				}
+				idB, err := s.SaveSnapshot(ctx, p.b, "b", []byte("bbb"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(%q): %v", p.b, err)
+				}
+				// Listings must not bleed across rooms.
+				a, err := s.ListSnapshots(ctx, p.a)
+				if err != nil {
+					t.Fatalf("ListSnapshots(%q): %v", p.a, err)
+				}
+				if len(a) != 1 || a[0].Label != "a" {
+					t.Fatalf("room %q = %+v, want single label a", p.a, a)
+				}
+				b, err := s.ListSnapshots(ctx, p.b)
+				if err != nil {
+					t.Fatalf("ListSnapshots(%q): %v", p.b, err)
+				}
+				if len(b) != 1 || b[0].Label != "b" {
+					t.Fatalf("room %q = %+v, want single label b", p.b, b)
+				}
+				// State is keyed by (room, id): each room reads its own blob. IDs
+				// are only unique within a room, so ids may legitimately collide
+				// across rooms — do NOT assert the other room's id is missing,
+				// that would fail on a correct backend.
+				sa, err := s.GetSnapshotState(ctx, p.a, idA)
+				if err != nil {
+					t.Fatalf("GetSnapshotState(%q): %v", p.a, err)
+				}
+				sb, err := s.GetSnapshotState(ctx, p.b, idB)
+				if err != nil {
+					t.Fatalf("GetSnapshotState(%q): %v", p.b, err)
+				}
+				if !bytes.Equal(sa, []byte("aaa")) || !bytes.Equal(sb, []byte("bbb")) {
+					t.Fatalf("states = %q / %q, want aaa / bbb", sa, sb)
+				}
+				// Deleting in one room must not affect the other.
+				if err := s.DeleteSnapshot(ctx, p.b, idB); err != nil {
+					t.Fatalf("DeleteSnapshot(%q): %v", p.b, err)
+				}
+				if _, err := s.GetSnapshotState(ctx, p.a, idA); err != nil {
+					t.Fatalf("room %q snapshot must survive %q delete: %v", p.a, p.b, err)
+				}
+			})
 		}
 	})
 }

--- a/persistence/snapshots_conformance.go
+++ b/persistence/snapshots_conformance.go
@@ -16,42 +16,51 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 	t.Helper()
 	ctx := context.Background()
 
+	// Parameterised over conformanceRoomNames: the room name reaches the
+	// snapshot path's name-derived surface (the per-room counter object embeds
+	// it, and IDs are often recovered by parsing them back out of an object
+	// name), so an awkward name can corrupt ID handling rather than fail
+	// loudly. See conformance_names.go and issue #211.
 	t.Run("SaveThenListNewestFirst", func(t *testing.T) {
-		s := factory()
-		id1, err := s.SaveSnapshot(ctx, "room", "first", []byte("state-1"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(first): %v", err)
-		}
-		id2, err := s.SaveSnapshot(ctx, "room", "second", []byte("state-22"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(second): %v", err)
-		}
-		if id1 == id2 {
-			t.Fatalf("ids must be distinct, both = %d", id1)
-		}
-		if id2 <= id1 {
-			t.Fatalf("ids must increase: id1=%d id2=%d", id1, id2)
-		}
+		for _, room := range conformanceRoomNames {
+			t.Run(room, func(t *testing.T) {
+				s := factory()
+				id1, err := s.SaveSnapshot(ctx, room, "first", []byte("state-1"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(first): %v", err)
+				}
+				id2, err := s.SaveSnapshot(ctx, room, "second", []byte("state-22"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(second): %v", err)
+				}
+				if id1 == id2 {
+					t.Fatalf("ids must be distinct, both = %d", id1)
+				}
+				if id2 <= id1 {
+					t.Fatalf("ids must increase: id1=%d id2=%d", id1, id2)
+				}
 
-		got, err := s.ListSnapshots(ctx, "room")
-		if err != nil {
-			t.Fatalf("ListSnapshots: %v", err)
-		}
-		if len(got) != 2 {
-			t.Fatalf("len(ListSnapshots) = %d, want 2", len(got))
-		}
-		// Newest first.
-		if got[0].ID != id2 || got[1].ID != id1 {
-			t.Fatalf("order = [%d %d], want newest-first [%d %d]", got[0].ID, got[1].ID, id2, id1)
-		}
-		if got[0].Label != "second" || got[1].Label != "first" {
-			t.Fatalf("labels = [%q %q], want [second first]", got[0].Label, got[1].Label)
-		}
-		if got[0].Size != int64(len("state-22")) {
-			t.Fatalf("Size = %d, want %d", got[0].Size, len("state-22"))
-		}
-		if got[0].CreatedAt.IsZero() || got[1].CreatedAt.IsZero() {
-			t.Fatalf("CreatedAt must be stamped, got %v and %v", got[0].CreatedAt, got[1].CreatedAt)
+				got, err := s.ListSnapshots(ctx, room)
+				if err != nil {
+					t.Fatalf("ListSnapshots: %v", err)
+				}
+				if len(got) != 2 {
+					t.Fatalf("len(ListSnapshots) = %d, want 2", len(got))
+				}
+				// Newest first.
+				if got[0].ID != id2 || got[1].ID != id1 {
+					t.Fatalf("order = [%d %d], want newest-first [%d %d]", got[0].ID, got[1].ID, id2, id1)
+				}
+				if got[0].Label != "second" || got[1].Label != "first" {
+					t.Fatalf("labels = [%q %q], want [second first]", got[0].Label, got[1].Label)
+				}
+				if got[0].Size != int64(len("state-22")) {
+					t.Fatalf("Size = %d, want %d", got[0].Size, len("state-22"))
+				}
+				if got[0].CreatedAt.IsZero() || got[1].CreatedAt.IsZero() {
+					t.Fatalf("CreatedAt must be stamped, got %v and %v", got[0].CreatedAt, got[1].CreatedAt)
+				}
+			})
 		}
 	})
 
@@ -67,18 +76,22 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 	})
 
 	t.Run("GetSnapshotStateRoundTrip", func(t *testing.T) {
-		s := factory()
-		want := []byte("the-state-blob")
-		id, err := s.SaveSnapshot(ctx, "room", "lbl", want)
-		if err != nil {
-			t.Fatalf("SaveSnapshot: %v", err)
-		}
-		got, err := s.GetSnapshotState(ctx, "room", id)
-		if err != nil {
-			t.Fatalf("GetSnapshotState: %v", err)
-		}
-		if !bytes.Equal(got, want) {
-			t.Fatalf("state = %q, want %q", got, want)
+		for _, room := range conformanceRoomNames {
+			t.Run(room, func(t *testing.T) {
+				s := factory()
+				want := []byte("the-state-blob")
+				id, err := s.SaveSnapshot(ctx, room, "lbl", want)
+				if err != nil {
+					t.Fatalf("SaveSnapshot: %v", err)
+				}
+				got, err := s.GetSnapshotState(ctx, room, id)
+				if err != nil {
+					t.Fatalf("GetSnapshotState: %v", err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("state = %q, want %q", got, want)
+				}
+			})
 		}
 	})
 
@@ -199,30 +212,34 @@ func RunSnapshotStoreConformance(t *testing.T, factory func() SnapshotStore) {
 	})
 
 	t.Run("DeleteSnapshotRemovesOnlyThatOne", func(t *testing.T) {
-		s := factory()
-		keep, err := s.SaveSnapshot(ctx, "room", "keep", []byte("k"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(keep): %v", err)
-		}
-		drop, err := s.SaveSnapshot(ctx, "room", "drop", []byte("d"))
-		if err != nil {
-			t.Fatalf("SaveSnapshot(drop): %v", err)
-		}
-		if err := s.DeleteSnapshot(ctx, "room", drop); err != nil {
-			t.Fatalf("DeleteSnapshot: %v", err)
-		}
-		got, err := s.ListSnapshots(ctx, "room")
-		if err != nil {
-			t.Fatalf("ListSnapshots: %v", err)
-		}
-		if len(got) != 1 || got[0].ID != keep {
-			t.Fatalf("after delete got %+v, want only id=%d", got, keep)
-		}
-		if _, err := s.GetSnapshotState(ctx, "room", drop); !errors.Is(err, ErrSnapshotNotFound) {
-			t.Fatalf("deleted snapshot err = %v, want ErrSnapshotNotFound", err)
-		}
-		if _, err := s.GetSnapshotState(ctx, "room", keep); err != nil {
-			t.Fatalf("kept snapshot must survive: %v", err)
+		for _, room := range conformanceRoomNames {
+			t.Run(room, func(t *testing.T) {
+				s := factory()
+				keep, err := s.SaveSnapshot(ctx, room, "keep", []byte("k"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(keep): %v", err)
+				}
+				drop, err := s.SaveSnapshot(ctx, room, "drop", []byte("d"))
+				if err != nil {
+					t.Fatalf("SaveSnapshot(drop): %v", err)
+				}
+				if err := s.DeleteSnapshot(ctx, room, drop); err != nil {
+					t.Fatalf("DeleteSnapshot: %v", err)
+				}
+				got, err := s.ListSnapshots(ctx, room)
+				if err != nil {
+					t.Fatalf("ListSnapshots: %v", err)
+				}
+				if len(got) != 1 || got[0].ID != keep {
+					t.Fatalf("after delete got %+v, want only id=%d", got, keep)
+				}
+				if _, err := s.GetSnapshotState(ctx, room, drop); !errors.Is(err, ErrSnapshotNotFound) {
+					t.Fatalf("deleted snapshot err = %v, want ErrSnapshotNotFound", err)
+				}
+				if _, err := s.GetSnapshotState(ctx, room, keep); err != nil {
+					t.Fatalf("kept snapshot must survive: %v", err)
+				}
+			})
 		}
 	})
 


### PR DESCRIPTION
Closes #211. Closes #212.

Both issues came out of wiring snapshot-backed version history in reearth-flow, and both live in the `persistence` snapshot surface.

## #212 — auto versions were evicting named snapshots

`trimSnapshots` kept the newest `KeepSnapshots` for a room with no regard for how each snapshot was created. With `Server.AutoVersionEvery` enabled, a snapshot named `"before-migration"` was silently deleted once `KeepSnapshots` newer auto versions existed — at a 15-minute interval with keep-50, roughly half a day of continuous editing, with no way to protect it.

The two classes have opposite retention needs. Auto versions are cheap, numerous and individually disposable, which is the entire point of bounding them. A named snapshot is an explicit user act and the thing a user would most object to losing. One newest-N rule over both means the disposable ones evict the durable ones.

**Retention is now scoped to the label the caller just wrote.** An `"auto"` save trims only auto versions; a named save trims only that same name.

The label is a *parameter* rather than something the adapter infers, and that was the design crux: `persistence` and `provider/websocket` do not import each other, so `persistence` cannot see `websocket.AutoVersionLabel`. The issue's suggested option 1 ("treat `AutoVersionLabel` as the trimmable class") reads as needing no API change, but it would have required `persistence` to hardcode `"auto"` and stay in sync with another package by string. Scoping to the caller's own label needs no such knowledge — and as a side effect `AutoVersionLabel` is now free to change without breaking retention.

It is also strictly tighter than exempting named snapshots outright, which would leave them unbounded; here each class is bounded at `KeepSnapshots`.

### `trimSnapshots` → `TrimSnapshots`

```go
func (a *LegacyAdapter) TrimSnapshots(ctx context.Context, room, label string) (int, error)
```

The issue's second half notes retention ran only from `SaveVersion`, so a caller writing through `SnapshotStore.SaveSnapshot` was never trimmed and with auto-versioning off `KeepSnapshots` did nothing at all. Exporting the entry point lets such a caller apply the same policy deliberately — the shape Deln0r/ygo already exposes as `persist.PruneVersions`, so this is proven rather than speculative. Two deliberate differences from theirs: errors are returned rather than the first one aborting the loop, and `keep <= 0` keeps everything where theirs deletes everything.

`SaveVersion` keeps its internal best-effort call and still swallows retention errors, for the reason its own doc already gives — the version is durable by then, and a missed trim retries on the next save.

### Accepted trade-off, stated explicitly

`KeepSnapshots` was a per-room bound and is now per-label, so a room's total is `distinct labels × KeepSnapshots` and there is **no** way to express a hard per-room cap. That is deliberate: capping the total is exactly what evicts named snapshots. If an application lets end users name snapshots, that growth is user-driven. This is spelled out in the `KeepSnapshots` doc, the CHANGELOG under **Changed**, and the release notes, rather than left for an operator to discover.

## #211 — the snapshot suite never used an awkward room name

`RunSnapshotStoreConformance` used the literal `"room"` for every call site, while `RunRoomListerConformance` already probed `"with/slash"`, `"with:colon"`, `"üñïçödé"`, `"with space"`. The snapshot path has strictly more name-derived surface: the per-room counter object embeds the room name, and IDs are often recovered by parsing them back out of an object name. A name carrying an implementation's delimiter corrupts ID handling *silently* instead of failing, and a wrong ID decides which state a user restores.

- **One shared `conformanceRoomNames`**, read by both suites so they cannot drift apart again. Two names added beyond the existing four: `"../escape"` (`roomname.Valid` rejects exactly `"."` and `".."` but accepts this, so a backend using raw names as path segments traverses out of its root) and an NFD counterpart to the precomposed Unicode name (distinct bytes that collide if a normalizing filesystem names the object).
- **Core round-trip parameterised** — save/list/get/delete, 7 names each. Narrow cases stay on the plain name where the room name is irrelevant, rather than costing every implementer 7× runtime for no coverage.
- **`RoomsAreIsolated` parameterised over collision-prone pairs** rather than duplicated into a new case: it already asserted the right things, just with names no encoding collapses.

| pair | collides when an implementation… |
|---|---|
| `a/b` vs `a:b` | maps both separators to one character |
| `a/b` vs `a%2Fb` | percent-encodes unevenly |
| `a b` vs `a+b` | encodes space as `+` |
| NFC vs NFD | lets the filesystem normalize the name |

### Verified the suite actually catches the bug

Built a store that emulates the reearth-flow GCS defect — rewriting awkward characters in its storage key so two rooms collapse onto one:

- **Previous suite: `ok`.** It passed a backend that silently merges two rooms.
- **This suite: fails on 3 of 4 pairs.** The normalization pair correctly does not fire, since that fake only mangles separators.

That gap is precisely what #211 reports.

Two details worth flagging:

- **Both Unicode entries use explicit `\u` escapes.** As literals the NFC and NFD lines are indistinguishable in any editor or diff, and tooling that normalizes the file would collapse them into one string — leaving a case that passes while asserting nothing. The pair also carries a `p.a == p.b` guard so that failure mode is loud.
- **No cross-room `ErrSnapshotNotFound` assertion.** IDs are per-room by contract, so both rooms may legitimately hold id 1; asserting the other room's ID is missing would fail on a *correct* backend. The case asserts each room reads its own blob instead.

## Blast radius

The in-tree memory, file, and sqlite backends pass unchanged — the file backend hex-encodes room names, sqlite keys by column, memory by map key. Confirmed by running, not assumed.

**Third-party `SnapshotStore` implementations may newly fail conformance. That is the intent**, and the release notes say so directly so it does not read as a surprise regression.

## Verification

- `go test -race ./...` green across all 17 packages.
- `make fixtures` regenerated with zero drift — no wire-format impact.
- Both pre-existing retention tests pass **unchanged**: they save every version under `"auto"`, so label-scoping is invisible to the auto path the provider drives.
- Guard ordering mutation-checked: swapping the store-type check and the `KeepSnapshots` short-circuit makes a misconfigured store return `(0, nil)` — reading as "nothing to trim" instead of "this store cannot hold snapshots" — and the test catches it.
- The `Release docs` and tag-time CHANGELOG/notes gates added in v1.44.0 were run against this branch before pushing; all four pass.

## Semver

`LegacyAdapter.TrimSnapshots` is a new exported method → **MINOR, v1.45.0**. CHANGELOG and RELEASE_NOTES entries are in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)