### PR TITLE
feat(ygo-server): flags for periodic version capture and retention (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ testdata/fuzz/
 # Build output
 /dist/
 /bin/
+# `go build ./cmd/ygo-server/` drops the binary in the repo root, where
+# nothing else ignores it — a 16MB artifact one `git add -A` away from being
+# committed.
+/ygo-server
 
 # Go workspace
 go.work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.0] — 2026-08-05
+
+### Added
+
+- **`cmd/ygo-server` can capture versions on a timer.** Two flags wire the
+  binary to the auto-versioning the library has supported since v1.41.0:
+  `-version-interval` sets how often each **changed** room is captured (a quiet
+  room is never re-versioned), and `-keep-snapshots` bounds how many
+  auto-captured versions each room retains. Both default to off, so a default
+  run is unchanged. Retention is per label, so `-keep-snapshots` only ever trims
+  the server's own `auto` versions and cannot evict a snapshot an application
+  named deliberately. Setting `-keep-snapshots` without `-version-interval` now
+  warns at startup, because retention is applied at capture time and would
+  otherwise be silently inert (#167).
+
+### Fixed
+
+- **`ygo-server`'s documented flag list was missing two flags.**
+  `-awareness-expiry` and `-max-awareness-clients` had shipped without being
+  added to the package doc's `Usage` block. Both are documented now, and a test
+  asserts every declared flag appears there so the list cannot drift again
+  (#167).
+
 ## [1.45.0] — 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ func main() {
 
 ### Run a server
 
-For a ready-to-run binary — with flags for origins, connection/room limits, an optional Redis cluster relay (`-redis`), and SQLite persistence (`-store`) — use [`cmd/ygo-server`](cmd/ygo-server/):
+For a ready-to-run binary — with flags for origins, connection/room limits, an optional Redis cluster relay (`-redis`), SQLite persistence (`-store`), and periodic version capture (`-version-interval`, `-keep-snapshots`) — use [`cmd/ygo-server`](cmd/ygo-server/):
 
 ```bash
 # Binds 127.0.0.1:1234 by default (loopback only). The server has no built-in

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+## v1.46.0
+
+**Who is affected:** anyone running the `ygo-server` binary who wants a version
+history without writing one. The library is unchanged; this release only wires
+existing capability to the command line.
+
+**Two new flags.**
+
+```
+-version-interval duration   capture a version of each CHANGED room at most this often
+-keep-snapshots int          retain this many auto-captured versions per room
+```
+
+Both default to off, so a default run behaves exactly as before.
+
+`-version-interval 15m` captures at most one version per room per 15 minutes,
+and only for rooms that actually changed — a quiet room is never re-versioned,
+which is what keeps a history panel usable rather than full of identical
+entries.
+
+`-keep-snapshots 50` bounds the auto-captured versions. Retention is **per
+label**, so it trims only the server's own `auto` versions and cannot evict a
+snapshot your application named deliberately (say `before-migration`). That
+guarantee is v1.45.0's label-scoped retention; without it this flag would have
+been a footgun.
+
+Setting `-keep-snapshots` without `-version-interval` warns at startup:
+retention is applied at the moment a version is captured, so with nothing
+capturing, the bound is never enforced.
+
+**Also:** `-awareness-expiry` and `-max-awareness-clients` were missing from the
+binary's documented flag list and are now included, with a test that keeps the
+list from drifting again.
+
 ## v1.45.0
 
 **Who is affected:** anyone running `Server.AutoVersionEvery` together with

--- a/cmd/ygo-server/main.go
+++ b/cmd/ygo-server/main.go
@@ -17,9 +17,19 @@
 //	-max-peers-per-room per-room peer cap (0 = unlimited)
 //	-max-rooms          cap on total resident rooms (0 = unlimited)
 //	-max-message-bytes  per-message read cap in bytes (default 64 MiB)
+//	-max-awareness-clients
+//	                    per-room cap on distinct awareness client entries
+//	                    (default 10000; 0 = unlimited)
+//	-awareness-expiry   reclaim a remote client's presence after this idle
+//	                    duration (default 30s; 0 = disabled)
 //	-redis              Redis address for cross-process relay; empty = disabled
 //	-path               URL path pattern for the WebSocket handler (default "/yjs/{room}")
 //	-log                log format: "text" or "json" (default "text")
+//	-version-interval   capture a version of each CHANGED room at most this
+//	                    often; a quiet room is never re-versioned (0 = disabled)
+//	-keep-snapshots     retain this many auto-captured versions per room;
+//	                    applied on capture, so it needs -version-interval
+//	                    (0 = keep all)
 //
 // The process serves until it receives SIGINT or SIGTERM, then shuts down
 // gracefully: it stops accepting connections, drains in-flight work, detaches
@@ -83,6 +93,17 @@ type Config struct {
 	Path string
 	// Log is the log format: "text" or "json".
 	Log string
+	// VersionInterval enables periodic version capture: each room that CHANGED
+	// since its last version is captured at most this often, giving a
+	// user-facing history without the application driving one. A quiet room is
+	// never re-versioned. 0 = disabled.
+	VersionInterval time.Duration
+	// KeepSnapshots bounds retained auto-captured versions per room. It is
+	// applied when a version is captured, so it does nothing without
+	// VersionInterval. Retention is per LABEL, so it only ever trims the
+	// server's own auto versions and cannot evict a snapshot an application
+	// named deliberately. 0 = keep all.
+	KeepSnapshots int
 }
 
 // parseFlags parses the supplied arguments into a Config. It uses a dedicated
@@ -90,9 +111,21 @@ type Config struct {
 // tests and never calls os.Exit on a parse error — it returns the error so the
 // caller decides.
 func parseFlags(args []string) (Config, error) {
+	var cfg Config
+	fs := newFlagSet(&cfg)
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// newFlagSet declares every flag against cfg and returns the FlagSet without
+// parsing. Split out from parseFlags so a test can enumerate the flags via
+// VisitAll and assert the package doc's Usage block lists all of them — two
+// flags had already drifted out of that block before this seam existed.
+func newFlagSet(cfg *Config) *flag.FlagSet {
 	fs := flag.NewFlagSet("ygo-server", flag.ContinueOnError)
 
-	var cfg Config
 	fs.StringVar(&cfg.Addr, "addr", "127.0.0.1:1234",
 		"TCP listen address (default loopback-only; a non-loopback bind exposes the server, which has no built-in auth)")
 	fs.StringVar(&cfg.Store, "store", "", "SQLite DB path (empty = ephemeral in-memory; lost on restart)")
@@ -106,11 +139,12 @@ func parseFlags(args []string) (Config, error) {
 	fs.StringVar(&cfg.Redis, "redis", "", "Redis address for cross-process relay (empty = disabled)")
 	fs.StringVar(&cfg.Path, "path", "/yjs/{room}", "URL path pattern for the WebSocket handler")
 	fs.StringVar(&cfg.Log, "log", "text", `log format: "text" or "json"`)
+	fs.DurationVar(&cfg.VersionInterval, "version-interval", 0,
+		"capture a version of each CHANGED room at most this often; a quiet room is never re-versioned (0 = disabled)")
+	fs.IntVar(&cfg.KeepSnapshots, "keep-snapshots", 0,
+		"retain this many auto-captured versions per room; applied on capture, so it needs -version-interval (0 = keep all)")
 
-	if err := fs.Parse(args); err != nil {
-		return Config{}, err
-	}
-	return cfg, nil
+	return fs
 }
 
 // newLogger builds a slog.Logger writing to stderr in the requested format.
@@ -176,6 +210,20 @@ func isPublicBindAddr(addr string) bool {
 // document. The default bind is loopback, so this fires only when an operator
 // overrides -addr — at which point the deployment is expected to provide auth
 // at a layer in front (e.g. an authenticating reverse proxy).
+// warnIfInertRetention logs when -keep-snapshots is set without
+// -version-interval. Retention is applied at the moment a version is captured,
+// so with nothing capturing versions the bound is never enforced — an operator
+// who asked for one would otherwise believe it was in force. Same reasoning as
+// warnIfInsecureBind: a configuration that silently does nothing deserves to
+// say so at startup, where it will actually be read.
+func warnIfInertRetention(log *slog.Logger, cfg Config) {
+	if cfg.KeepSnapshots <= 0 || cfg.VersionInterval > 0 {
+		return
+	}
+	log.Warn("-keep-snapshots has no effect without -version-interval: " +
+		"retention is applied when a version is captured, and nothing captures versions")
+}
+
 func warnIfInsecureBind(log *slog.Logger, addr string) {
 	if !isPublicBindAddr(addr) {
 		return
@@ -216,7 +264,16 @@ func run(ctx context.Context, cfg Config, ready chan<- struct{}) error {
 	if err != nil {
 		return err
 	}
-	srv := ygows.NewServerWithPersistence(persistence.NewLegacyAdapter(store))
+	// The adapter is named rather than inlined because auto-versioning splits
+	// across both objects: the capture cadence is the server's concern
+	// (AutoVersionEvery) while retention is the adapter's (KeepSnapshots). Both
+	// are set before serving, as KeepSnapshots' contract requires.
+	adapter := persistence.NewLegacyAdapter(store)
+	adapter.KeepSnapshots = cfg.KeepSnapshots
+	srv := ygows.NewServerWithPersistence(adapter)
+	srv.AutoVersionEvery = cfg.VersionInterval
+
+	warnIfInertRetention(log, cfg)
 
 	srv.AllowedOrigins = parseOrigins(cfg.Origins)
 	srv.MaxConnections = cfg.MaxConns

--- a/cmd/ygo-server/main.go
+++ b/cmd/ygo-server/main.go
@@ -204,12 +204,6 @@ func isPublicBindAddr(addr string) bool {
 	return true
 }
 
-// warnIfInsecureBind logs a prominent warning when addr exposes the server to
-// the network. ygo-server wires no authentication of its own, so a non-loopback
-// bind means any host that can reach the port can read and modify every
-// document. The default bind is loopback, so this fires only when an operator
-// overrides -addr — at which point the deployment is expected to provide auth
-// at a layer in front (e.g. an authenticating reverse proxy).
 // warnIfInertRetention logs when -keep-snapshots is set without
 // -version-interval. Retention is applied at the moment a version is captured,
 // so with nothing capturing versions the bound is never enforced — an operator
@@ -224,6 +218,12 @@ func warnIfInertRetention(log *slog.Logger, cfg Config) {
 		"retention is applied when a version is captured, and nothing captures versions")
 }
 
+// warnIfInsecureBind logs a prominent warning when addr exposes the server to
+// the network. ygo-server wires no authentication of its own, so a non-loopback
+// bind means any host that can reach the port can read and modify every
+// document. The default bind is loopback, so this fires only when an operator
+// overrides -addr — at which point the deployment is expected to provide auth
+// at a layer in front (e.g. an authenticating reverse proxy).
 func warnIfInsecureBind(log *slog.Logger, addr string) {
 	if !isPublicBindAddr(addr) {
 		return

--- a/cmd/ygo-server/main_test.go
+++ b/cmd/ygo-server/main_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -236,5 +238,94 @@ func TestRun_InMemoryStore_StartsAndShutsDown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("run did not shut down")
+	}
+}
+
+// Auto-versioning is off unless asked for: both flags default to zero, which is
+// what keeps a default run from writing periodic versions nobody requested.
+func TestUnit_ParseFlags_AutoVersioningDefaultsOff(t *testing.T) {
+	cfg, err := parseFlags(nil)
+	if err != nil {
+		t.Fatalf("parseFlags(nil): %v", err)
+	}
+	if cfg.VersionInterval != 0 {
+		t.Errorf("VersionInterval = %v, want 0 (disabled)", cfg.VersionInterval)
+	}
+	if cfg.KeepSnapshots != 0 {
+		t.Errorf("KeepSnapshots = %d, want 0 (keep all)", cfg.KeepSnapshots)
+	}
+}
+
+func TestUnit_ParseFlags_AutoVersioningFlags(t *testing.T) {
+	cfg, err := parseFlags([]string{"-version-interval", "15m", "-keep-snapshots", "50"})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if cfg.VersionInterval != 15*time.Minute {
+		t.Errorf("VersionInterval = %v, want 15m", cfg.VersionInterval)
+	}
+	if cfg.KeepSnapshots != 50 {
+		t.Errorf("KeepSnapshots = %d, want 50", cfg.KeepSnapshots)
+	}
+}
+
+// -keep-snapshots without -version-interval is inert, because retention runs
+// only when a version is captured. The operator must be told, or they will
+// believe a bound is being enforced that is not.
+func TestUnit_KeepSnapshotsWithoutInterval_Warns(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantWarned bool
+	}{
+		{"retention without capture", []string{"-keep-snapshots", "50"}, true},
+		{"both set", []string{"-keep-snapshots", "50", "-version-interval", "15m"}, false},
+		{"neither set", nil, false},
+		{"capture without retention", []string{"-version-interval", "15m"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseFlags(tc.args)
+			if err != nil {
+				t.Fatalf("parseFlags: %v", err)
+			}
+			var buf bytes.Buffer
+			// Exercises the production function run() calls, not a restatement
+			// of its condition.
+			warnIfInertRetention(newLoggerTo(&buf, "text"), cfg)
+			warned := strings.Contains(buf.String(), "-keep-snapshots has no effect")
+			if warned != tc.wantWarned {
+				t.Fatalf("warned = %v, want %v (log: %q)", warned, tc.wantWarned, buf.String())
+			}
+		})
+	}
+}
+
+// Every flag must appear in the package doc's "# Usage" block. This is not
+// ceremony: -awareness-expiry and -max-awareness-clients had both shipped
+// without ever being added there, and nothing noticed until someone read the
+// two lists side by side.
+func TestUnit_PackageDocUsage_ListsEveryFlag(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	// The Usage block runs from "# Usage" to the end of the doc comment.
+	doc := string(src)
+	start := strings.Index(doc, "// # Usage")
+	end := strings.Index(doc, "\npackage main")
+	if start < 0 || end < 0 || end < start {
+		t.Fatalf("could not locate the package doc Usage block (start=%d end=%d)", start, end)
+	}
+	usage := doc[start:end]
+
+	var missing []string
+	newFlagSet(&Config{}).VisitAll(func(f *flag.Flag) {
+		if !strings.Contains(usage, "-"+f.Name) {
+			missing = append(missing, f.Name)
+		}
+	})
+	if len(missing) > 0 {
+		t.Fatalf("flags declared but absent from the package doc Usage block: %v", missing)
 	}
 }


### PR DESCRIPTION
Addresses the auto-versioning item of #167. **Two of that issue's three items need no work** — details below, and the issue should be updated to say so.

## What this adds

```
-version-interval duration   capture a version of each CHANGED room at most this often (0 = disabled)
-keep-snapshots int          retain this many auto-captured versions per room (0 = keep all)
```

Both default to off, so a default run is byte-for-byte unchanged in behaviour.

## #167 had gone stale — most of it already shipped

| #167 item | State |
|---|---|
| Auto-versioning flags | **This PR** — only the wiring was missing |
| Dockerfile | Outstanding, deliberately left for its own PR |
| Widen Go CI matrix | **Already satisfied** — `ci.yml` runs `["1.23", "1.26"]`, which is the `go.mod` floor through latest stable |

The issue asks for flags "wrapping the existing versioned persistence (`MaterializeAt` / `CaptureSnapshot` / `PruneAfter`)". Those names no longer exist; the mechanism is `Server.AutoVersionEvery` (v1.41.0) plus `LegacyAdapter.KeepSnapshots` (label-scoped as of v1.45.0).

It also asks for "a dirty-set optimization so idle documents aren't needlessly re-versioned" — **that already exists** as `dirtySinceVersion` in `provider/websocket/persistence.go`. `AutoVersionEvery`'s contract already guarantees "ONLY when the room actually changed since the last version. A quiet room is never versioned."

So what remained was the binary wiring the issue itself identifies as the gap.

## Deliberate deviation: `-keep-snapshots`, not `-keep-versions`

The issue proposes `-keep-versions`. `LegacyAdapter` has **two retention fields on different axes**:

- `KeepVersions` — retention over the **raw update log**, applied at compaction
- `KeepSnapshots` — retention over **snapshot entries**, applied on version save

A flag named `-keep-versions` that set `KeepSnapshots` would point at the wrong one while a real field of that name exists meaning something else. Named after what it actually sets.

## Two properties inherited, worth knowing

- **Idle rooms are skipped.** `-version-interval 15m` on a mostly-quiet server doesn't accumulate identical versions — that's the pre-existing dirty-set.
- **Retention is per label**, so `-keep-snapshots` trims only the server's own `"auto"` versions and **cannot evict a snapshot an application named deliberately**. That's v1.45.0's label-scoped retention; a week ago this flag would have been a footgun.

## A flag that would have silently done nothing

`-keep-snapshots` alone is inert: retention is applied *at capture time*, so with no `-version-interval` nothing ever captures a version to trim. An operator setting a bound would believe it was enforced. It now warns at startup via `warnIfInertRetention`, following the existing `warnIfInsecureBind` pattern.

The test calls that production function rather than restating its condition — my first version mirrored the predicate in the test, which would have passed even if `run()` never called it.

## Pre-existing gap fixed while in there

`-awareness-expiry` and `-max-awareness-clients` had **shipped without ever being added to the package doc's `Usage` block**. Both are documented now, and `newFlagSet` is split out of `parseFlags` so a test enumerates flags via `VisitAll` and asserts every one appears there:

```
flags declared but absent from the package doc Usage block: [keep-snapshots]
```

— that's the guard failing when I removed a flag from the block, so it genuinely bites.

## Verification

- 17 packages green under `-race`; `golangci-lint` v2.12.2 clean.
- **Mutation-checked both new guards**: removing a flag from the Usage block fails the drift test; inverting `warnIfInertRetention`'s condition fails the warning test.
- **Confirmed the assignments target the fields the library reads** — `AutoVersionEvery` at `provider/websocket/persistence.go:58`, `KeepSnapshots` at `persistence/adapter.go:173/188/195`. This is the residual risk on a 2-line wiring, so I checked it directly rather than trusting that it looked right.
- Help output verified as an operator sees it.

**Limit worth stating:** there is no end-to-end test booting the binary, making an edit, and asserting a version lands. The auto-version *behaviour* is covered by 7 existing provider-level tests, and what's new here is two field assignments; adding a websocket dial helper to the cmd test purely for that felt disproportionate. If you'd rather have it, say so and I'll add it.

## Also

`.gitignore` now ignores `/ygo-server`. `go build ./cmd/ygo-server/` drops a 16MB binary in the repo root and nothing ignored it — I hit exactly that with a `git add -A` during this work and caught it in the diff. Separate commit.

## Release

**v1.46.0**, filed under **Added**. Worth flagging the ambiguity: `cmd/ygo-server` is `package main` and therefore not importable, so the library's API surface does not change and a strict reading of "bump size follows API surface" would make this a PATCH. I went MINOR because it adds user-facing functionality to a shipped binary — one-line change in `CHANGELOG.md`/`RELEASE_NOTES.md` if you'd rather it be `v1.45.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)