### PR TITLE
fix(websocket): drain and join outbound relay lanes on Shutdown (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.46.0] — 2026-08-05
+## [1.46.0] — 2026-08-09
 
 ### Added
 
@@ -21,6 +21,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detached array the type splices into the staged content and plain-value runs
   split around it at attach. Conformance fixtures pin both shapes byte-identical
   to `yjs@13.6.30`, and the plain-value rejection now names `InsertType` first.
+
+### Fixed
+
+- **`Server.Shutdown` no longer silently discards queued outbound relay
+  updates.** Shutdown used to cancel the relay context as its second act —
+  before closing peer connections and before the persistence drain — while
+  each lane worker's cancellation path returned without draining and nothing
+  joined the workers. Everything peers committed during that window vanished
+  with `RelayStats().Dropped` and `HardDrops` both reading zero, and a
+  `relay.Publish` call could still be in flight after `Shutdown` returned,
+  making the documented "caller `Close()`s the relay last" ownership rule
+  unsafe. `Shutdown` now retires every outbound lane after the persistence
+  drain, drains them under the still-live relay context (so the final tail is
+  actually published), joins the lane workers bounded by `Shutdown`'s ctx,
+  and only then cancels the relay context — which also stops inbound
+  delivery, safely deferred because `Inject`/`Apply`/`BroadcastUpdate` have
+  refused with `ErrServerShutdown` since `shutdownCh` closed at the top of
+  `Shutdown`. A backlog that cannot be delivered before the caller's ctx
+  expires is counted in `Dropped` instead of vanishing: there is no longer
+  any path where updates are lost while both counters read zero (#202).
+
+### Changed
+
+- **`RelayStats.Dropped` now counts every lost outbound payload, not only
+  pre-lane discards.** Previously it only counted payloads that never reached
+  a lane; a payload taken from a lane and then lost — `relay.Publish`
+  returning an error (no retry path exists), or a backlog discarded because
+  shutdown could not deliver it — was logged but uncounted. All three paths
+  now increment `Dropped`, and the documented shutdown exception ("`Dropped`
+  reading zero after a `Shutdown` does not mean nothing was lost") is gone:
+  zero now means zero (#202).
+
+- **Contract amendment for `cluster.Relay` implementers:** `Publish` must
+  return promptly once its ctx is cancelled. `Server.Shutdown` relies on this
+  to unwedge a blocked `Publish` after the caller's deadline; an
+  implementation that ignores cancellation stalls the shutdown join and
+  leaves its worker goroutine running past `Shutdown`. Both shipped relays
+  (`cluster.MemRelay`, `cluster/redis`) already conform (#202).
 
 ## [1.45.0] — 2026-08-05
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,17 @@
 ## v1.46.0
 
-One addition: `YArray.InsertType`, completing the prelim constructor surface
-from v1.43.0. `PushType` could attach a nested type only at the end of an
-array; `InsertType` places one at any index. The gap mattered because the
-obvious workaround — `PushType` then `Move` — emits `ContentMove`, a ygo wire
-extension other implementations mis-parse, usually silently (#207), so
-mid-array placement of a nested type had no safe expression. No breaking API
-changes.
+Two changes. `YArray.InsertType` completes the prelim constructor surface
+from v1.43.0, and `Server.Shutdown` no longer silently discards queued
+outbound relay updates (#202).
 
 ### Added
 
-- **`YArray.InsertType(txn, index, type)`.** Attached placement mirrors
+- **`YArray.InsertType(txn, index, type)`** places a detached shared type at
+  any index; `PushType` could attach one only at the end. The gap mattered
+  because the obvious workaround — `PushType` then `Move` — emits
+  `ContentMove`, a ygo wire extension other implementations mis-parse,
+  usually silently (#207), so mid-array placement of a nested type had no
+  safe expression. Attached placement mirrors
   `Insert`: live-index semantics, splitting a plain-value run when the index
   falls inside it, and any unresolvable index anchoring at the tail. On a
   detached array the type splices into the staged content, and plain-value runs
@@ -21,6 +22,53 @@ changes.
   attached for interior, ends, beyond-the-end and negative indices. The
   rejection message for a shared type passed to `Insert`/`Push` as a plain
   value now points at `InsertType` first.
+
+### Fixed: shutdown relay-tail loss (#202)
+
+**Who is affected:** every clustered deployment — any server with a
+`cluster.Relay` attached — plus authors of third-party `Relay`
+implementations.
+
+**The fix.** `Server.Shutdown` cancelled the relay context as its second act,
+before closing peer connections and before the persistence drain. Peers kept
+committing for the rest of shutdown — potentially seconds — into per-room
+outbound lanes whose workers had already exited without draining, and nothing
+joined those workers. Two consequences, both fixed (#202):
+
+1. **Silent, uncounted tail loss.** Every update queued in that window was
+   discarded with `RelayStats().Dropped` and `HardDrops` both reading zero,
+   so an operator alerting on those counters concluded nothing was lost. On a
+   hot room — never reloaded from persistence — the peer node never converged
+   on those updates. `Shutdown` now drains each lane while publishing still
+   works and cancels the relay context last; whatever it cannot deliver
+   within your ctx budget is counted in `Dropped`. There is no longer any
+   path where updates vanish while both counters read zero — v1.42.0's
+   "`Dropped`/`HardDrops` should always be zero; alert on their presence"
+   operator model now holds across `Shutdown` too, and the exception
+   documented there is retired.
+
+2. **`Publish` could outlive `Shutdown`.** Nothing joined the lane workers,
+   so a `relay.Publish` call could still be in flight after `Shutdown`
+   returned — unsafe for a relay that frees resources in `Close()`, despite
+   the documented rule that the caller `Close()`s the relay once every
+   attached server is done. `Shutdown` now joins the workers, bounded by its
+   ctx.
+
+**What changes for you.** Give `Shutdown` a real deadline: its ctx is now
+also the delivery budget for the final outbound tail, and a `Shutdown` that
+could not finish within it returns the ctx error with the undelivered backlog
+counted in `Dropped`. `RelayStats.Dropped` is broader — it now also counts
+payloads lost to a failed `relay.Publish` call at any time, not just pre-lane
+discards — so a deployment that graphs it may see non-zero values it
+previously missed; they were always losses, just invisible ones. Inbound
+shutdown ordering is unchanged in effect: `Inject` has always refused with
+`ErrServerShutdown` from the moment `Shutdown` begins, so cancelling the
+relay context later cannot let remote changes mutate rooms.
+
+**For `Relay` implementers:** the `Publish` contract now states explicitly
+that it must return promptly once its ctx is cancelled — `Shutdown` relies on
+this to unwedge a blocked `Publish` after your deadline. Both shipped relays
+already conform.
 
 ## v1.45.0
 

--- a/cluster/relay.go
+++ b/cluster/relay.go
@@ -132,6 +132,17 @@ type Relay interface {
 	// own mutex, releases it, then sends on per-node channels; cluster/redis's
 	// Publish deliberately takes no lock at all and uses atomics plus
 	// channels.
+	//
+	// Publish MUST return promptly once ctx is cancelled (returning ctx's
+	// error for whatever it could not deliver). websocket.Server.Shutdown
+	// relies on this to unwedge a blocked Publish after its own deadline: it
+	// cancels the relay context and then joins the lane workers, counting
+	// every payload an aborted Publish abandons in RelayStats().Dropped
+	// (#202). A Publish that ignores cancellation stalls that join and
+	// leaves its worker goroutine running past Shutdown. Both shipped relays
+	// conform: MemRelay selects on ctx around its per-node channel sends,
+	// and cluster/redis's Publish selects on ctx around the hand-off to its
+	// publisher goroutine.
 	Publish(ctx context.Context, out Outbound) error
 	// Start binds a Sink for one node and begins delivering inbound changes to
 	// it. Each node (each Server) calls Start once; a relay shared across

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -380,18 +380,20 @@ If a deployment needs at-least-once delivery (no catch-up dependency on
 persistence), a Redis Streams-based adapter (`XADD` + last-read-id
 tracking) would replace this one. Tracked separately; not in v1.21.0.
 
-**`Shutdown` discards queued outbound updates, uncounted.** `Server.Shutdown`
-cancels the relay context before closing peer connections and before the
-persistence drain, so peers can keep committing for the rest of shutdown —
-potentially seconds — after outbound relay delivery has already stopped.
-Anything still queued in a room's outbound lane at that point, or enqueued
-afterward, is discarded with neither `Dropped` nor `HardDrops` incrementing:
-those counters reading zero after a `Shutdown` does not mean nothing was
-lost. This is pre-existing behaviour (the single shared outbound worker it
-replaced discarded the same way), not a regression from #187 — but it is
-worth calling out explicitly here, since the `Stats()`/`RelayStats()`
-section above establishes those same counters as the "always zero, alert on
-presence" signal for every other code path.
+**`Shutdown` drains queued outbound updates, and counts what it cannot
+deliver** (#202). `Server.Shutdown` used to cancel the relay context as its
+second act — before closing peer connections and before the persistence
+drain — so everything peers committed for the rest of shutdown was discarded
+with neither `Dropped` nor `HardDrops` incrementing. Since the #202 fix the
+relay context is cancelled at the *end* of `Shutdown`: each room's outbound
+lane is retired and drained while publishing still works, the lane workers
+are joined (bounded by `Shutdown`'s ctx, so no `Publish` call outlives a
+`Shutdown` that completed within its budget), and only then is the context
+cancelled. A backlog that cannot be delivered before the caller's ctx
+expires is counted in `RelayStats().Dropped` instead of vanishing. `Dropped`
+and `HardDrops` both reading zero after a `Shutdown` therefore means what it
+should: nothing was lost. Give `Shutdown` a real deadline — it is also the
+delivery budget for the final outbound tail.
 
 ### Observability: `Stats()`
 

--- a/provider/websocket/cluster.go
+++ b/provider/websocket/cluster.go
@@ -177,6 +177,11 @@ func (s *Server) ensureRelayLane(room string) *relayRoomLane {
 	prev, hadPrev := s.relayLanes[room]
 	l := &relayRoomLane{lane: relaylane.New(0), done: make(chan struct{})}
 	s.relayLanes[room] = l
+	// Register the worker on relayWG INSIDE the locked section: Shutdown's
+	// retireRelayLanes sets s.relayLanes to nil under this same mutex before
+	// its Waits start, so every Add is either strictly ordered before those
+	// Waits or never happens at all (the nil check above already returned).
+	s.relayWG.Add(1)
 	if hadPrev {
 		// This is the OTHER place (besides stopRelayLane) a lane can be
 		// retired, so it needs the identical fold: without it, a predecessor
@@ -251,9 +256,18 @@ func (s *Server) relayLaneFor(room string) *relayRoomLane {
 // the same time — that is a different, deliberately accepted overlap between
 // two distinct lanes, not a violation of this one.
 func (s *Server) relayLaneWorker(ctx context.Context, room string, l *relayRoomLane) {
+	defer s.relayWG.Done()
 	for {
 		select {
 		case <-ctx.Done():
+			// The relay context is dead, so the backlog cannot be published —
+			// but it must not vanish while Dropped reads zero (#202): count
+			// every abandoned payload. In the ordinary Shutdown sequence this
+			// case is rare (retireRelayLanes closes l.done and the final drain
+			// runs under a still-live relay context first); it is reached when
+			// Shutdown's ctx expired before the drain finished, or on a lane
+			// still live at cancellation time.
+			s.discardRelayLane(room, l)
 			return
 		case <-l.done:
 			s.drainRelayLane(ctx, room, l)
@@ -261,6 +275,62 @@ func (s *Server) relayLaneWorker(ctx context.Context, room string, l *relayRoomL
 		case <-l.lane.Signal():
 			s.drainRelayLane(ctx, room, l)
 		}
+	}
+}
+
+// discardRelayLane empties l without publishing, counting every abandoned
+// payload in relayDropped so the loss is visible in RelayStats(). Only called
+// once the relay context is cancelled — publishing is no longer possible.
+func (s *Server) discardRelayLane(room string, l *relayRoomLane) {
+	n := 0
+	for {
+		if _, ok := l.lane.TakeSync(); ok {
+			n++
+			continue
+		}
+		if _, ok := l.lane.TakeAwareness(); ok {
+			n++
+			continue
+		}
+		break
+	}
+	if n > 0 {
+		s.relayDropped.Add(uint64(n))
+		s.log().Warn("relay outbound: shutdown discarded undeliverable backlog",
+			"room", room, "payloads", n)
+	}
+}
+
+// retireRelayLanes retires EVERY remaining outbound lane at once and marks
+// the lane table closed: called only from Shutdown, after peers are gone and
+// the persistence drain is over. Setting s.relayLanes to nil (rather than
+// deleting entries) makes ensureRelayLane refuse new lanes from this point on
+// — it already treats a nil map as "no relay attached" — so no worker can be
+// created after Shutdown's WaitGroup joins begin, and a straggling
+// enqueueRelayOutbound finds no lane and counts its payload in Dropped
+// instead of parking it where nothing will ever drain it. RelayStats() keeps
+// reporting: it reads s.relayRetired (folded here) plus a range over the nil
+// map, which is a no-op.
+//
+// Concurrency with the other two retirement sites is the same
+// identity-under-mutex dance they play with each other: a stopRelayLane that
+// got there first already removed its lane from the map (so it is not in
+// this snapshot, and only that call closes its done); one that arrives after
+// finds s.relayLanes[room] no longer matching (nil map) and skips its own
+// close — never a double close.
+func (s *Server) retireRelayLanes() {
+	s.relayLanesMu.Lock()
+	lanes := s.relayLanes
+	s.relayLanes = nil
+	for _, l := range lanes {
+		st := l.lane.Stats()
+		s.relayRetired.Coalesced += st.Coalesced
+		s.relayRetired.AwarenessSuperseded += st.AwarenessSuperseded
+		s.relayRetired.HardDrops += st.HardDrops
+	}
+	s.relayLanesMu.Unlock()
+	for _, l := range lanes {
+		close(l.done)
 	}
 }
 
@@ -282,6 +352,12 @@ func (s *Server) publishRelay(ctx context.Context, room string, kind cluster.Kin
 	if err := s.relay.Publish(ctx, cluster.Outbound{
 		Room: room, Kind: kind, Data: data,
 	}); err != nil {
+		// The payload was already taken off the lane, so a failed Publish
+		// loses it — count it (#202). There is no retry path: KindSync blobs
+		// are only recoverable via a room reload's sync step, which a hot
+		// room never performs, so "logged but uncounted" would be exactly
+		// the silent divergence RelayStats.Dropped exists to surface.
+		s.relayDropped.Add(1)
 		s.log().Warn("relay publish failed", "room", room, "kind", kind, "err", err)
 	}
 }
@@ -487,18 +563,20 @@ type RelayStats struct {
 	// HardDrops counts payloads lost because a merge failed on a saturated
 	// lane. Should always be zero.
 	HardDrops uint64
-	// Dropped counts payloads discarded before ever reaching a lane (no
+	// Dropped counts every payload that was lost after the commit path
+	// handed it to the outbound side: discarded before reaching a lane (no
 	// relay attached at enqueue time, or a genuine straggler that lost its
 	// race against its lane's own retirement — see enqueueRelayOutbound's
-	// doc). Should always be zero in a healthy deployment.
+	// doc), taken from a lane but abandoned because relay.Publish returned
+	// an error (there is no retry path — see publishRelay), or still queued
+	// in a lane when Shutdown had to give up on delivery (see
+	// discardRelayLane). Should always be zero in a healthy deployment.
 	//
-	// Exception: Server.Shutdown cancels the relay context before closing
-	// peer connections and before the persistence drain, so peers can keep
-	// committing for the rest of shutdown. Whatever is still queued in a
-	// room's outbound lane at that point, or enqueued afterward, is
-	// discarded without incrementing Dropped (or HardDrops) — see
-	// docs/CLUSTERING.md's "Delivery semantics" section. Dropped reading
-	// zero after a Shutdown does not mean nothing was lost.
+	// Since the #202 fix there is no shutdown exception: Server.Shutdown
+	// drains each lane under the still-live relay context before cancelling
+	// it, and whatever it cannot deliver within its ctx budget is counted
+	// here. Dropped and HardDrops both reading zero after a Shutdown means
+	// nothing was lost.
 	Dropped uint64
 }
 

--- a/provider/websocket/relay_shutdown_test.go
+++ b/provider/websocket/relay_shutdown_test.go
@@ -1,0 +1,239 @@
+package websocket_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// shutdownProbeRelay is the #202 acceptance harness: a relay whose Publish
+// wedges (until released or its ctx is cancelled) while exposing exactly the
+// two facts those tests must assert on — every successfully published
+// payload, and how many Publish calls are in flight right now.
+//
+// Distinct from relay_lane_test.go's stallingRelay, which wedges by room name
+// and records nothing about in-flight calls: the #202 tests need to observe
+// "a Publish call outlived Shutdown" directly, not infer it.
+type shutdownProbeRelay struct {
+	release  chan struct{}
+	inFlight atomic.Int64
+
+	// ignoreCtx makes Publish sleep out its wedge even when ctx is cancelled,
+	// standing in for a relay mid-network-write that cannot unwind instantly.
+	// Used by the join test; zero means "honor ctx like a conforming relay".
+	ignoreCtxFor time.Duration
+
+	mu        sync.Mutex
+	published []cluster.Outbound
+}
+
+func newShutdownProbeRelay() *shutdownProbeRelay {
+	return &shutdownProbeRelay{release: make(chan struct{})}
+}
+
+func (r *shutdownProbeRelay) Publish(ctx context.Context, out cluster.Outbound) error {
+	r.inFlight.Add(1)
+	defer r.inFlight.Add(-1)
+	if r.ignoreCtxFor > 0 {
+		time.Sleep(r.ignoreCtxFor)
+	} else {
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	r.mu.Lock()
+	r.published = append(r.published, out)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *shutdownProbeRelay) Start(context.Context, cluster.Sink) error { return nil }
+func (r *shutdownProbeRelay) RoomActivated(string)                      {}
+func (r *shutdownProbeRelay) RoomDeactivated(string)                    {}
+func (r *shutdownProbeRelay) Close() error                              { return nil }
+
+// syncPayloads returns the successfully published KindSync blobs for room.
+func (r *shutdownProbeRelay) syncPayloads(room string) [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out [][]byte
+	for _, p := range r.published {
+		if p.Room == room && p.Kind == cluster.KindSync {
+			out = append(out, p.Data)
+		}
+	}
+	return out
+}
+
+// replayedTextLen applies blobs to a fresh doc and reports the length of its
+// "t" text — the ground truth for "how much of the backlog actually arrived".
+func replayedTextLen(t *testing.T, blobs [][]byte) int {
+	t.Helper()
+	d := crdt.New()
+	for _, b := range blobs {
+		require.NoError(t, crdt.ApplyUpdateV1(d, b, nil))
+	}
+	return len(d.GetText("t").ToString())
+}
+
+// THE #202 DELIVERY GATE: updates queued in a room's outbound lane when
+// Shutdown is called must still be PUBLISHED when the relay recovers within
+// Shutdown's ctx budget. Before the fix, Shutdown cancelled the relay context
+// as its second act, so the wedged Publish aborted, the lane's backlog was
+// discarded by the worker's bare ctx.Done() return, and releasing the wedge
+// mid-Shutdown delivered nothing — with Dropped still reading zero.
+func TestRelayShutdown_DeliversBacklogWhenRelayRecovers(t *testing.T) {
+	relay := newShutdownProbeRelay()
+	srv := ygws.NewServer()
+	require.NoError(t, srv.AttachRelay(relay))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+		ts.Close()
+	})
+
+	conn := dial(t, ts, "r")
+	drainHandshake(t, conn, crdt.New())
+
+	// Wedge the worker inside its first Publish, then pile a backlog behind it.
+	const edits = 50
+	for i := 0; i < edits; i++ {
+		require.NoError(t, crdt.ApplyUpdateV1(srv.GetDoc("r"), syncUpdate(t, "a"), nil))
+	}
+	require.Eventually(t, func() bool { return relay.inFlight.Load() == 1 },
+		2*time.Second, 5*time.Millisecond,
+		"the lane worker must be wedged inside Publish before Shutdown for this test to prove anything")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Shutdown(ctx) }()
+
+	// Let Shutdown get past its connection-close phase while the relay is
+	// still wedged, then let the relay recover. The 200ms is not load-bearing
+	// for the pre-fix failure: before the fix Shutdown has already cancelled
+	// the relay context (aborting the wedged Publish and killing the worker)
+	// regardless of when release is closed.
+	time.Sleep(200 * time.Millisecond)
+	close(relay.release)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "Shutdown must complete within its generous ctx once the relay recovers")
+	case <-time.After(8 * time.Second):
+		t.Fatal("Shutdown did not return after the relay recovered")
+	}
+
+	// Every queued edit must have arrived (possibly coalesced into fewer,
+	// larger blobs) — and nothing may have been counted as lost.
+	require.Equal(t, edits, replayedTextLen(t, relay.syncPayloads("r")),
+		"the outbound backlog queued at Shutdown must be published, not discarded")
+	require.Zero(t, srv.RelayStats().Dropped,
+		"nothing was lost, so Dropped must stay zero")
+}
+
+// THE #202 ACCOUNTING GATE: when the relay never recovers and Shutdown's ctx
+// expires, the queued backlog is undeliverable — and then it MUST be counted.
+// The invariant from the issue: no path may exist where updates vanish while
+// RelayStats().Dropped and HardDrops both read zero. Before the fix, the
+// worker's ctx.Done() case returned without draining and publishRelay's
+// failure path only logged, so exactly that silent-zero path existed.
+func TestRelayShutdown_CountsBacklogWhenRelayNeverRecovers(t *testing.T) {
+	relay := newShutdownProbeRelay() // release is never closed
+	srv := ygws.NewServer()
+	require.NoError(t, srv.AttachRelay(relay))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+		ts.Close()
+	})
+
+	conn := dial(t, ts, "r")
+	drainHandshake(t, conn, crdt.New())
+
+	for i := 0; i < 50; i++ {
+		require.NoError(t, crdt.ApplyUpdateV1(srv.GetDoc("r"), syncUpdate(t, "a"), nil))
+	}
+	require.Eventually(t, func() bool { return relay.inFlight.Load() == 1 },
+		2*time.Second, 5*time.Millisecond,
+		"the lane worker must be wedged inside Publish before Shutdown")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Shutdown(ctx) }()
+
+	// While Shutdown is in flight, inbound delivery must already be refused:
+	// shutdownCh closes as Shutdown's first act, so delaying the relay-context
+	// cancellation (part of the #202 fix) cannot let remote changes mutate
+	// rooms during the shutdown window.
+	require.Eventually(t, func() bool {
+		err := srv.Inject(context.Background(), cluster.Inbound{
+			Room: "r", Kind: cluster.KindSync, Data: syncUpdate(t, "x"),
+		})
+		return err == ygws.ErrServerShutdown
+	}, 2*time.Second, 5*time.Millisecond,
+		"Inject during an in-flight Shutdown must refuse with ErrServerShutdown")
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"a Shutdown that could not deliver within its ctx must say so")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return by its own deadline")
+	}
+
+	// The backlog could not be delivered — so its loss must become visible.
+	// (The worker counts asynchronously as the cancelled Publish unwinds,
+	// hence Eventually rather than an immediate read.)
+	require.Eventually(t, func() bool {
+		st := srv.RelayStats()
+		return st.Dropped > 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"an undeliverable shutdown backlog must be counted in RelayStats().Dropped — silent loss is the #202 bug")
+	require.Empty(t, relay.syncPayloads("r"),
+		"sanity: nothing can have been published, the relay never recovered")
+}
+
+// THE #202 OWNERSHIP GATE: no relay.Publish call may still be in flight after
+// Shutdown returns within its ctx budget — otherwise the documented rule "the
+// caller must Close() the relay once every attached server is done with it"
+// is unsafe for relays that free resources in Close. Before the fix nothing
+// joined the lane workers, so a Publish that does not unwind instantly (here:
+// one mid-"network write" for 150ms) was still running when Shutdown returned.
+func TestRelayShutdown_JoinsInFlightPublish(t *testing.T) {
+	relay := newShutdownProbeRelay()
+	relay.ignoreCtxFor = 150 * time.Millisecond
+	srv := ygws.NewServer()
+	require.NoError(t, srv.AttachRelay(relay))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+		ts.Close()
+	})
+
+	conn := dial(t, ts, "r")
+	drainHandshake(t, conn, crdt.New())
+	require.NoError(t, crdt.ApplyUpdateV1(srv.GetDoc("r"), syncUpdate(t, "a"), nil))
+	require.Eventually(t, func() bool { return relay.inFlight.Load() == 1 },
+		2*time.Second, 5*time.Millisecond,
+		"a Publish call must be in flight when Shutdown starts")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+
+	require.Zero(t, relay.inFlight.Load(),
+		"no Publish may outlive a Shutdown that completed within its ctx — Shutdown must join the lane workers")
+}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -420,7 +420,9 @@ type Server struct {
 
 	// relay, when non-nil, mirrors local doc/awareness changes to other server
 	// nodes and applies inbound changes. Set once via AttachRelay. relayCtx /
-	// relayCancel govern the relay's delivery lifetime; cancelled on Shutdown.
+	// relayCancel govern the relay's delivery lifetime; cancelled at the END
+	// of Shutdown, after the outbound lanes have been retired, drained and
+	// joined (#202 — see Shutdown's step comment).
 	// relaySentinel is the origin stamped on relay-injected changes so the
 	// per-room observers can drop echoes (identity guard: a *relayOriginSentinel,
 	// see that type's doc comment in cluster.go for why it must never be a
@@ -443,6 +445,18 @@ type Server struct {
 	relayLanesMu  sync.RWMutex
 	relayLanes    map[string]*relayRoomLane
 	relayDropped  atomic.Uint64
+
+	// relayWG counts live lane-worker goroutines (one per relayLaneWorker,
+	// Add under relayLanesMu in ensureRelayLane, Done when the worker
+	// returns) so Shutdown can JOIN them: without the join, a relay.Publish
+	// call could still be in flight after Shutdown returned, making the
+	// documented "the caller must Close() the relay once every attached
+	// server is done with it" rule unsafe for relays that free resources in
+	// Close (#202). The Add-vs-Wait ordering is safe because every Add
+	// happens under relayLanesMu while relayLanes is non-nil, and Shutdown's
+	// waits only start after retireRelayLanes has set relayLanes to nil under
+	// that same mutex — after which no Add can ever happen again.
+	relayWG sync.WaitGroup
 
 	// relayRetired accumulates the Coalesced/AwarenessSuperseded/HardDrops of
 	// every outbound lane this server has ever retired, folded in (under
@@ -993,16 +1007,18 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// Stop THIS server's relay delivery by cancelling the relay context: this
-	// winds down the relay worker and the relay's per-node delivery goroutine
-	// (started under relayCtx). It does NOT Close the relay — the caller owns
-	// the relay lifetime and must Close() it once every attached server is done,
-	// because a single relay is commonly shared across multiple in-process
-	// Servers (the MemRelay pattern) and Closing it would stop delivery for all
-	// of them (FIX C). No-op when no relay is attached.
-	if s.relayCancel != nil {
-		s.relayCancel()
-	}
+	// NOTE the relay context is deliberately NOT cancelled here (#202). It
+	// used to be, and that ordering silently discarded the outbound tail:
+	// peers keep committing for the whole connection-close-plus-persistence
+	// -drain window below, every one of those updates lands in a room lane
+	// whose worker had already exited on ctx.Done() without draining, and no
+	// counter fired. Cancellation now happens at the END of Shutdown, after
+	// the lanes have been retired, drained under the still-live relay
+	// context, and joined. Delaying it is safe for the INBOUND side because
+	// Inject (like Apply and BroadcastUpdate) refuses with ErrServerShutdown
+	// the moment shutdownCh closes — which was this function's first act —
+	// so the relay's delivery goroutine outliving this point cannot mutate
+	// any room; its deliveries just bounce.
 
 	// Collect all active peer connections and persistence channels.
 	s.rmu.RLock()
@@ -1061,7 +1077,61 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	case <-ctx.Done():
 	}
 
+	// Wind down outbound relay delivery (#202), in three ordered steps. The
+	// peers are gone and the persistence drain is over, so nothing can feed
+	// the lanes anymore (Apply/BroadcastUpdate/Inject have been refusing
+	// since shutdownCh closed); whatever the lanes still hold is the final
+	// outbound tail.
+	//
+	// 1. Retire every remaining lane (rooms evicted during the connection
+	//    closes above already retired theirs via stopRelayLane; this catches
+	//    idle-resident and Apply-created rooms). Each worker sees its done
+	//    channel close and performs its usual final drain — under the relay
+	//    context, which is STILL LIVE, so the tail is actually published.
+	// 2. Join the workers, bounded by ctx: Shutdown does not return while a
+	//    relay.Publish is in flight unless the caller's deadline forces it.
+	// 3. Cancel the relay context. This stops the relay's per-node inbound
+	//    delivery goroutine and unwedges any Publish still blocked past the
+	//    caller's deadline — a conforming Relay returns on ctx cancellation,
+	//    and every payload a cancelled Publish abandons is counted in
+	//    RelayStats().Dropped by publishRelay, so a Shutdown that could not
+	//    deliver never reads as lossless. The second join then reaps the
+	//    unwedged workers; with ctx already expired it returns immediately,
+	//    in which case ctx.Err() below tells the caller the join is
+	//    incomplete.
+	//
+	// It does NOT Close the relay — the caller owns the relay lifetime and
+	// must Close() it once every attached server is done, because a single
+	// relay is commonly shared across multiple in-process Servers (the
+	// MemRelay pattern) and Closing it would stop delivery for all of them
+	// (FIX C). No-op when no relay is attached.
+	s.retireRelayLanes()
+	s.waitRelayWorkers(ctx)
+	if s.relayCancel != nil {
+		s.relayCancel()
+	}
+	s.waitRelayWorkers(ctx)
+
 	return ctx.Err()
+}
+
+// waitRelayWorkers blocks until every lane worker has returned or ctx
+// expires, whichever comes first. The helper goroutine holds no lock and
+// exits as soon as the WaitGroup drains, so an expired-ctx return leaks it
+// only for as long as the workers themselves keep running.
+func (s *Server) waitRelayWorkers(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		s.relayWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
 }
 
 // NewServerWithPersistence returns a Server that loads and stores room state


### PR DESCRIPTION
Closes #202. Fixes the last of the PR #200 whole-branch-review findings: `Server.Shutdown` cancelled the relay context as its second act — before closing peer connections and before the persistence drain — while each lane worker's `ctx.Done()` case returned without draining and nothing joined the workers.

**Consequences fixed:**
1. **Silent, uncounted tail loss.** Every update peers committed during the connection-close + persistence-drain window landed in a lane whose worker had already exited; it was discarded with `RelayStats().Dropped` and `HardDrops` both reading zero — defeating the "always zero, alert on presence" operator model v1.42.0 established.
2. **`Publish` could outlive `Shutdown`.** Nothing joined the lane workers, making the documented "caller `Close()`s the relay once every attached server is done" ownership rule unsafe for relays that free resources in `Close`.

**The fix** (three ordered steps at the END of `Shutdown`): retire every remaining lane after the persistence drain (rooms evicted during connection close already retired theirs); drain under the still-live relay context so the tail is actually *published*; join the workers bounded by `Shutdown`'s ctx; cancel the relay context last. `retireRelayLanes` nils the lane map under `relayLanesMu`, which both blocks new lanes/`WaitGroup.Add`s structurally and routes straggling enqueues to the existing counted-drop path. Backlogs abandoned at cancellation (`discardRelayLane`) and failed `Publish` calls (`publishRelay`) now increment `Dropped` — the issue's acceptance invariant: no path where updates vanish while both counters read zero.

**Why delaying the cancel is safe inbound** (the part #202 flagged as needing its own reasoning): `Inject`, `Apply`, and `BroadcastUpdate` all refuse with `ErrServerShutdown` the moment `shutdownCh` closes — `Shutdown`'s first act — so the relay's delivery goroutine outliving the old cancel point cannot mutate any room. Pinned by an in-flight-Shutdown `Inject` assertion in the new tests.

**Contract amendments:** `cluster.Relay.Publish` must return promptly on ctx cancellation (both shipped relays already conform — verified, MemRelay selects on ctx per-node send, redis selects on ctx at the publisher hand-off). `RelayStats.Dropped` semantics broadened to count all post-commit losses; its documented shutdown exception is retired, along with docs/CLUSTERING.md's matching caveat.

**Testing:** three new acceptance tests (`relay_shutdown_test.go`), each verified RED against unfixed code: backlog behind a wedged `Publish` is delivered when the relay recovers within `Shutdown`'s ctx (replayed blob content equals every queued edit, `Dropped == 0`); an undeliverable backlog is counted (`Dropped > 0`, nothing published, `Shutdown` returns `DeadlineExceeded`); no `Publish` outlives a `Shutdown` that completes in budget (relay that ignores ctx for 150ms, in-flight gauge reads zero after return). Full `-race` suite green across `provider/websocket`, `cluster`, `cluster/redis`, `internal/relaylane`; `make test` and `make lint` clean.

CHANGELOG and RELEASE_NOTES under `[1.46.0]` — same version PR #213 targets; whichever merges second reconciles the shared heading. Date to be bumped to the release date at merge per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)