### PR TITLE
ci: Dependabot for Go security advisories + action bumps, and a weekly govulncheck (#102)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+updates:
+  # Security updates only, deliberately.
+  #
+  # Four direct dependencies' latest releases require a newer Go than go.mod's
+  # floor of 1.23 — modernc.org/sqlite, golang.org/x/sync and golang.org/x/time
+  # need 1.25, and github.com/redis/go-redis/v9 needs 1.24 — so version updates
+  # would open pull requests that cannot pass the Go 1.23 matrix job. A limit of
+  # 0 disables version updates; security updates are unaffected and do not count
+  # toward it.
+  #
+  # NOT solved with `ignore` rules: those would encode the Go floor a second
+  # time, where nothing verifies it, and would silently suppress valid updates
+  # once the real floor moves. When the floor rises, raise this number and delete
+  # this comment.
+  #
+  # Requires "Dependabot alerts" and "Dependabot security updates" to be enabled
+  # in repository settings; this file alone does not turn them on.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 0
+
+  # Every action is pinned to a major tag (actions/checkout@v5 and friends), so
+  # updates are rare and always mergeable. Grouped so a week's worth of bumps
+  # arrives as a single pull request instead of one each.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+
+  # npm is deliberately absent.
+  #
+  # testutil/package.json pins yjs exactly because it is the conformance oracle,
+  # not a dependency: CHANGELOG.md cites yjs@13.6.30 as the version our
+  # byte-for-byte wire compatibility is verified against, and the committed
+  # fixtures under crdt/testdata are generated from it, so the "Conformance
+  # fixture drift" job fails the moment the pin and the fixtures disagree.
+  #
+  # Bumping yjs is a deliberate act — regenerate fixtures, re-verify conformance,
+  # write a release note — not weekly triage. Please do not add an npm entry here
+  # thinking it was forgotten.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,22 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Weekly canary. govulncheck on push/PR only catches an advisory when
+  # something is pushed; this covers one landing against an unchanged dependency
+  # in a quiet week. Every job in this workflow runs on the schedule,
+  # deliberately: guarding the others with `if: github.event_name != 'schedule'`
+  # would silently fail to apply to any job added later, and a weekly check that
+  # main still builds green is worth having on its own.
+  #
+  # Note GitHub disables scheduled workflows in public repositories after 60 days
+  # with no repository activity, so this is bounded coverage, not a standing
+  # guarantee — Dependabot security alerts are the durable channel.
+  #
+  # 04:17 Monday UTC: off-hour and off-minute, because GitHub delays schedules at
+  # the top of every hour, and benchmark.yml already holds 06:00 daily.
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #102.

## ⚠️ Needs one admin action to be fully live

The `gomod` half of this config **does nothing until Dependabot alerts and security updates are enabled** in **Settings → Advanced Security**. My token has `maintain`, not `admin`, so I can't enable them — and I can't even read the current state: `GET /repos/reearth/ygo/vulnerability-alerts` returns 404, but that endpoint requires admin, so the 404 is inconclusive rather than proof it's off.

The `github-actions` half and the weekly schedule **both work on merge**, since version updates don't depend on alerts.

## Two departures from the issue as written

**1. npm is excluded, not included.** #102 lists "the `testutil` npm dir" in scope. But its only two entries are the conformance oracle, exact-pinned:

```json
"yjs": "13.6.30",
"yjs14": "npm:yjs@14.0.0-16"
```

`yjs@13.6.30` is cited throughout `CHANGELOG.md` as the version our byte-for-byte compatibility is *verified against*, and the committed fixtures are generated from it — so `Conformance fixture drift` fails the moment the pin and the fixtures disagree. Bumping yjs means regenerating fixtures, re-verifying, and writing a release note.

Deln0r/ygo enabled npm on their equivalent directory, and **every yjs PR the bot opened was closed** (`#6`, `#12`); they landed 13.6.31 deliberately instead. Enabling it buys triage, not safety. The absence carries a comment so a later reader doesn't "fix" it.

**2. `on:` is workflow-level, so the whole workflow runs weekly.** #102 asks for "a ~3-line addition to the existing `vuln` job's `on:` — **not** a new workflow file". Jobs have no triggers, so that isn't possible as described. Three ways out; I took the third:

| Option | Cost |
|---|---|
| Guard the other four jobs with `if: github.event_name != 'schedule'` | A trap — any job added later silently runs weekly unless someone remembers |
| Split `vuln` into its own workflow | Trap-free, but contradicts the issue's explicit "not a new workflow file" |
| **Let all of `ci.yml` run weekly** | More flake surface, but no trap, and a free weekly canary that main still builds green |

Verified structurally that the job set is unchanged and **no job acquired a guard**.

## Why `gomod` is security-only

Four of seven direct dependencies can't be bumped at our `go 1.23` floor:

| Dependency | Current | Latest | Latest needs |
|---|---|---|---|
| `modernc.org/sqlite` | v1.34.5 | v1.56.0 | **Go 1.25** |
| `golang.org/x/sync` | v0.10.0 | v0.22.0 | **Go 1.25** |
| `golang.org/x/time` | v0.10.0 | v0.15.0 | **Go 1.25** |
| `github.com/redis/go-redis/v9` | v9.18.0 | v9.22.0 | **Go 1.24** |

Naive version updates would open four PRs on day one that **cannot pass the Go 1.23 matrix job**. `open-pull-requests-limit: 0` disables version updates while leaving security updates flowing — they don't count toward that limit.

**Deliberately not solved with `ignore` rules.** Deln0r hit this same wall reactively (closed PRs for `modernc.org/sqlite → 1.51.0` and `coder/websocket → 1.8.14`) and added ignores afterwards. Their config comments now read *"project floor is 1.22"* — a Go floor encoded in `dependabot.yml` is a second source of truth that nothing verifies, and it silently suppresses valid updates once the real floor moves. One number to change when the floor rises beats four ignores to remember to delete.

## Other choices

- **Actions grouped into one PR** via `groups` (a mapping, not a list). All 7 actions are major-tag pinned so bumps are rare and always mergeable. The rival doesn't group, which is why they have three separate action PRs open since June.
- **No `labels`/`commit-message` on the `gomod` block.** GitHub documents only `open-pull-requests-limit` (and `groups` with `applies-to: security-updates`) as applying to security updates, so those keys would be decoration I can't substantiate.
- **Security PRs left ungrouped** — advisories are rare, and grouping would bundle unrelated fixes behind one merge.
- **Labels created first.** `dependencies` and `github-actions` did not exist, and Dependabot *"ignores"* custom labels that aren't defined rather than creating them — so `labels:` would have silently done nothing. Both now exist.
- **Cron is `17 4 * * 1`.** Off-hour and off-minute: GitHub delays schedules at the top of every hour, and `benchmark.yml` already holds `0 6 * * *` daily with `fuzz.yml` at `0 2 * * *`.

## A limitation worth knowing

**Scheduled workflows in public repos are disabled after 60 days of no repository activity.** #102 wants the cron precisely to catch an advisory during a quiet period — so its coverage is bounded at 60 quiet days and then stops, silently. Recorded in a comment in `ci.yml`. It's worth having, but Dependabot security alerts are the durable channel, which is why the admin action above matters more than this cron does.

## Verification

- Both YAML files parse; `dependabot.yml` asserted to have exactly the intended shape (gomod limit 0, no `ignore`, no `labels`; actions grouped with both labels).
- `ci.yml`'s job set proven byte-identical before and after, and no job-level `if:` guard added.
- Three distinct crons across the three workflows, no collision.
- No `.go` files touched, so per CONTRIBUTING this is CI-only and needs no CHANGELOG or RELEASE_NOTES entry; `Release docs`' path filter agrees.
- `go test -race ./...` green (17 packages) and `golangci-lint` v2.12.2 clean.
- Re-checked the npm exclusion premise programmatically: `testutil/package.json` still has exactly the two oracle pins. If an ordinary npm dependency ever appears there, the exclusion argument no longer holds and this should be revisited.

## After merge

1. **Enable Dependabot alerts + security updates** (Settings → Advanced Security) — until then the `gomod` block is dormant.
2. Confirm GitHub parsed `dependabot.yml` on the repository's Dependabot page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)