### PR TITLE
fix(crdt): reject zero-size-pointer origin tokens in WithTrackedOrigins (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.46.1] — 2026-08-09
+## [1.47.0] — 2026-08-09
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.1] — 2026-08-09
+
+### Fixed
+
+- **`WithTrackedOrigins` refuses origin tokens that cannot be told apart.**
+  Tracked-origin matching is Go interface equality, and pointers to zero-size
+  types break the "fresh pointer = unique token" idiom: every zero-size
+  allocation may share one address (`runtime.zerobase`), so two
+  `new(struct{})` tokens compare equal and tracking one silently captured the
+  other's transactions — the same aliasing that once disabled relay publishing
+  inside `provider/websocket` for six releases. The library cannot make
+  caller-supplied values distinct after the fact, so `WithTrackedOrigins` now
+  panics on a pointer-to-zero-size origin with guidance to use a non-zero-size
+  token type (e.g. `type token struct{ _ byte }`). Distinct named zero-size
+  VALUE types (`originA{}` vs `originB{}`) remain legal — interface equality
+  compares the dynamic type first, so they never alias each other. The origin
+  identity semantics are now documented on `WithTrackedOrigins`, `Transact`,
+  and `OnUpdate` (#203).
+
 ## [1.46.0] — 2026-08-09
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-## v1.46.1
+## v1.47.0
+
+### Fixed: zero-size origin tokens alias in `WithTrackedOrigins` (#203)
 
 **Who is affected:** anyone using `UndoManager` with `WithTrackedOrigins`,
 and more broadly anyone minting transaction-origin tokens as pointers.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+## v1.46.1
+
+**Who is affected:** anyone using `UndoManager` with `WithTrackedOrigins`,
+and more broadly anyone minting transaction-origin tokens as pointers.
+
+**The fix.** Tracked-origin matching is Go interface equality (`==`), and Go
+satisfies every zero-size allocation from a single address
+(`runtime.zerobase`) — so two origin tokens minted as `new(struct{})` compare
+equal even though the code plainly intends two distinct identities. An
+UndoManager tracking one such token silently captured the other's
+transactions too: user B's edits landing on user A's undo stack, with no
+error anywhere. This is the same aliasing that silently disabled relay
+publishing inside `provider/websocket` for six releases (fixed in v1.42.0);
+this occurrence sat on a public API where the library cannot fix the values
+for you (#203).
+
+**What changes for you.** `WithTrackedOrigins` now panics at construction
+when given a pointer to a zero-size type, naming the offending type and the
+fix. If you hit the panic, change your token type from `struct{}` to
+something with size — the conventional spelling is:
+
+```go
+type originToken struct{ _ byte }
+tok := &originToken{} // every allocation is now a distinct origin
+```
+
+Distinct named zero-size *value* types (`originA{}` vs `originB{}`) remain
+legal and correct — interface equality compares the dynamic type first, so
+they never alias each other. Ordinary comparable values (strings, ints) are
+unaffected. The identity semantics are now documented on
+`WithTrackedOrigins`, `Doc.Transact`, and `Doc.OnUpdate`.
+
+No API surface changes; strictly a misuse guard plus documentation.
+
 ## v1.46.0
 
 Two changes. `YArray.InsertType` completes the prelim constructor surface

--- a/crdt/doc.go
+++ b/crdt/doc.go
@@ -662,6 +662,15 @@ func (d *Doc) transactInternal(ctx context.Context, fn func(*Transaction) error,
 // Transact executes fn inside a transaction. All insertions and deletions made
 // during fn are batched; observers fire once after fn returns.
 //
+// The optional origin value tags the transaction: observers receive it
+// (OnUpdate's origin parameter, Transaction.Origin) and UndoManager's
+// WithTrackedOrigins filters on it — always by Go interface equality (==).
+// If you mint per-caller origin tokens as pointers, use a pointer to a
+// NON-zero-size type (e.g. type token struct{ _ byte }): pointers to
+// zero-size types may all share one address (runtime.zerobase) and compare
+// equal, silently merging origins that were meant to be distinct — see
+// WithTrackedOrigins' doc for the full trap (#203).
+//
 // Transact holds the document write lock for the duration of fn. Anything
 // that takes that same non-reentrant lock MUST NOT be called from inside fn
 // — it deadlocks silently, and Go exposes no goroutine identity with which
@@ -736,6 +745,11 @@ func (d *Doc) TransactE(fn func(*Transaction) error, origin ...any) error {
 // OnUpdate registers a callback that fires after every committed transaction.
 // The callback receives the incremental V1 update bytes for that transaction
 // and the origin value passed to Transact. Returns an unsubscribe function.
+//
+// Callbacks that compare the origin (an echo guard, a per-user filter) do so
+// with Go ==, so the caution on Transact's doc applies: pointer origin
+// tokens must point at non-zero-size types, or distinct tokens may alias
+// (runtime.zerobase, #203).
 //
 // The unsubscribe function is safe to call concurrently and handles
 // out-of-order unsubscription correctly (no index-capture bug).

--- a/crdt/undo.go
+++ b/crdt/undo.go
@@ -2,6 +2,8 @@ package crdt
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"sync"
 	"time"
 )
@@ -41,7 +43,40 @@ func WithCaptureTimeout(d time.Duration) UndoManagerOption {
 //
 // This is useful for multi-user documents where each user has a distinct
 // origin tag and should only be able to undo their own changes.
+//
+// Matching is Go interface equality (==), so origin values must be
+// DISTINGUISHABLE under ==. Values that compare equal are one origin, not
+// two — most surprisingly for pointers to zero-size types: Go satisfies
+// every zero-size allocation from one address (runtime.zerobase), so
+//
+//	a := new(struct{})
+//	b := new(struct{})
+//	// a == b — both may point at runtime.zerobase
+//
+// two "unique" tokens minted that way alias, and tracking one silently
+// captures the other's transactions too. This exact aliasing once disabled
+// relay publishing inside provider/websocket for six releases (#203, and
+// see relayOriginSentinel's doc in that package). Because the library
+// cannot make caller-supplied values distinct after the fact,
+// WithTrackedOrigins PANICS when given a pointer to a zero-size type.
+//
+// Safe token shapes:
+//   - a pointer to a NON-zero-size type — e.g. type token struct{ _ byte };
+//     &token{} — every allocation is a distinct origin;
+//   - distinct named types compared by value — originA{} and originB{}
+//     never alias each other (interface equality compares the dynamic type
+//     first), though every originA{} is the same origin as every other;
+//   - ordinary comparable values (strings, ints) with the usual value
+//     semantics: "alice" from anywhere is the origin "alice".
 func WithTrackedOrigins(origins ...any) UndoManagerOption {
+	for _, o := range origins {
+		if t := reflect.TypeOf(o); t != nil && t.Kind() == reflect.Pointer && t.Elem().Size() == 0 {
+			panic(fmt.Sprintf(
+				"crdt: WithTrackedOrigins: %T is a pointer to a zero-size type and cannot serve as a unique origin token "+
+					"(all zero-size allocations may share one address, runtime.zerobase, so two such tokens compare ==); "+
+					"use a pointer to a non-zero-size type instead, e.g. type token struct{ _ byte }", o))
+		}
+	}
 	return func(u *UndoManager) {
 		u.trackedOrigins = make(map[any]struct{}, len(origins))
 		for _, o := range origins {

--- a/crdt/undo_test.go
+++ b/crdt/undo_test.go
@@ -192,3 +192,87 @@ func TestUndoManager_RedoContext_OkReturnsResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, did, "Redo should succeed with one item on the redo stack")
 }
+
+// zeroTok is a named zero-size type: a pointer to it can NOT serve as a
+// unique per-instance token (all such pointers may share runtime.zerobase),
+// which is exactly what WithTrackedOrigins must refuse (#203).
+type zeroTok struct{}
+
+// undoTok is the safe spelling the godoc recommends: the _ byte field makes
+// every allocation distinct, so pointer identity is real.
+type undoTok struct{ _ byte }
+
+// THE #203 GUARD: WithTrackedOrigins must reject pointer-to-zero-size origin
+// tokens at construction time. Go satisfies every zero-size allocation from
+// runtime.zerobase, so two `new(struct{})` tokens compare ==, and a caller
+// who tracks one silently captures the other's transactions too — the same
+// aliasing that disabled relay publish for six releases inside
+// provider/websocket (see relayOriginSentinel's doc). The library cannot
+// give caller-supplied values distinct types after the fact, so the only
+// safe move is to refuse the un-distinguishable shape loudly.
+func TestUnit_UndoManager_WithTrackedOrigins_RejectsZeroSizePointerTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		origin any
+	}{
+		{"new(struct{})", new(struct{})},
+		{"&struct{}{}", &struct{}{}},
+		{"pointer to named empty struct", &zeroTok{}},
+		{"pointer to zero-size array", new([0]int)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := newTestDoc(1)
+			txt := doc.GetText("t")
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("WithTrackedOrigins accepted %s, a pointer to a zero-size type; "+
+						"want a construction-time panic — pointer identity for zero-size types is a lie (runtime.zerobase)", tc.name)
+				}
+			}()
+			um := NewUndoManager(doc, []sharedType{txt}, WithTrackedOrigins(tc.origin))
+			um.Destroy() // not reached
+		})
+	}
+}
+
+// The shapes the godoc points callers at must keep working, and must actually
+// be distinguishable: tracking one token never captures another's txns.
+func TestUnit_UndoManager_WithTrackedOrigins_DistinguishableTokenShapes(t *testing.T) {
+	t.Run("non-zero-size pointer tokens are distinct per allocation", func(t *testing.T) {
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+		mine, theirs := &undoTok{}, &undoTok{}
+		require.NotSame(t, mine, theirs,
+			"sanity: non-zero-size allocations must not alias")
+
+		um := NewUndoManager(doc, []sharedType{txt}, WithTrackedOrigins(mine))
+		defer um.Destroy()
+
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "mine", nil) }, mine)
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, 4, " theirs", nil) }, theirs)
+
+		require.Equal(t, 1, um.UndoStackSize(), "only the tracked token's txn may be captured")
+		require.True(t, um.Undo())
+		assert.Equal(t, " theirs", txt.ToString())
+	})
+
+	t.Run("distinct named zero-size VALUE types are distinguishable by type", func(t *testing.T) {
+		// Interface equality compares dynamic type first, so two different
+		// named empty-struct types never alias each other — only pointers to
+		// them are refused. Values stay legal.
+		type originA struct{}
+		type originB struct{}
+		doc := newTestDoc(1)
+		txt := doc.GetText("t")
+
+		um := NewUndoManager(doc, []sharedType{txt}, WithTrackedOrigins(originA{}))
+		defer um.Destroy()
+
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "a", nil) }, originA{})
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, 1, "b", nil) }, originB{})
+
+		require.Equal(t, 1, um.UndoStackSize(), "originB{} must not be captured when tracking originA{}")
+		require.True(t, um.Undo())
+		assert.Equal(t, "b", txt.ToString())
+	})
+}


