### PR TITLE
fix(crdt): reject cross-container double-staging at the call site (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.47.1] — 2026-08-09
+
+### Fixed
+
+- **Staging one detached shared type onto two containers now fails at the
+  second call, not at attach.** `PushType`/`InsertType`/`YMap.Set` accepted a
+  handle that was already staged on a *different* detached container (or, for
+  a map, under another key of the same map); both stagings succeeded and the
+  losing container's attach later panicked inside `flushPrelim` with a message
+  naming `PushType` — a function the caller may never have used. Each staging
+  entry point now tracks the container a detached handle is staged on and
+  rejects a spoken-for handle at the call site, naming the entry point
+  actually invoked. Removing a staged handle (map overwrite, `YMap.Delete`,
+  staged `YArray.Delete`) releases it for restaging — moving a staged type by
+  deleting it first remains legal, and same-key overwrite with the same
+  handle stays a no-op. Pre-existing since the prelim constructors (v1.43.0),
+  narrowed but not closed by v1.46.0's same-array guard (#222).
+
 ## [1.47.0] — 2026-08-09
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+## v1.47.1
+
+**Who is affected:** anyone building nested documents with the prelim
+constructors (`NewMapPrelim`/`NewArrayPrelim`/`NewTextPrelim`, v1.43.0) —
+specifically code that, by bug or by design, hands one detached handle to two
+containers.
+
+**The fix.** A shared type attaches once, but the staging entry points only
+enforced that against *attached* handles and (since v1.46.0) duplicates on
+the *same array*. Staging one handle onto two different containers — two
+detached arrays, a detached array and a detached map, or two keys of one
+detached map — succeeded at both calls, and the mistake only surfaced when
+the second container attached: a panic from inside `flushPrelim` complaining
+that `PushType` requires a detached type, pointing at a function the caller
+may never have used, with no hint which container double-staged the handle.
+
+`PushType`, `InsertType`, and `YMap.Set` now track where a detached handle is
+staged and reject a spoken-for handle **at the call site**, naming the entry
+point you actually called. The claim is released when the handle leaves its
+container — overwriting the staged key, `YMap.Delete`, or a staged
+`YArray.Delete` — so the legitimate "move it" flow (delete there, stage here)
+works, and overwriting a staged key with the same handle remains the
+documented no-op.
+
+No API changes; misuse that previously failed late and confusingly now fails
+immediately and precisely (#222).
+
 ## v1.47.0
 
 ### Added: `ygo-server` flags for periodic version capture and retention (#167)

--- a/crdt/abstract_type.go
+++ b/crdt/abstract_type.go
@@ -43,6 +43,19 @@ type abstractType struct {
 	item    *Item            // the Item containing this type when nested
 	owner   sharedType       // back-pointer to the concrete wrapper
 	name    string           // root type name; used during V1 update encoding
+
+	// stagedOn is the container whose staged (prelim) content currently holds
+	// this DETACHED type, nil otherwise. It exists so the staging entry points
+	// (PushType/InsertType/YMap.Set) can reject a handle that is already
+	// staged on a DIFFERENT container at the call site (#222) — without it,
+	// both stagings succeeded and the loser's attach later panicked inside
+	// flushPrelim, blaming a function the caller never used. Set when a handle
+	// enters a container's staged content, cleared when it leaves it (map
+	// overwrite/Delete, staged array Delete) or when its own container's flush
+	// re-enters the entry point to integrate it (claimForAttach). A handle
+	// released this way is legitimately re-stageable — this is deliberately an
+	// owner pointer, not a sticky bit.
+	stagedOn *abstractType
 	// deepSubIDGen issues unique IDs for ObserveDeep subscriptions so that
 	// out-of-order unsubscription removes the correct entry (C5).
 	deepSubIDGen  uint64

--- a/crdt/cross_stage_test.go
+++ b/crdt/cross_stage_test.go
@@ -1,0 +1,198 @@
+package crdt
+
+import (
+	"strings"
+	"testing"
+)
+
+// #222: staging one detached handle onto two DIFFERENT containers must fail at
+// the second staging call — not later, at attach, inside flushPrelim, with a
+// panic naming a function the caller never used. The same-container duplicate
+// is already rejected at the call (#213's rejectAlreadyStaged); these tests
+// close the cross-container half.
+
+// mustPanicContaining runs fn and requires it to panic with a message
+// containing want. It fails the test if fn returns normally.
+func mustPanicContaining(t *testing.T, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("want panic containing %q, got no panic", want)
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, want) {
+			t.Fatalf("want panic containing %q, got %v", want, r)
+		}
+	}()
+	fn()
+}
+
+// Staging the same detached handle onto two different DETACHED containers must
+// panic at the second call, naming the entry point actually used.
+func TestUnit_CrossStage_TwoDetachedContainers_PanicsAtSecondCall(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		wantFn  string
+		staleFn func(txn *Transaction, m *YMap) // first staging, container 1
+		dupFn   func(txn *Transaction, m *YMap) // second staging, container 2 — must panic
+	}{
+		{
+			"array PushType then array PushType",
+			"PushType",
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().PushType(txn, m) },
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().PushType(txn, m) },
+		},
+		{
+			"array PushType then array InsertType",
+			"InsertType",
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().PushType(txn, m) },
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().InsertType(txn, 0, m) },
+		},
+		{
+			"array PushType then map Set",
+			"Set",
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().PushType(txn, m) },
+			func(txn *Transaction, m *YMap) { NewMapPrelim().Set(txn, "k", m) },
+		},
+		{
+			"map Set then array PushType",
+			"PushType",
+			func(txn *Transaction, m *YMap) { NewMapPrelim().Set(txn, "k", m) },
+			func(txn *Transaction, m *YMap) { NewArrayPrelim().PushType(txn, m) },
+		},
+		{
+			"map Set then map Set",
+			"Set",
+			func(txn *Transaction, m *YMap) { NewMapPrelim().Set(txn, "k", m) },
+			func(txn *Transaction, m *YMap) { NewMapPrelim().Set(txn, "k", m) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := newTestDoc(1)
+			m := NewMapPrelim()
+			doc.Transact(func(txn *Transaction) {
+				tc.staleFn(txn, m)
+				mustPanicContaining(t, tc.wantFn, func() { tc.dupFn(txn, m) })
+			})
+		})
+	}
+}
+
+// Staging on a detached container and then handing the same handle to an
+// ATTACHED container must also panic at the call: the handle is still
+// detached (staged ≠ attached), so the pre-#222 entry-point check let it
+// integrate — and the detached container's later attach then blew up inside
+// flushPrelim blaming PushType.
+func TestUnit_CrossStage_StagedThenAttachedContainer_PanicsAtCall(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		wantFn string
+		dupFn  func(txn *Transaction, doc *Doc, m *YMap)
+	}{
+		{"attached PushType", "PushType",
+			func(txn *Transaction, doc *Doc, m *YMap) { txn.GetArray("b").PushType(txn, m) }},
+		{"attached InsertType", "InsertType",
+			func(txn *Transaction, doc *Doc, m *YMap) { txn.GetArray("b").InsertType(txn, 0, m) }},
+		{"attached map Set", "Set",
+			func(txn *Transaction, doc *Doc, m *YMap) { txn.GetMap("bm").Set(txn, "k", m) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := newTestDoc(1)
+			staging := NewArrayPrelim()
+			m := NewMapPrelim()
+			doc.Transact(func(txn *Transaction) {
+				staging.PushType(txn, m) // staged on a detached array
+				mustPanicContaining(t, tc.wantFn, func() { tc.dupFn(txn, doc, m) })
+			})
+		})
+	}
+}
+
+// One handle under two different KEYS of the same detached map is the same
+// attach-twice bug inside a single container, and must fail at the second Set.
+func TestUnit_CrossStage_SameMapTwoKeys_PanicsAtSecondSet(t *testing.T) {
+	doc := newTestDoc(1)
+	outer := NewMapPrelim()
+	inner := NewTextPrelim()
+	doc.Transact(func(txn *Transaction) {
+		outer.Set(txn, "a", inner)
+		mustPanicContaining(t, "Set", func() { outer.Set(txn, "b", inner) })
+	})
+}
+
+// Displacement releases the handle: a staged type removed from its container
+// (map overwrite, map delete, array delete) is legitimately re-stageable, and
+// the whole build must attach cleanly afterwards.
+func TestUnit_CrossStage_DisplacedHandleIsRestageable(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		displace func(txn *Transaction, arr *YArray, mp *YMap, h *YText)
+	}{
+		{"map overwrite", func(txn *Transaction, _ *YArray, mp *YMap, h *YText) {
+			mp.Set(txn, "k", h)
+			mp.Set(txn, "k", "plain instead")
+		}},
+		{"map delete", func(txn *Transaction, _ *YArray, mp *YMap, h *YText) {
+			mp.Set(txn, "k", h)
+			mp.Delete(txn, "k")
+		}},
+		{"array delete", func(txn *Transaction, arr *YArray, _ *YMap, h *YText) {
+			arr.Push(txn, []any{"x"})
+			arr.PushType(txn, h)
+			arr.Delete(txn, 1, 1)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := newTestDoc(1)
+			root := doc.GetMap("root")
+			arr := NewArrayPrelim()
+			mp := NewMapPrelim()
+			h := NewTextPrelim()
+
+			doc.Transact(func(txn *Transaction) {
+				tc.displace(txn, arr, mp, h)
+				h.Insert(txn, 0, "hello", nil)
+
+				// h left its first container, so a second container may take it.
+				dest := NewMapPrelim()
+				dest.Set(txn, "text", h)
+				root.Set(txn, "dest", dest)
+				root.Set(txn, "arr", arr)
+				root.Set(txn, "mp", mp)
+			})
+
+			dest, _ := root.Get("dest")
+			dm, ok := dest.(*YMap)
+			if !ok {
+				t.Fatalf("dest = %T, want *YMap", dest)
+			}
+			got, _ := dm.Get("text")
+			txt, ok := got.(*YText)
+			if !ok || txt.ToString() != "hello" {
+				t.Fatalf("dest.text = %v, want the re-staged YText reading %q", got, "hello")
+			}
+		})
+	}
+}
+
+// Overwriting a staged key with the SAME handle stays a no-op, and the map
+// still attaches with the handle in place — the release-on-overwrite path
+// must not release a handle that is being kept.
+func TestUnit_CrossStage_SameKeySameHandleOverwrite_Keeps(t *testing.T) {
+	doc := newTestDoc(1)
+	root := doc.GetMap("root")
+	mp := NewMapPrelim()
+	h := NewTextPrelim()
+	doc.Transact(func(txn *Transaction) {
+		mp.Set(txn, "k", h)
+		mp.Set(txn, "k", h) // same key, same handle: keep, not release-then-lose
+		h.Insert(txn, 0, "kept", nil)
+		root.Set(txn, "mp", mp)
+	})
+	got, _ := mp.Get("k")
+	txt, ok := got.(*YText)
+	if !ok || txt.ToString() != "kept" {
+		t.Fatalf("mp.k = %v, want the kept YText reading %q", got, "kept")
+	}
+}

--- a/crdt/prelim.go
+++ b/crdt/prelim.go
@@ -70,6 +70,10 @@ func NewArrayPrelim() *YArray {
 // nested type must occupy an item of its own, hence the separate entry point
 // (the same reason YXmlFragment exposes InsertElement/InsertText).
 //
+// A shared type attaches once: PushType panics if st is already attached,
+// already staged on this array, or staged on any other container (#222).
+// Deleting it from its staging container first makes it stageable again.
+//
 // Placement mirrors Push: anchor after the last PHYSICAL item, tombstones
 // included, matching Yjs's typeListPushGenerics.
 func (a *YArray) PushType(txn *Transaction, st sharedType) {
@@ -79,10 +83,12 @@ func (a *YArray) PushType(txn *Transaction, st sharedType) {
 	}
 	if a.detached() {
 		rejectAlreadyStaged(a.prelim, st, "PushType")
+		claimForStage(&a.abstractType, bt, "PushType")
 		a.prelim = append(a.prelim, st)
 		return
 	}
 	t := &a.abstractType
+	claimForAttach(t, bt, "PushType")
 
 	var last *Item
 	for it := t.start; it != nil; it = it.Right {
@@ -122,6 +128,41 @@ func rejectAlreadyStaged(prelim []any, st sharedType, fn string) {
 	}
 }
 
+// claimForStage records that bt is entering t's STAGED content, panicking if
+// it is already staged on a different container (#222) — the cross-container
+// counterpart of rejectAlreadyStaged, failing at the call site with the entry
+// point the caller actually used rather than later, at the losing container's
+// attach, inside flushPrelim.
+func claimForStage(t *abstractType, bt *abstractType, fn string) {
+	if bt.stagedOn != nil && bt.stagedOn != t {
+		panic("crdt: " + fn + ": this type is already staged on another container (a shared type attaches once; Delete it there first to move it)")
+	}
+	bt.stagedOn = t
+}
+
+// claimForAttach clears bt's staging claim as it is about to integrate under
+// t, panicking if that claim belongs to a DIFFERENT container (#222): a
+// staged handle is spoken for, and integrating it elsewhere would leave the
+// staging container to blow up at its own attach. The one legitimate holder
+// is t itself — a container's flushPrelim re-enters the entry points to
+// integrate its own staged children, so its claim admits and releases here.
+func claimForAttach(t *abstractType, bt *abstractType, fn string) {
+	if bt.stagedOn != nil && bt.stagedOn != t {
+		panic("crdt: " + fn + ": this type is staged on another container (a shared type attaches once; Delete it there first to move it)")
+	}
+	bt.stagedOn = nil
+}
+
+// releaseStaged drops v's staging claim if v is a shared-type handle leaving
+// a container's staged content (map overwrite or Delete, staged array
+// Delete). The handle becomes re-stageable — leaving a container is the one
+// legitimate way a staged type moves.
+func releaseStaged(v any) {
+	if st, ok := v.(sharedType); ok {
+		st.baseType().stagedOn = nil
+	}
+}
+
 // InsertType inserts a DETACHED shared type at logical position index
 // (0 = prepend, Len() = append), as its own nested item.
 //
@@ -130,6 +171,9 @@ func rejectAlreadyStaged(prelim []any, st sharedType, fn string) {
 // only way to place a nested type anywhere but the end is PushType followed by
 // Move — and Move emits ContentMove, a ygo extension other implementations
 // mis-parse, usually silently (#207).
+//
+// A shared type attaches once: InsertType panics if st is already attached,
+// already staged on this array, or staged on any other container (#222).
 //
 // Placement mirrors Insert: leftNeighbourAt uses LIVE-index semantics (it
 // skips tombstones), splitting the neighbour when the index falls inside it,
@@ -148,6 +192,7 @@ func (a *YArray) InsertType(txn *Transaction, index int, st sharedType) {
 		// around it at attach. Unresolvable indices anchor at the tail, the
 		// attached rule.
 		rejectAlreadyStaged(a.prelim, st, "InsertType")
+		claimForStage(&a.abstractType, bt, "InsertType")
 		if index < 0 || index > len(a.prelim) {
 			index = len(a.prelim)
 		}
@@ -155,6 +200,7 @@ func (a *YArray) InsertType(txn *Transaction, index int, st sharedType) {
 		return
 	}
 	t := &a.abstractType
+	claimForAttach(t, bt, "InsertType")
 	left, offset := t.leftNeighbourAt(index)
 	if offset > 0 {
 		splitItem(txn, left, offset)

--- a/crdt/prelim_test.go
+++ b/crdt/prelim_test.go
@@ -214,6 +214,11 @@ func TestDetachedReadsUnwrapStagedNestedTypes(t *testing.T) {
 	el := NewYXmlElement("div")
 	xtext := NewYXmlText()
 	arr := NewArrayPrelim()
+	// arrInner is a separate handle for the array read: this test originally
+	// staged `inner` on BOTH outer and arr, which is exactly the
+	// double-staging #222 now rejects at the call site (had both containers
+	// been attached, the second attach would have panicked in flushPrelim).
+	arrInner := NewMapPrelim()
 	doc.Transact(func(txn *Transaction) {
 		inner.Set(txn, "deep", "value")
 		list.Push(txn, []any{1.0, 2.0})
@@ -221,13 +226,14 @@ func TestDetachedReadsUnwrapStagedNestedTypes(t *testing.T) {
 		outer.Set(txn, "list", list)
 		outer.Set(txn, "el", el)
 		outer.Set(txn, "xtext", xtext)
-		arr.PushType(txn, inner)
+		arrInner.Set(txn, "deep", "value")
+		arr.PushType(txn, arrInner)
 	})
 
 	if got, ok := outer.Get("inner"); !ok || got != any(inner) {
 		t.Fatalf(`detached Get("inner") = %v, %v; want the staged *YMap handle`, got, ok)
 	}
-	if got := arr.Get(0); got != any(inner) {
+	if got := arr.Get(0); got != any(arrInner) {
 		t.Fatalf("detached array Get(0) = %v, want the staged *YMap handle", got)
 	}
 

--- a/crdt/yarray.go
+++ b/crdt/yarray.go
@@ -439,6 +439,11 @@ func (a *YArray) Delete(txn *Transaction, index, length int) {
 		if index+length > len(a.prelim) {
 			length = len(a.prelim) - index
 		}
+		// Deleted staged handles leave this array and become re-stageable
+		// (#222); their claims must not outlive their membership.
+		for _, v := range a.prelim[index : index+length] {
+			releaseStaged(v)
+		}
 		a.prelim = append(a.prelim[:index], a.prelim[index+length:]...)
 		return
 	}

--- a/crdt/ymap.go
+++ b/crdt/ymap.go
@@ -170,6 +170,12 @@ func extractMapValue(item *Item) any {
 
 // Set writes value under key. If a live entry already exists for key, it is
 // deleted and the new item becomes the winner.
+//
+// A DETACHED shared type passed as value is staged (or attached, if this map
+// is live) as a nested type. A shared type attaches once: Set panics if the
+// value is already attached, staged under another key of this map, or staged
+// on any other container (#222). Overwriting or deleting a staged entry
+// releases its handle, making it stageable elsewhere.
 func (m *YMap) Set(txn *Transaction, key string, value any) {
 	checkUTF8("YMap.Set", "key", key)
 	checkAnyUTF8("YMap.Set", "value", value)
@@ -179,14 +185,39 @@ func (m *YMap) Set(txn *Transaction, key string, value any) {
 	// Detached: stage the entry (see prelim). Re-setting a key overwrites in
 	// place and keeps its original position, as a JS Map does.
 	if t.detached() {
-		if _, exists := m.prelim[key]; !exists {
+		if st, ok := value.(sharedType); ok {
+			// A handle staged on ANOTHER container — or under another key of
+			// THIS map — is spoken for (#222): reject at the call rather than
+			// at the losing container's attach. Same key with the same handle
+			// stays the documented overwrite no-op.
+			for _, k := range m.prelimKeys {
+				if k != key && m.prelim[k] == value {
+					panic("crdt: Set: this type is already staged under another key of this map (a shared type attaches once)")
+				}
+			}
+			claimForStage(t, st.baseType(), "Set")
+		}
+		old, exists := m.prelim[key]
+		if !exists {
 			m.prelimKeys = append(m.prelimKeys, key)
+		}
+		if exists && old != value {
+			// Overwriting displaces the previous value: if it was a staged
+			// handle, it leaves this map and becomes re-stageable.
+			releaseStaged(old)
 		}
 		if m.prelim == nil {
 			m.prelim = make(map[string]any)
 		}
 		m.prelim[key] = value
 		return
+	}
+	if st, ok := value.(sharedType); ok {
+		// Attached path: a handle staged on a detached container must not
+		// integrate here (#222) — its staging container would panic at its own
+		// attach. The one legitimate claim is this map's own flushPrelim
+		// re-entering Set to integrate its staged children.
+		claimForAttach(t, st.baseType(), "Set")
 	}
 
 	// Establish a causal link from the previous value for this key so that
@@ -217,9 +248,13 @@ func (m *YMap) Delete(txn *Transaction, key string) {
 	// key and no tombstone reaches the wire. A later Set re-appends it at the
 	// end, as a JS Map does.
 	if t.detached() {
-		if _, exists := m.prelim[key]; !exists {
+		old, exists := m.prelim[key]
+		if !exists {
 			return
 		}
+		// A deleted staged handle leaves this map and becomes re-stageable
+		// (#222); its claim must not outlive its membership.
+		releaseStaged(old)
 		delete(m.prelim, key)
 		for i, k := range m.prelimKeys {
 			if k == key {


### PR DESCRIPTION
Closes #222, the follow-up filed from the #213 review. Targeted at **v1.47.1** (PATCH: no API changes; misuse that failed late and confusingly now fails immediately and precisely).

**The bug:** `PushType`/`InsertType`/`YMap.Set` accepted a detached handle that was already staged on a *different* container — two detached arrays, array + map, or two keys of one detached map. Both stagings succeeded; the losing container's attach then panicked inside `flushPrelim` with `"PushType requires a detached type"` — a function the caller may never have used, and no hint which container double-staged. v1.46.0's `rejectAlreadyStaged` closed only the same-array case.

**The fix:** the issue's suggested "staged somewhere" bit, refined to a **clearable owner pointer** (`abstractType.stagedOn`) after Phase-1 verification showed a sticky bit would wrongly reject legal flows — YMap staging has overwrite/delete semantics and staged arrays support `Delete`, all of which legitimately displace a handle. Wiring:
- **Staged branches** of `PushType`/`InsertType`/`Set` claim the handle for their container, panicking at the call site (naming the entry point actually invoked) if it is spoken for; `Set` additionally rejects the same handle under a second key of the same map, while same-key-same-handle overwrite stays the documented no-op.
- **Attached branches** claim-and-clear: the one legitimate existing claim is the container's own `flushPrelim` re-entering the entry point to integrate its staged children — so the flush cascade (nested prelims all the way down) needs zero changes and is covered by the existing prelim suite. A handle staged on A handed to an *attached* B also panics at the call now (previously it integrated, and A's attach blew up).
- **Displacement paths** (`Set` overwrite, `YMap.Delete`, staged `YArray.Delete`) release the claim, so "move it by deleting it first" remains legal.

**Testing (TDD, RED verified):** five cross-staging combinations across both detached containers, three staged-then-attached-container cases, the same-map-two-keys case — all watched failing before the fix — plus green-by-construction pins for the legal flows: displaced handles are re-stageable through all three displacement paths, and same-key overwrite keeps the handle. One pre-existing test (`TestDetachedReadsUnwrapStagedNestedTypes`, from #199) had itself staged one handle on two containers as a shortcut; it now uses a distinct handle per container — the behaviour this change makes mandatory.

`make test` and `make lint` clean; release docs under `[1.47.1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)