### PR DESCRIPTION
Closes #203, another PR #200 whole-branch-review finding — the public-API twin of the `runtime.zerobase` sentinel aliasing fixed inside `provider/websocket` in v1.42.0.

**The bug:** `WithTrackedOrigins` matches `txn.Origin` by interface equality, and Go satisfies every zero-size allocation from one address — so two origin tokens minted as `new(struct{})` compare `==` even though the code plainly intends two identities. Tracking one silently captures the other's transactions: user B's edits on user A's undo stack, no error anywhere.

**The fix (issue's option 2 + a precise option 1/3):** the library cannot make caller-supplied values distinct after the fact, so `WithTrackedOrigins` now **panics at construction** on a pointer-to-zero-size origin (`reflect.TypeOf(o).Kind() == Pointer && Elem().Size() == 0`), naming the offending type and the conventional fix (`type token struct{ _ byte }`). Panic-on-misuse follows the crdt package's house style (`PushType` on an attached type, shared-type-as-plain-value) and the v1.44.0 precedent of rejecting at the boundary rather than documenting around it. The guard is deliberately narrow: distinct named zero-size **value** types (`originA{}` vs `originB{}`) stay legal — interface equality compares dynamic type first, so they never alias each other — and ordinary comparable values are untouched.

**The sweep the issue asked for:** `trackedOrigins` is the only place crdt compares caller-supplied `any` values by identity (`undo.go`'s other compare is against the manager pointer itself, non-zero-size; the `item.Origin` hits are wire-level `*ID`s). `Doc.Transact`'s origin parameter and `Doc.OnUpdate`'s surfaced origin don't compare anything themselves, so they get documentation: both now carry the identity-semantics note pointing at `WithTrackedOrigins`' full explanation.

**Testing (TDD, RED verified):** a four-shape rejection table (`new(struct{})`, `&struct{}{}`, pointer to named empty struct, `new([0]int)`) — all four failed before the guard — plus a regression pinning the two safe shapes: non-zero-size pointer tokens are distinct per allocation (tracking one never captures the other), and distinct named zero-size value types don't alias. `make test` and `make lint` clean.

**Versioning:** no new exported symbols → PATCH per CONTRIBUTING's API-surface rule; release docs under `[1.46.1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)