### PR TITLE
fix(websocket,client): append-then-compact MemoryPersistence (#186); shutdown drain durability (#229); client follow-ups (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,24 +78,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closing it. The worker's exit triggers are unchanged, so this cannot
   introduce the opposite failure — a shutdown that hangs waiting for a producer
   that never appears. **The guarantee is exactly: given that you stopped
-  accepting new connections first, then for every room that was present and had
-  finished loading when `Shutdown` began, any commit whose `Transact` returned
-  before `Shutdown` returned is durable.** Both qualifiers are real. `Shutdown`
-  snapshots the room set once and skips rooms still mid-load, and `ServeHTTP`
-  has no shutdown gate, so a connection accepted during `Shutdown` can create or
+  accepting new connections first, then — provided `Shutdown` returns
+  `nil` — for every room that was present and had finished loading when
+  `Shutdown` began, any commit whose `Transact` returned before `Shutdown`
+  returned has been handed to the adapter, and the adapter reported success.**
+  That is a completed, successful persistence attempt, not an unconditional
+  durability claim, and every qualifier in it is real. `Shutdown` snapshots
+  the room set once and skips rooms still mid-load, and `ServeHTTP` has no
+  shutdown gate, so a connection accepted during `Shutdown` can create or
   finish loading a room after that snapshot — one `Shutdown` never waits on
   (pre-existing; called out here because the sentence would otherwise read as
-  promising against it). And a commit that *begins* after `Shutdown` observes
-  its last in-flight write is not covered and cannot be — peer read loops and
-  `*crdt.Doc` holders are producers the server has no way to join. Three
-  consequences worth knowing rather than discovering: a
-  straggler write is synchronous for its committer and delays that update's
-  relay fan-out (the persistence observer is registered before the relay ones);
-  a caller that retains a `*crdt.Doc` past teardown now keeps writing for a
-  room the server considers gone, where those commits were previously dropped
-  silently; and both widen the window in which `Compact` can overlap a
-  `StoreUpdate` for the same room NAME, which `CompactableAdapter`'s godoc now
-  scopes explicitly (#229).
+  promising against it). A commit that *begins* after `Shutdown` observes its
+  last in-flight write is not covered and cannot be — peer read loops and
+  `*crdt.Doc` holders are producers the server has no way to join. Every wait
+  inside `Shutdown` is bounded by the caller's `ctx`, not by the work actually
+  finishing, so a non-nil return (e.g. `context.DeadlineExceeded`) means a
+  final flush or a stranded write may still have been in flight when the
+  deadline hit — it may still land, but `Shutdown` returning gives no way to
+  know. And even on a `nil` return, an adapter error or a recovered panic
+  while storing a commit is logged, not propagated through `Shutdown` — the
+  guarantee is only as strong as the adapter's own success report, not proof
+  that report was correct. Three consequences worth knowing rather than
+  discovering: a straggler write is synchronous for its committer and delays
+  that update's relay fan-out (the persistence observer is registered before
+  the relay ones); a caller that retains a `*crdt.Doc` past teardown now keeps
+  writing for a room the server considers gone, where those commits were
+  previously dropped silently; and both widen the window in which `Compact`
+  can overlap a `StoreUpdate` for the same room NAME, which
+  `CompactableAdapter`'s godoc now scopes explicitly (#229).
 - **`provider/websocket`: context-aware adapters lost the shutdown tail on
   the coalescing-disabled path.** That path handed the worker's
   **cancellable** ctx — the one a sibling goroutine cancels on `shutdownCh` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   producer two airtight cases and no third one: a send that completed while
   the latch was open is necessarily seen by the final drain, and otherwise
   the committing goroutine performs the write itself. The escape hatch that
-  used to drop the update now has a durable destination. `Shutdown` ordering
-  is deliberately unchanged, so this cannot introduce the opposite failure —
-  a shutdown that hangs waiting for a producer that never appears (#229).
+  used to drop the update now has a durable destination. `Shutdown` then joins
+  those committer-performed writes — bounded by the caller's ctx, placed after
+  the persistence join and before the relay wind-down so #202's ordering is
+  untouched — because otherwise the usual `srv.Shutdown(ctx)`-then-exit shape
+  would kill the process mid-write, narrowing the loss window rather than
+  closing it. The worker's exit triggers are unchanged, so this cannot
+  introduce the opposite failure — a shutdown that hangs waiting for a producer
+  that never appears. **The guarantee is exactly: any commit whose `Transact`
+  returned before `Shutdown` returned is durable.** A commit that *begins*
+  after `Shutdown` observes its last in-flight write is not covered and cannot
+  be — peer read loops and `*crdt.Doc` holders are producers the server has no
+  way to join. Three consequences worth knowing rather than discovering: a
+  straggler write is synchronous for its committer and delays that update's
+  relay fan-out (the persistence observer is registered before the relay ones);
+  a caller that retains a `*crdt.Doc` past teardown now keeps writing for a
+  room the server considers gone, where those commits were previously dropped
+  silently; and both widen the window in which `Compact` can overlap a
+  `StoreUpdate` for the same room NAME, which `CompactableAdapter`'s godoc now
+  scopes explicitly (#229).
 - **`provider/websocket`: context-aware adapters lost the shutdown tail on
   the coalescing-disabled path.** That path handed the worker's
   **cancellable** ctx — the one a sibling goroutine cancels on `shutdownCh` —
@@ -83,8 +99,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `context.Background()`, and a store aborted by cancellation is **retained**
   and re-stored on the exit path rather than dropped — the same
   retain-and-re-flush rule the coalescing path already applied to an
-  unflushed batch. Cancellation still unwedges a slow adapter mid-write; it
-  just no longer decides which committed transactions count (#229).
+  unflushed batch. Cancellation still aborts a write already in flight when
+  shutdown begins; it just no longer decides which committed transactions
+  count. Note the trade: because the final flush and the retained re-stores
+  run under `context.Background()`, an adapter that blocks indefinitely now
+  wedges that room's worker at exit, so `Shutdown` can return
+  `context.DeadlineExceeded` where it previously returned `nil` by discarding
+  the data (#229).
 
 ## [1.48.0] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   goroutine cancels concurrently, discarding a still-queued committed write
   with only a log line. Measured: 51-151 of 200 concurrent writes dropped
   across trials when this was tried during development, attributable to this
-  method. (A separate, pre-existing gap in the coalescing-disabled shutdown
+  method. (The separate, pre-existing gap in the coalescing-disabled shutdown
   drain — it drains its queue once and exits, regardless of adapter — also
-  drops writes under this same repro shape and was filed separately; it is
-  not what this method's removal fixes.)
+  drops writes under this same repro shape. It was filed as #229 and is fixed
+  in this same release, below; it is not what this method's removal fixes.)
 
 ### Fixed
 
@@ -55,6 +55,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LoadDoc` is no longer O(1) — it now folds whatever records the room still
   holds (bounded by `CompactEvery`) and persists that fold, so subsequent
   loads are cheap again (#186).
+- **`provider/websocket`: transactions committed during `Shutdown` were
+  silently dropped by the persistence worker.** The worker's shutdown exit
+  drained `r.persistCh` **once** and returned, but its producer —
+  `doc.OnUpdate` — watched only the room-teardown signal, never
+  `shutdownCh`. `Shutdown` closes `shutdownCh` as its first act and the peer
+  connections much later, so peer read loops kept committing for the whole
+  close-and-join window; everything they committed after that one-shot sweep
+  landed in the 256-slot buffer with no reader and was lost without even a
+  log line — while the package documented the opposite guarantee. Affected
+  the **default** configuration and every adapter. Same class as the
+  relay-side #202. The worker now publishes its retirement (a new
+  `room.persistRetire` latch) **before** its final drain, which gives the
+  producer two airtight cases and no third one: a send that completed while
+  the latch was open is necessarily seen by the final drain, and otherwise
+  the committing goroutine performs the write itself. The escape hatch that
+  used to drop the update now has a durable destination. `Shutdown` ordering
+  is deliberately unchanged, so this cannot introduce the opposite failure —
+  a shutdown that hangs waiting for a producer that never appears (#229).
+- **`provider/websocket`: context-aware adapters lost the shutdown tail on
+  the coalescing-disabled path.** That path handed the worker's
+  **cancellable** ctx — the one a sibling goroutine cancels on `shutdownCh` —
+  to its final drain, so any `PersistenceAdapterContext` implementation
+  (including `persistence/sqlite` via `NewLegacyAdapterContext`) returned
+  `ctx.Err()` and the write was discarded; measured at 51-151 of 200
+  concurrent writes dropped per trial. Both paths' final flushes now use
+  `context.Background()`, and a store aborted by cancellation is **retained**
+  and re-stored on the exit path rather than dropped — the same
+  retain-and-re-flush rule the coalescing path already applied to an
+  unflushed batch. Cancellation still unwedges a slow adapter mid-write; it
+  just no longer decides which committed transactions count (#229).
 
 ## [1.48.0] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`provider/websocket`: `MemoryPersistence.Compact`, `StoreUpdateContext`,
-  and a `CompactEvery` field.** `Compact(ctx, room)` folds a room's appended
-  update log into one blob on demand, satisfying the optional
-  `CompactableAdapter` interface so `Server.CompactEvery` and on-unload
-  compaction apply to this adapter too — additively, on top of the threshold
-  below. `StoreUpdateContext` is the context-aware `PersistenceAdapterContext`
-  variant, forwarded to the wrapped adapter so `Server.Shutdown` can abort an
-  in-flight write instead of blocking on it. `CompactEvery int` bounds how
+- **`provider/websocket`: `MemoryPersistence.Compact` and a `CompactEvery`
+  field.** `Compact(ctx, room)` folds a room's appended update log into one
+  blob on demand, satisfying the optional `CompactableAdapter` interface so
+  `Server.CompactEvery` and on-unload compaction apply to this adapter too —
+  additively, on top of the threshold below. `CompactEvery int` bounds how
   many appended updates a room accumulates before `MemoryPersistence` folds
   itself, independent of whether the caller ever sets `Server.CompactEvery`;
   0 or less means the default of 500, matching `provider/client`'s own
-  compaction default (#186).
+  compaction default. `MemoryPersistence` deliberately does **not** implement
+  `PersistenceAdapterContext`: an in-memory append has nothing to abort, and
+  implementing it anyway newly satisfies that interface, switching the
+  server's persistence worker onto its cancellable-ctx path — where the
+  coalescing-disabled path's final shutdown drain reuses a ctx a separate
+  goroutine cancels concurrently, discarding a still-queued committed write
+  with only a log line. Measured: 51-151 of 200 concurrent writes dropped
+  across trials when this was tried during development; 0 dropped once it was
+  removed (#186).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would kill the process mid-write, narrowing the loss window rather than
   closing it. The worker's exit triggers are unchanged, so this cannot
   introduce the opposite failure — a shutdown that hangs waiting for a producer
-  that never appears. **The guarantee is exactly: any commit whose `Transact`
-  returned before `Shutdown` returned is durable.** A commit that *begins*
-  after `Shutdown` observes its last in-flight write is not covered and cannot
-  be — peer read loops and `*crdt.Doc` holders are producers the server has no
-  way to join. Three consequences worth knowing rather than discovering: a
+  that never appears. **The guarantee is exactly: given that you stopped
+  accepting new connections first, then for every room that was present and had
+  finished loading when `Shutdown` began, any commit whose `Transact` returned
+  before `Shutdown` returned is durable.** Both qualifiers are real. `Shutdown`
+  snapshots the room set once and skips rooms still mid-load, and `ServeHTTP`
+  has no shutdown gate, so a connection accepted during `Shutdown` can create or
+  finish loading a room after that snapshot — one `Shutdown` never waits on
+  (pre-existing; called out here because the sentence would otherwise read as
+  promising against it). And a commit that *begins* after `Shutdown` observes
+  its last in-flight write is not covered and cannot be — peer read loops and
+  `*crdt.Doc` holders are producers the server has no way to join. Three
+  consequences worth knowing rather than discovering: a
   straggler write is synchronous for its committer and delays that update's
   relay fan-out (the persistence observer is registered before the relay ones);
   a caller that retains a `*crdt.Doc` past teardown now keeps writing for a
@@ -105,7 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run under `context.Background()`, an adapter that blocks indefinitely now
   wedges that room's worker at exit, so `Shutdown` can return
   `context.DeadlineExceeded` where it previously returned `nil` by discarding
-  the data (#229).
+  the data. A second, unrelated cause of the same error: `Shutdown`'s wait
+  covers every committing goroutine, so a sustained writer on a retained
+  `*crdt.Doc` can hold it above zero until the deadline expires with no wedged
+  adapter anywhere (#229).
 
 ## [1.48.0] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covers every committing goroutine, so a sustained writer on a retained
   `*crdt.Doc` can hold it above zero until the deadline expires with no wedged
   adapter anywhere (#229).
+- **`provider/client`: three follow-ups from the #165 review rounds
+  (#228).** `Client.Close`, called a second time, always returned `nil`
+  regardless of what the owned store's `Close` actually returned on the
+  first call — `closeErr` was a variable local to `Close`, re-declared fresh
+  (and never touched, since `closeOnce.Do` is a no-op on a repeat call) on
+  every call after the first. It is now cached on the `Client` and returned
+  consistently by every call. `Client.maybeCompact` could lose a concurrent
+  `storeWrites` increment: it read the counter via `Load()` and then reset
+  it unconditionally via `Store(0)`, discarding any `Add(1)` that landed in
+  between (from a concurrent local edit's `onDocUpdate`, incrementing from
+  either the caller's own goroutine or the loop goroutine). It now consumes
+  exactly its threshold via `Add(-threshold)`, which cannot lose a
+  concurrent increment either side of it — impact was compaction cadence
+  drift, never lost data. And `Close`'s teardown closed the WebSocket
+  connection without ever sending a close frame, so the server logged an
+  abnormal closure (1006) for every ordinary, on-purpose disconnect; it now
+  sends `WriteControl(CloseMessage, CloseNormalClosure)` before
+  `conn.Close()`, mirroring every other control frame this package already
+  sends.
 
 ## [1.48.0] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,24 +81,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepting new connections first, then — provided `Shutdown` returns
   `nil` — for every room that was present and had finished loading when
   `Shutdown` began, any commit whose `Transact` returned before `Shutdown`
-  returned has been handed to the adapter, and the adapter reported success.**
-  That is a completed, successful persistence attempt, not an unconditional
-  durability claim, and every qualifier in it is real. `Shutdown` snapshots
-  the room set once and skips rooms still mid-load, and `ServeHTTP` has no
-  shutdown gate, so a connection accepted during `Shutdown` can create or
-  finish loading a room after that snapshot — one `Shutdown` never waits on
-  (pre-existing; called out here because the sentence would otherwise read as
-  promising against it). A commit that *begins* after `Shutdown` observes its
-  last in-flight write is not covered and cannot be — peer read loops and
-  `*crdt.Doc` holders are producers the server has no way to join. Every wait
-  inside `Shutdown` is bounded by the caller's `ctx`, not by the work actually
-  finishing, so a non-nil return (e.g. `context.DeadlineExceeded`) means a
-  final flush or a stranded write may still have been in flight when the
-  deadline hit — it may still land, but `Shutdown` returning gives no way to
-  know. And even on a `nil` return, an adapter error or a recovered panic
-  while storing a commit is logged, not propagated through `Shutdown` — the
-  guarantee is only as strong as the adapter's own success report, not proof
-  that report was correct. Three consequences worth knowing rather than
+  returned has been handed to the adapter: the write attempt completed and
+  was not abandoned mid-flight.** Whether the adapter *accepted* that write
+  is a separate question this does not answer, and every qualifier here is
+  real. `Shutdown` snapshots the room set once and skips rooms still
+  mid-load, and `ServeHTTP` has no shutdown gate, so a connection accepted
+  during `Shutdown` can create or finish loading a room after that snapshot
+  — one `Shutdown` never waits on (pre-existing; called out here because the
+  sentence would otherwise read as promising against it). A commit that
+  *begins* after `Shutdown` observes its last in-flight write is not covered
+  and cannot be — peer read loops and `*crdt.Doc` holders are producers the
+  server has no way to join. Every wait inside `Shutdown` is bounded by the
+  caller's `ctx`, not by the work actually finishing, so a non-nil return
+  (e.g. `context.DeadlineExceeded`) means even the weaker "handed to the
+  adapter" claim does not hold — a final flush or a stranded write may still
+  have been in flight when the deadline hit. And even on a `nil` return, an
+  adapter error or a recovered panic while storing a commit is logged, not
+  propagated through `Shutdown` — so a `nil` return tells you the write
+  attempt completed without being abandoned, never that the adapter accepted
+  it; a caller who needs that stronger property has to get it from the
+  adapter itself. Three consequences worth knowing rather than
   discovering: a straggler write is synchronous for its committer and delays
   that update's relay fan-out (the persistence observer is registered before
   the relay ones); a caller that retains a `*crdt.Doc` past teardown now keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.49.0] — 2026-08-10
+## [1.49.0] — 2026-08-21
 
 ### Added
 
@@ -147,6 +147,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sends `WriteControl(CloseMessage, CloseNormalClosure)` before
   `conn.Close()`, mirroring every other control frame this package already
   sends.
+
+### Documentation
+
+- **`docs/ARCHITECTURE.md`: package dependency graph redrawn.** It listed
+  only `provider/{websocket,http}` and omitted five packages shipped between
+  v1.19 and v1.48 — `persistence/`, `cluster/`, `mobile/`,
+  `provider/webhook`, and `provider/client`. Every arrow in the new graph was
+  verified against real imports with `go list` across 14 packages, including
+  the non-obvious one: `awareness/` does **not** import `crdt/`.
+- **`docs/ARCHITECTURE.md`: the "Garbage collection" section documented an
+  API that does not exist.** It told readers to write `doc.GC = true` /
+  `doc.GC = false`; `Doc` has no exported `GC` field, and the flag is set at
+  construction with `crdt.New(crdt.WithGC(false))`. The section also
+  described only the automatic per-transaction pass, omitting two behaviours
+  shipped since: automatic collection is **suspended while any `UndoManager`
+  is registered** (undo re-inserts a copy of the deleted content, so that
+  content must still be present), and `crdt.RunGC` performs tombstone
+  reclamation (#166) — replacing deleted content with `ContentDeleted`
+  tombstones and then merging adjacent tombstones from the same client into
+  single nodes. Its destructive effect on `RestoreDocument` is now stated.
+- **`docs/ARCHITECTURE.md`: "Compatibility testing" described only the
+  fixture layer.** The randomised layer under `testutil/fuzz/` was missing
+  entirely, including `TestFuzzConvergenceMoves` — the oracle that caught the
+  `YArray.Move` divergence fixed in v1.40.0. All four oracles are now listed
+  with what each one proves, which need node, and how to reproduce a failing
+  seed.
+- **`mobile`: the package doc understated the bound surface.** It named only
+  `*Doc` and `*Awareness` as bound pointers, omitting `*SyncClient` and
+  `*Subscription`, and claimed the package never exposes callbacks — it
+  exposes three observer *interfaces* (`DocObserver`, `AwarenessObserver`,
+  `SyncStatusObserver`), which is the only callback form `gomobile bind`
+  supports in that direction. The claim is now precise (no Go **func
+  values**), and `docs/ARCHITECTURE.md`'s `mobile/` section says the same.
 
 ## [1.48.0] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coalescing-disabled path's final shutdown drain reuses a ctx a separate
   goroutine cancels concurrently, discarding a still-queued committed write
   with only a log line. Measured: 51-151 of 200 concurrent writes dropped
-  across trials when this was tried during development; 0 dropped once it was
-  removed (#186).
+  across trials when this was tried during development, attributable to this
+  method. (A separate, pre-existing gap in the coalescing-disabled shutdown
+  drain — it drains its queue once and exits, regardless of adapter — also
+  drops writes under this same repro shape and was filed separately; it is
+  not what this method's removal fixes.)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.49.0] — 2026-08-10
+
+### Added
+
+- **`provider/websocket`: `MemoryPersistence.Compact`, `StoreUpdateContext`,
+  and a `CompactEvery` field.** `Compact(ctx, room)` folds a room's appended
+  update log into one blob on demand, satisfying the optional
+  `CompactableAdapter` interface so `Server.CompactEvery` and on-unload
+  compaction apply to this adapter too — additively, on top of the threshold
+  below. `StoreUpdateContext` is the context-aware `PersistenceAdapterContext`
+  variant, forwarded to the wrapped adapter so `Server.Shutdown` can abort an
+  in-flight write instead of blocking on it. `CompactEvery int` bounds how
+  many appended updates a room accumulates before `MemoryPersistence` folds
+  itself, independent of whether the caller ever sets `Server.CompactEvery`;
+  0 or less means the default of 500, matching `provider/client`'s own
+  compaction default (#186).
+
+### Fixed
+
+- **`provider/websocket`: `MemoryPersistence.StoreUpdate` re-merged the whole
+  document on every write.** Each call ran
+  `crdt.MergeUpdatesV1(existing, update)` against the room's full accumulated
+  state, so one incremental write cost O(document) and a session of N writes
+  cost O(document²) overall — exactly the shape `PersistenceAdapter`'s own doc
+  warns adapters against. `MemoryPersistence` now delegates to
+  `persistence.MemoryPersistence` + `persistence.LegacyAdapter`
+  (`KeepVersions = 1`): each write **appends** the update (O(update)), and the
+  room folds its own backlog into one blob every `CompactEvery` writes, so the
+  O(document) cost is paid once per `CompactEvery` writes rather than on every
+  one. Measured per-write cost, old merge-on-write vs. new
+  append-then-compact: ~9.6× faster at 100 updates already in the room
+  (13,975ns → 1,457ns), ~77.7× at 1,000 (132,871ns → 1,710ns), ~360× at 10,000
+  (1,676,329ns → 4,653ns). Read literally, #186's acceptance criterion ("flush
+  cost no longer grows with doc size") is **not fully met**: the growth
+  constant is divided by `CompactEvery` (500 by default), not eliminated —
+  per-write cost is still `append + O(document)/CompactEvery`, so it keeps
+  growing with document size, just far more slowly. Flat, constant-time
+  writes are not achievable for this storage model, since `LoadDoc` must
+  still return the room as one V1 blob. The trade this makes explicit:
+  `LoadDoc` is no longer O(1) — it now folds whatever records the room still
+  holds (bounded by `CompactEvery`) and persists that fold, so subsequent
+  loads are cheap again (#186).
+
 ## [1.48.0] — 2026-08-10
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -211,9 +211,11 @@ What is guaranteed is narrower, and every one of its qualifiers is real:
 > **Stop accepting new WebSocket connections before calling `Shutdown`.** Then,
 > provided `Shutdown` returns `nil`: for every room that was present and had
 > finished loading when `Shutdown` began, any commit whose `Transact` returned
-> before `Shutdown` returned has been handed to the adapter, and the adapter
-> reported success. That is a completed, successful persistence attempt — not
-> an unconditional durability claim.
+> before `Shutdown` returned has been handed to the adapter — the write
+> attempt completed and was not abandoned mid-flight. Whether the adapter
+> *accepted* it is a separate question this does not answer: adapter errors
+> and panics are logged, not propagated, so this is not an unconditional
+> durability claim.
 
 The precondition is not decoration. `Shutdown` snapshots the room set once and
 skips any room still mid-load at that instant, and `ServeHTTP` has no shutdown
@@ -228,13 +230,14 @@ Nor is "provided `Shutdown` returns `nil`" decoration. Every wait inside
 `Shutdown` is bounded by the caller's `ctx`, not by the work actually
 finishing — a deadline that fires mid-drain returns `ctx.Err()` while a final
 flush or a stranded write may still be in flight, landing or not with no way
-for the caller to tell. And "the adapter reported success" is exactly that,
-no more: an adapter error or a recovered panic while storing a commit is
-logged (see `persistStranded`'s and the persistence worker's own doc
-comments) and the write abandoned, not propagated through `Shutdown`'s return
-value. A `nil` `Shutdown` tells you every in-scope commit reached the adapter
-and the adapter did not report a problem — it cannot tell you the adapter's
-report was itself correct.
+for the caller to tell. And "handed to the adapter" is exactly that, no
+more: an adapter error or a recovered panic while storing a commit is logged
+(see `persistStranded`'s and the persistence worker's own doc comments) and
+the write abandoned right there, never propagated through `Shutdown`'s return
+value. A `nil` `Shutdown` tells you every in-scope commit's write attempt
+completed without being abandoned mid-flight — it cannot tell you the
+adapter accepted any of them. A caller who needs that stronger property has
+to get it from the adapter itself.
 
 **What this costs you.** A straggler write is synchronous for the goroutine
 that committed it and bypasses coalescing, auto-versioning, and compaction. It

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -179,6 +179,14 @@ case that previously returned `nil` by discarding your data. If you have a
 seeing `context.DeadlineExceeded` where you saw success before. That is the
 honest signal replacing a silent lie.
 
+There is a **second, unrelated cause** of that same error, so do not read it as
+"my adapter is wedged": `Shutdown`'s new wait counts *every* committing
+goroutine, not only the ones performing a write themselves. Code that holds a
+retained `*crdt.Doc` and commits in a tight loop keeps that count above zero for
+as long as it runs, so `Shutdown` burns its whole deadline with nothing stuck
+anywhere. Stop your writers, not just your connections, if you want `Shutdown`
+to return early.
+
 **`Shutdown` now joins the writes it can see.** A transaction committed during
 `Shutdown` may arrive too late for its room's worker, in which case the
 committing goroutine performs the adapter write itself. `Shutdown` waits for
@@ -191,8 +199,23 @@ cannot.** A transaction that *begins* committing after `Shutdown` has observed
 its last in-flight write is not covered. The producers are peer read loops and
 any code holding a `*crdt.Doc`; the server has no way to join them, and
 inventing one would risk a `Shutdown` that never returns — a worse failure than
-the one being fixed. What is now guaranteed is narrower and checkable: **any
-commit whose `Transact` returned before `Shutdown` returned is durable.**
+the one being fixed.
+
+What is guaranteed is narrower, and both of its qualifiers are real:
+
+> **Stop accepting new WebSocket connections before calling `Shutdown`.** Then,
+> for every room that was present and had finished loading when `Shutdown`
+> began, any commit whose `Transact` returned before `Shutdown` returned is
+> durable.
+
+The precondition is not decoration. `Shutdown` snapshots the room set once and
+skips any room still mid-load at that instant, and `ServeHTTP` has no shutdown
+gate — so a connection accepted while `Shutdown` runs can create a room, or
+finish loading one, after the snapshot, and `Shutdown` never waits on that
+room's persistence worker. A commit into it can return from `Transact` with the
+update merely buffered, and `Shutdown(ctx)`-then-exit kills the drain. That
+behaviour predates v1.49.0; it is called out here because everything above
+would otherwise read as promising against it.
 
 **What this costs you.** A straggler write is synchronous for the goroutine
 that committed it and bypasses coalescing, auto-versioning, and compaction. It

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -301,6 +301,46 @@ a backpressured-but-alive peer could otherwise have added up to 10 seconds
 to `Close`'s return latency, right where the design intent for this
 teardown path was already 2 seconds.
 
+### Documentation drift, fixed alongside
+
+`docs/ARCHITECTURE.md`'s package dependency graph had not been redrawn since
+v1.19: it showed only `provider/{websocket,http}` and omitted five packages
+shipped since — `persistence/`, `cluster/`, `mobile/`, `provider/webhook`,
+and `provider/client`. Every arrow in the replacement was verified against
+real imports with `go list` across 14 packages, which confirmed one arrow
+most readers would draw wrong: `awareness/` does **not** import `crdt/`.
+
+Three further drifts were found while auditing the rest of that file, and are
+fixed here rather than filed:
+
+- **"Garbage collection" documented an API that does not exist.** It told you
+  to write `doc.GC = true` / `doc.GC = false`. `Doc` has no exported `GC`
+  field — the flag is set at construction, `crdt.New(crdt.WithGC(false))`.
+  Code copied from that section would not have compiled.
+- **The same section described only half the behaviour.** Automatic
+  collection is **suspended for as long as any `UndoManager` is registered**
+  (undoing a deletion re-inserts a copy of the deleted content, so that
+  content has to still be there) — worth knowing, because it means a
+  long-lived undo manager keeps deleted content alive. And `crdt.RunGC` does
+  tombstone reclamation (#166): it replaces deleted content with
+  `ContentDeleted` tombstones and then merges adjacent tombstones from the
+  same client into single nodes. It stays available as the manual entry point
+  when auto-GC is suspended, and it is destructive with respect to
+  `RestoreDocument` — take snapshots first.
+- **"Compatibility testing" described only the Yjs fixture layer**, omitting
+  the randomised layer under `testutil/fuzz/` entirely — including
+  `TestFuzzConvergenceMoves`, the oracle that found the `YArray.Move`
+  divergence fixed in v1.40.0. All four oracles are now listed with what each
+  proves, which require node, and how to replay a failing seed.
+
+Finally, `mobile`'s package doc understated its own bound surface: it named
+only `*Doc` and `*Awareness`, omitting `*SyncClient` and `*Subscription`, and
+said the package never exposes callbacks. It exposes three observer
+*interfaces* (`DocObserver`, `AwarenessObserver`, `SyncStatusObserver`) —
+the only callback form `gomobile bind` supports in that direction. The claim
+now says what it meant (no Go **func values**) and points at the threading
+rules each observer imposes.
+
 ## v1.48.0
 
 **Who is affected:** anyone building a Go client — or, via `mobile.SyncClient`,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ at all, and nothing under `provider/`, `cmd/`, or `examples/` constructs
 `MemoryPersistence` outside its own tests; you have to opt into it via
 `NewServerWithPersistence`. If that's not you, this release changes nothing
 you use. **What you must do:** nothing — this is a drop-in fix, same
-constructor, same behaviour from the outside, just cheaper.
+constructor — cheaper on the write path, see the trade below.
 
 ### Fixed: `MemoryPersistence` re-merged the whole document on every write (#186)
 
@@ -70,7 +70,7 @@ you read #186 directly:**
    `provider/websocket`, which measures the type and path #186 is actually
    about — the numbers above come from it.
 
-### Added: `Compact`, `StoreUpdateContext`, `CompactEvery` (#186)
+### Added: `Compact`, `CompactEvery` (#186)
 
 New exported surface on `MemoryPersistence`, which is why this ships MINOR
 rather than PATCH even though it's a bug fix — nothing existing changes
@@ -81,11 +81,19 @@ behaviour or signature.
   interface, so `Server.CompactEvery` and the server's on-unload compaction
   work against `MemoryPersistence` too, additively on top of its own
   threshold.
-- **`StoreUpdateContext(ctx, room, update) error`** is the context-aware
-  `PersistenceAdapterContext` variant, forwarded to the wrapped adapter so
-  `Server.Shutdown` can abort an in-flight write rather than block on it.
 - **`CompactEvery int`** (field) sets the self-compaction threshold; 0 or
   less means the default of 500.
+
+**Deliberately not added:** `StoreUpdateContext`. An in-memory append has
+nothing to abort, so implementing the context-aware `PersistenceAdapterContext`
+variant would only cost writes — it would newly satisfy that interface and
+switch the server's persistence worker onto its cancellable-ctx path, where
+the coalescing-disabled path's final shutdown drain reuses a ctx a separate
+goroutine cancels concurrently with that same drain. A committed update still
+sitting in the queue when that race goes the wrong way is discarded with only
+a log line. Measured while this was still in the branch: 51-151 of 200
+concurrent writes dropped across 20 trials during a concurrent `Shutdown`; 0
+dropped once it was removed.
 
 ## v1.48.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,21 @@
 ## v1.49.0
 
-**Who is affected:** callers who explicitly construct
-`websocket.MemoryPersistence` (`websocket.NewMemoryPersistence()`) — **not**
-every deployment. A fresh `websocket.NewServer()` has no persistence adapter
-at all, and nothing under `provider/`, `cmd/`, or `examples/` constructs
-`MemoryPersistence` outside its own tests; you have to opt into it via
-`NewServerWithPersistence`. If that's not you, this release changes nothing
-you use. **What you must do:** nothing — this is a drop-in fix, same
-constructor — cheaper on the write path, see the trade below.
+**Who is affected:** two separate audiences, so read the one that is you.
+
+- **The `MemoryPersistence` performance fix (#186)** affects only callers who
+  explicitly construct `websocket.MemoryPersistence`
+  (`websocket.NewMemoryPersistence()`) — **not** every deployment. A fresh
+  `websocket.NewServer()` has no persistence adapter at all, and nothing under
+  `provider/`, `cmd/`, or `examples/` constructs `MemoryPersistence` outside
+  its own tests; you have to opt into it via `NewServerWithPersistence`.
+- **The shutdown durability fix (#229)** affects **anyone running
+  `provider/websocket` with any persistence adapter at all**, in the default
+  configuration. If you call `Server.Shutdown` on a server that has peers
+  connected, you were losing committed transactions.
+
+**What you must do:** nothing — both are drop-in fixes with unchanged
+constructors and signatures. The write path gets cheaper (see the trade
+below), and `Shutdown` gets more honest.
 
 ### Fixed: `MemoryPersistence` re-merged the whole document on every write (#186)
 
@@ -99,10 +107,80 @@ That figure is **not** a claim that removing it makes such a `Shutdown` race
 lossless. A separate, pre-existing gap in the coalescing-disabled shutdown
 drain — it drains its queue exactly once and exits, whatever the adapter —
 drops writes under this same repro shape regardless of which
-`PersistenceAdapter` is behind it, and remains open (filed separately, not
-part of this release). What this removal fixes is specifically the extra,
-compounding loss this method caused on top of that; it does not fix the
-pre-existing drain gap itself.
+`PersistenceAdapter` is behind it. What this removal fixes is specifically the
+extra, compounding loss this method caused on top of that. The underlying gap
+was filed as #229 and is fixed separately in this same release — next.
+
+### Fixed: transactions committed during `Shutdown` were silently dropped (#229)
+
+**This one affects everybody with persistence configured, in the default
+configuration**, and is unrelated to `MemoryPersistence`. It was found during
+the whole-branch review of #186 and verified as pre-existing against v1.48.0.
+
+**The bug.** Each room's persistence worker exited on `Server.Shutdown` by
+draining its 256-slot queue **once** and returning. Its producer — the
+`doc.OnUpdate` observer — watched only the room-teardown signal, never the
+server's shutdown signal. And `Shutdown` closes the shutdown signal as its
+*first* act but the peer connections much later, so peer read loops keep
+committing for the entire close-connections-and-join window. Every
+transaction committed after that one-shot sweep went into a buffer nobody was
+reading, and disappeared — no error, no counter, not even a log line. The
+package's own doc comment promised the opposite: *"draining any buffered
+updates before returning so that no committed transaction is silently lost."*
+
+This is the same shape as the relay-side [#202](https://github.com/reearth/ygo/issues/202)
+fixed in v1.46.0: `Shutdown` winding a consumer down while producers were
+still producing.
+
+**The fix — and why it is not the obvious one.** The tempting shape is to
+quiesce the producers first and let the worker exit once they are provably
+gone. We deliberately did not do that. Producers here are peer read loops with
+no join point, `ServeHTTP` handlers that can register mid-shutdown, and any
+caller holding a `*crdt.Doc`; "provably gone" is not provable, and a wrong
+guess there turns silent data loss into a **hung `Shutdown`** — a strictly
+worse failure. `Shutdown`'s ordering is therefore completely unchanged.
+
+Instead the handoff itself was made race-free. The worker now closes a new
+per-room retirement latch as the **first** act of every exit path — before its
+final drain, not after — which leaves the producer exactly two cases and no
+third:
+
+1. the send completed while the latch was open, so `close(latch)` and
+   therefore the final drain that follows it both happen after the send: the
+   drain is guaranteed to pick the update up;
+2. the latch is already closed, which a `select` on a closed channel always
+   observes with certainty: the committing goroutine performs the write
+   itself.
+
+The producer's escape hatch (needed so a full buffer can't wedge a committing
+transaction once the worker is gone) still exists — it now has a durable
+destination instead of the floor.
+
+**Also fixed, the second half of #229:** the coalescing-disabled path passed
+the worker's **cancellable** context — the one a sibling goroutine cancels on
+shutdown — to its final drain, so every `PersistenceAdapterContext`
+implementation (`persistence/sqlite` via `NewLegacyAdapterContext`, and any
+adapter that honours `ctx`) returned `ctx.Err()` and discarded the write.
+Measured at 51-151 of 200 concurrent writes dropped per trial. Both paths'
+final flushes now use `context.Background()`, and a store aborted by
+cancellation is **retained** and re-stored on the exit path rather than
+dropped — the same retain-and-re-flush rule the coalescing path already
+applied to an unflushed batch. Cancellation still aborts an in-flight write so
+a slow adapter cannot wedge `Shutdown`; it no longer decides which committed
+transactions count.
+
+**What this costs you.** A straggler write is synchronous for the goroutine
+that committed it and bypasses coalescing, auto-versioning, and compaction. It
+happens only during and after room retirement. An adapter must tolerate a
+`StoreUpdate` arriving late in, or just after, `Shutdown` — which the previous
+behaviour hid from you by throwing the data away.
+
+**Tested both directions**, because the failure mode of a bad fix here is a
+hang rather than a loss: a sequenced (not raced) regression test commits while
+the worker is parked immediately past its final drain and asserts the update
+reaches the adapter, with coalescing enabled *and* disabled; a second asserts
+`Shutdown` still returns promptly for rooms with no peers at all —
+idle-resident and `Apply`-created — where no producer will ever appear.
 
 ## v1.48.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,92 @@
+## v1.49.0
+
+**Who is affected:** callers who explicitly construct
+`websocket.MemoryPersistence` (`websocket.NewMemoryPersistence()`) — **not**
+every deployment. A fresh `websocket.NewServer()` has no persistence adapter
+at all, and nothing under `provider/`, `cmd/`, or `examples/` constructs
+`MemoryPersistence` outside its own tests; you have to opt into it via
+`NewServerWithPersistence`. If that's not you, this release changes nothing
+you use. **What you must do:** nothing — this is a drop-in fix, same
+constructor, same behaviour from the outside, just cheaper.
+
+### Fixed: `MemoryPersistence` re-merged the whole document on every write (#186)
+
+**The bug.** `MemoryPersistence.StoreUpdate` ran
+`crdt.MergeUpdatesV1(existing, update)` against the room's **entire**
+accumulated state on every incremental write — an O(document) cost per write,
+so a session of N updates cost O(document²) overall. `PersistenceAdapter`'s
+own doc warns adapters not to do exactly this; the built-in adapter was doing
+it.
+
+**The fix.** `MemoryPersistence` now delegates to `persistence.MemoryPersistence`
++ `persistence.LegacyAdapter` (`KeepVersions = 1`) instead of re-merging by
+hand: each write **appends** the update — O(update), not O(document) — and
+the room folds its own backlog into one blob every `CompactEvery` writes
+(new field, default 500, matching `provider/client`'s own compaction
+default). The O(document) fold still happens, but only once per
+`CompactEvery` writes instead of on every single one.
+
+**Measured**, old merge-on-write vs. new append-then-compact, timing a single
+`StoreUpdate` against a room already holding N updates:
+
+| Updates already in room | Before | After | Improvement |
+|---|---|---|---|
+| 100 | 13,975 ns/op | 1,457 ns/op | 9.6× |
+| 1,000 | 132,871 ns/op | 1,710 ns/op | 77.7× |
+| 10,000 | 1,676,329 ns/op | 4,653 ns/op | 360× |
+
+**Read the acceptance bar honestly, not generously.** #186 asked for "flush
+cost no longer grows with doc size." Taken literally, that is **not fully
+met**: per-write cost is now `append + O(document)/CompactEvery`, so it still
+grows with document size — the growth constant is divided by `CompactEvery`
+(500 by default), not eliminated. It *is* met in the sense that actually
+matters day to day: cost no longer grows **per write** in proportion to the
+document, because most writes are a cheap append and only one in
+`CompactEvery` pays the fold. Flat, constant-time writes aren't achievable
+for this storage model at all — `LoadDoc` has to keep returning the whole
+room as one V1 blob, so any bounded-record scheme must periodically fold the
+full document, and that fold is inherently O(document). See
+[docs/PERSISTENCE.md](docs/PERSISTENCE.md) for the same framing in the
+adapter's own docs.
+
+**The trade, stated plainly:** `LoadDoc` is no longer O(1). It now folds
+whatever records the room still holds — bounded by `CompactEvery` — and
+persists that fold, so subsequent loads are cheap again until the log builds
+back up. Writes are continuous and loads happen once per room residency, so
+this is the right direction to trade in, but it is not free.
+
+**Two corrections to the issue, verified against the code, worth knowing if
+you read #186 directly:**
+
+1. It calls `MemoryPersistence` "the default adapter." It is not.
+   `websocket.NewServer()` is documented as shipping with no persistence at
+   all, and the type is opt-in via `NewServerWithPersistence`.
+2. Its acceptance criterion points at a benchmark
+   (`BenchmarkMemoryPersistence_FlushVsDocSize` in `persistence/`) that
+   measures a **different type** (`persistence.MemoryPersistence`) on a
+   **different path** (`LoadDoc`, not `StoreUpdate`) than the one this issue
+   is actually about. This release adds
+   `BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize` in
+   `provider/websocket`, which measures the type and path #186 is actually
+   about — the numbers above come from it.
+
+### Added: `Compact`, `StoreUpdateContext`, `CompactEvery` (#186)
+
+New exported surface on `MemoryPersistence`, which is why this ships MINOR
+rather than PATCH even though it's a bug fix — nothing existing changes
+behaviour or signature.
+
+- **`Compact(ctx, room) error`** folds a room's appended records into one
+  now, on demand. It also satisfies the optional `CompactableAdapter`
+  interface, so `Server.CompactEvery` and the server's on-unload compaction
+  work against `MemoryPersistence` too, additively on top of its own
+  threshold.
+- **`StoreUpdateContext(ctx, room, update) error`** is the context-aware
+  `PersistenceAdapterContext` variant, forwarded to the wrapped adapter so
+  `Server.Shutdown` can abort an in-flight write rather than block on it.
+- **`CompactEvery int`** (field) sets the self-compaction threshold; 0 or
+  less means the default of 500.
+
 ## v1.48.0
 
 **Who is affected:** anyone building a Go client — or, via `mobile.SyncClient`,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -92,8 +92,17 @@ the coalescing-disabled path's final shutdown drain reuses a ctx a separate
 goroutine cancels concurrently with that same drain. A committed update still
 sitting in the queue when that race goes the wrong way is discarded with only
 a log line. Measured while this was still in the branch: 51-151 of 200
-concurrent writes dropped across 20 trials during a concurrent `Shutdown`; 0
-dropped once it was removed.
+concurrent writes dropped across 20 trials during a concurrent `Shutdown`,
+attributable to this method.
+
+That figure is **not** a claim that removing it makes such a `Shutdown` race
+lossless. A separate, pre-existing gap in the coalescing-disabled shutdown
+drain — it drains its queue exactly once and exits, whatever the adapter —
+drops writes under this same repro shape regardless of which
+`PersistenceAdapter` is behind it, and remains open (filed separately, not
+part of this release). What this removal fixes is specifically the extra,
+compounding loss this method caused on top of that; it does not fix the
+pre-existing drain gap itself.
 
 ## v1.48.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## v1.49.0
 
-**Who is affected:** two separate audiences, so read the one that is you.
+**Who is affected:** three separate audiences, so read the one that is you.
 
 - **The `MemoryPersistence` performance fix (#186)** affects only callers who
   explicitly construct `websocket.MemoryPersistence`
@@ -12,10 +12,15 @@
   `provider/websocket` with any persistence adapter at all**, in the default
   configuration. If you call `Server.Shutdown` on a server that has peers
   connected, you were losing committed transactions.
+- **The `provider/client` follow-ups (#228)** affect anyone using
+  `provider/client`, the embeddable sync client shipped in v1.48.0. One of
+  the three is directly visible on the *server* side too: every graceful
+  client disconnect was logging as an abnormal closure (code 1006).
 
-**What you must do:** nothing — both are drop-in fixes with unchanged
+**What you must do:** nothing — all three are drop-in fixes with unchanged
 constructors and signatures. The write path gets cheaper (see the trade
-below), and `Shutdown` gets more honest.
+below), `Shutdown` gets more honest, and `provider/client` disconnects now
+look like what they are.
 
 ### Fixed: `MemoryPersistence` re-merged the whole document on every write (#186)
 
@@ -234,6 +239,50 @@ parks the adapter inside the stranded write itself and asserts `Shutdown` has
 not returned, then that a wedged one still surfaces as the caller's deadline.
 Against them: `Shutdown` must still return promptly for rooms with no peers at
 all — idle-resident and `Apply`-created — where no producer will ever appear.
+
+### Fixed: `provider/client` follow-ups from the #165 review rounds (#228)
+
+**Who is affected:** anyone using `provider/client` (v1.48.0's embeddable
+sync client). Three independent, previously-deferred fixes, none touching a
+public signature — the most visible one is server-side: every graceful
+`provider/client` disconnect was logging as an abnormal closure (code 1006)
+on any server it talked to, ygo's own included.
+
+**`Client.Close`, called a second time, always returned `nil`.** `closeErr`
+was a variable local to `Close`, re-declared fresh on every call — including
+repeat calls, where `closeOnce.Do` is a no-op that never touches it — so the
+first call's real result (whatever the owned store's `Close` actually
+returned) was silently replaced by a fresh, untouched `nil` on every call
+after the first. It is now cached on the `Client` itself and returned
+consistently, first call or fifth.
+
+**`Client.maybeCompact` could lose a concurrent write count.** It read
+`storeWrites` via `Load` and then reset it unconditionally via `Store(0)`,
+discarding any `Add(1)` from a concurrent `onDocUpdate` — a local edit
+landing in that window, from either the caller's own goroutine or the loop
+goroutine — that happened to arrive between the two calls. It now consumes
+exactly its threshold via `Add(-threshold)`, which cannot lose a concurrent
+increment on either side of it. The impact was compaction cadence drift — a
+few extra updates before the next fold — never lost data.
+
+**`Close`'s teardown never sent a WebSocket close frame.** Tearing down via
+a bare `conn.Close()` tells the peer nothing: from `ReadMessage`'s point of
+view, a deliberate disconnect is indistinguishable from a crash or a severed
+network path, and ygo's own server (like most implementations of the
+ordinary WebSocket close handshake) logs that as an abnormal closure — on
+every ordinary disconnect, not only real failures. `runLoop`'s teardown now
+sends `WriteControl(CloseMessage, CloseNormalClosure)` before `conn.Close()`,
+the same thing a graceful `gorilla/websocket` client is documented to do,
+so the peer's read loop sees a proper close instead of a bare I/O error.
+Two things worth knowing precisely, not generously: that frame goes out on
+**every** exit from `runLoop`, including a rejected-auth or read-error exit,
+always carrying the same `CloseNormalClosure` code — so read it as "this
+client is done writing," not as a claim that the disconnect was clean. And
+the frame's own write is bounded by `closeDrainTimeout` (2s), not the
+10s handshake-path timeout the first version of this fix used by mistake —
+a backpressured-but-alive peer could otherwise have added up to 10 seconds
+to `Close`'s return latency, right where the design intent for this
+teardown path was already 2 seconds.
 
 ## v1.48.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -206,12 +206,14 @@ any code holding a `*crdt.Doc`; the server has no way to join them, and
 inventing one would risk a `Shutdown` that never returns — a worse failure than
 the one being fixed.
 
-What is guaranteed is narrower, and both of its qualifiers are real:
+What is guaranteed is narrower, and every one of its qualifiers is real:
 
 > **Stop accepting new WebSocket connections before calling `Shutdown`.** Then,
-> for every room that was present and had finished loading when `Shutdown`
-> began, any commit whose `Transact` returned before `Shutdown` returned is
-> durable.
+> provided `Shutdown` returns `nil`: for every room that was present and had
+> finished loading when `Shutdown` began, any commit whose `Transact` returned
+> before `Shutdown` returned has been handed to the adapter, and the adapter
+> reported success. That is a completed, successful persistence attempt — not
+> an unconditional durability claim.
 
 The precondition is not decoration. `Shutdown` snapshots the room set once and
 skips any room still mid-load at that instant, and `ServeHTTP` has no shutdown
@@ -221,6 +223,18 @@ room's persistence worker. A commit into it can return from `Transact` with the
 update merely buffered, and `Shutdown(ctx)`-then-exit kills the drain. That
 behaviour predates v1.49.0; it is called out here because everything above
 would otherwise read as promising against it.
+
+Nor is "provided `Shutdown` returns `nil`" decoration. Every wait inside
+`Shutdown` is bounded by the caller's `ctx`, not by the work actually
+finishing — a deadline that fires mid-drain returns `ctx.Err()` while a final
+flush or a stranded write may still be in flight, landing or not with no way
+for the caller to tell. And "the adapter reported success" is exactly that,
+no more: an adapter error or a recovered panic while storing a commit is
+logged (see `persistStranded`'s and the persistence worker's own doc
+comments) and the write abandoned, not propagated through `Shutdown`'s return
+value. A `nil` `Shutdown` tells you every in-scope commit reached the adapter
+and the adapter did not report a problem — it cannot tell you the adapter's
+report was itself correct.
 
 **What this costs you.** A straggler write is synchronous for the goroutine
 that committed it and bypasses coalescing, auto-versioning, and compaction. It

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -165,22 +165,52 @@ Measured at 51-151 of 200 concurrent writes dropped per trial. Both paths'
 final flushes now use `context.Background()`, and a store aborted by
 cancellation is **retained** and re-stored on the exit path rather than
 dropped — the same retain-and-re-flush rule the coalescing path already
-applied to an unflushed batch. Cancellation still aborts an in-flight write so
-a slow adapter cannot wedge `Shutdown`; it no longer decides which committed
+applied to an unflushed batch. Cancellation still aborts a write already in
+flight when shutdown begins, so it no longer decides which committed
 transactions count.
+
+**Read that last point precisely — it is a trade, not a free win.** Because the
+final flush and the retained re-stores now run under `context.Background()`, a
+`StoreUpdate` that never returns wedges that room's worker at exit where it
+used to be cancelled out of the way. `Shutdown` does not hang on it — every
+wait is bounded by the caller's context — but it now returns `ctx.Err()` in a
+case that previously returned `nil` by discarding your data. If you have a
+`Shutdown` deadline and an adapter that can block indefinitely, you may start
+seeing `context.DeadlineExceeded` where you saw success before. That is the
+honest signal replacing a silent lie.
+
+**`Shutdown` now joins the writes it can see.** A transaction committed during
+`Shutdown` may arrive too late for its room's worker, in which case the
+committing goroutine performs the adapter write itself. `Shutdown` waits for
+those to finish (bounded by your ctx) before returning — otherwise the fix
+would only narrow the loss window, since the usual `srv.Shutdown(ctx)` followed
+by returning from `main` would kill the process mid-write.
+
+**The residual, stated plainly: this does not make `Shutdown` lossless, and
+cannot.** A transaction that *begins* committing after `Shutdown` has observed
+its last in-flight write is not covered. The producers are peer read loops and
+any code holding a `*crdt.Doc`; the server has no way to join them, and
+inventing one would risk a `Shutdown` that never returns — a worse failure than
+the one being fixed. What is now guaranteed is narrower and checkable: **any
+commit whose `Transact` returned before `Shutdown` returned is durable.**
 
 **What this costs you.** A straggler write is synchronous for the goroutine
 that committed it and bypasses coalescing, auto-versioning, and compaction. It
-happens only during and after room retirement. An adapter must tolerate a
-`StoreUpdate` arriving late in, or just after, `Shutdown` — which the previous
-behaviour hid from you by throwing the data away.
+also delays that update's relay fan-out, since the persistence observer runs
+before the relay observers. And it writes for a room the server may already
+consider gone — including, if you retain a `*crdt.Doc` past teardown,
+indefinitely; before #229 those commits were silently dropped instead. Adapters
+whose `Compact` mutates state keyed by room name should serialise by name; see
+`CompactableAdapter`'s godoc and [docs/PERSISTENCE.md](docs/PERSISTENCE.md).
 
 **Tested both directions**, because the failure mode of a bad fix here is a
-hang rather than a loss: a sequenced (not raced) regression test commits while
-the worker is parked immediately past its final drain and asserts the update
-reaches the adapter, with coalescing enabled *and* disabled; a second asserts
-`Shutdown` still returns promptly for rooms with no peers at all —
-idle-resident and `Apply`-created — where no producer will ever appear.
+hang rather than a loss. Sequenced (not raced) regression tests commit while
+the worker is parked immediately past its final drain and assert the update
+reaches the adapter, with coalescing enabled *and* disabled; a second pair
+parks the adapter inside the stranded write itself and asserts `Shutdown` has
+not returned, then that a wedged one still surfaces as the caller's deadline.
+Against them: `Shutdown` must still return promptly for rooms with no peers at
+all — idle-resident and `Apply`-created — where no producer will ever appear.
 
 ## v1.48.0
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,8 +9,8 @@ provider/webhook                                        mobile/
        │                                                    │
        ▼                                                    ▼
 provider/websocket ────────────────────────────────── provider/client        provider/http
-       │                                                                            │
-       ├──────────────────┬───────────────┤                                         │
+       │                                                    │                       │
+       ├──────────────────┬───────────────┬─────────────────┤                       │
        ▼                  ▼               ▼                                         │
      sync/            cluster/       persistence/                                   │
        │                  │               │                                         │
@@ -25,6 +25,11 @@ provider/websocket ────────────────────�
   │                              ▼
   └─────────────────────────►encoding/
 ```
+
+The bus (`├──┬──┬──┤`) is fed from both provider entry points — `provider/websocket`'s
+trunk on the left, `provider/client`'s on the right — and forks into exactly
+three arrows, one per label (`sync/`, `cluster/`, `persistence/`); the bus's
+own width just spans from one trunk to the other, it is not a fourth branch.
 
 **Rule:** no upward imports. `encoding/` has zero runtime dependencies. `crdt/` depends only on `encoding/`. `sync/` depends on `crdt/` and `encoding/`; `persistence/` depends only on `crdt/`; `cluster/` depends on `awareness/` and `crdt/`. `awareness/` is the one exception to the otherwise-neat layering: it depends only on `encoding/`, not `crdt/`, despite sitting next to packages that do. `provider/websocket` and `provider/client` both import `sync/`, `awareness/`, `cluster/`, and `persistence/` directly; `provider/http` skips that whole tier and depends on `crdt/` directly. `provider/webhook` and `mobile/` sit one layer up, wrapping `provider/websocket` and `provider/client` respectively — but each also imports lower tiers directly for its own use: `provider/webhook` imports `crdt/`, and `mobile/` imports both `awareness/` and `crdt/`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,9 @@ The bus (`├──┬──┬──┤`) is fed from both provider entry point
 trunk on the left, `provider/client`'s on the right — and forks into exactly
 three arrows, one per label (`sync/`, `cluster/`, `persistence/`); the bus's
 own width just spans from one trunk to the other, it is not a fourth branch.
+The `┼` below `sync/` is a **crossing, not a junction**: the line running left
+through it is `awareness/`'s edge to `encoding/`, passing over `sync/`'s column
+on its way to the left rail. `awareness/` does not depend on `crdt/`.
 
 **Rule:** no upward imports. `encoding/` has zero runtime dependencies. `crdt/` depends only on `encoding/`. `sync/` depends on `crdt/` and `encoding/`; `persistence/` depends only on `crdt/`; `cluster/` depends on `awareness/` and `crdt/`. `awareness/` is the one exception to the otherwise-neat layering: it depends only on `encoding/`, not `crdt/`, despite sitting next to packages that do. `provider/websocket` and `provider/client` both import `sync/`, `awareness/`, `cluster/`, and `persistence/` directly; `provider/http` skips that whole tier and depends on `crdt/` directly. `provider/webhook` and `mobile/` sit one layer up, wrapping `provider/websocket` and `provider/client` respectively — but each also imports lower tiers directly for its own use: `provider/webhook` imports `crdt/`, and `mobile/` imports both `awareness/` and `crdt/`.
 
@@ -133,7 +136,7 @@ Lifecycle:
 
 ### Doc
 
-The root object. Holds the `StructStore`, named root types (`Share` map), `Subdocs` map, a `GC` flag, and observer subscriptions.
+The root object. Holds the `StructStore`, named root types (`Share` map), `Subdocs` map, an internal GC flag (set at construction with `crdt.WithGC`, not a settable field), and observer subscriptions.
 
 ---
 
@@ -234,7 +237,9 @@ The embeddable, offline-first counterpart to `provider/websocket`: a Go peer (no
 
 ## `mobile/` — Go Mobile bindings
 
-A `gomobile bind`-safe façade over `crdt/`, `awareness/`, and `provider/client`, for embedding ygo natively in iOS/Android apps with no JavaScript runtime and no CGo. Because `gomobile bind` only supports a restricted set of cross-language types, every exported method uses only `string`, `int64`, `bool`, `[]byte`, `error`, and the bound pointer types `*Doc`/`*Awareness`/`*SyncClient`; the package translates ygo's internal `uint64` IDs and maps at the boundary. `SyncClient` is the mobile-facing wrapper around `provider/client`'s dial/sync loop.
+A `gomobile bind`-safe façade over `crdt/`, `awareness/`, and `provider/client`, for embedding ygo natively in iOS/Android apps with no JavaScript runtime and no CGo. Because `gomobile bind` only supports a restricted set of cross-language types, every exported method uses only `string`, `int64`, `bool`, `[]byte`, `error`, and the bound pointer types `*Doc`/`*Awareness`/`*SyncClient`/`*Subscription`; the package translates ygo's internal `uint64` IDs and maps at the boundary. `SyncClient` is the mobile-facing wrapper around `provider/client`'s dial/sync loop.
+
+Callbacks cross the boundary as **interfaces** (`DocObserver`, `AwarenessObserver`, `SyncStatusObserver`) rather than as Go func values, which gomobile cannot bind in that direction — the platform implements the interface in Swift or Kotlin and passes it in. Each is delivered on a dedicated drain goroutine, never a lock-holding one and never the platform's UI thread, so observers must marshal to the main thread themselves; `SyncStatusObserver` exists specifically so a platform observer can call `SyncClient.Close` from inside a status callback, which is not safe against the raw `provider/client.Client`.
 
 ---
 
@@ -246,10 +251,29 @@ A `gomobile bind`-safe façade over `crdt/`, `awareness/`, and `provider/client`
 
 ## Garbage collection
 
-When `doc.GC = true` (default), deleted item content is freed at the end of each transaction. Set `doc.GC = false` to preserve full history for snapshots and undo/redo.
+GC is on by default and is configured at construction — `crdt.New(crdt.WithGC(false))` preserves full history for snapshots and undo/redo. There is no settable `GC` field on `Doc`.
+
+**Automatic.** With GC enabled, each transaction frees the content of the items it deleted, at commit, after observer deltas have been computed and before the document lock is released — so no goroutine ever observes a partially collected state. Auto-GC is **suspended while any `UndoManager` is registered**: undoing a deletion re-inserts a copy of the deleted item's content, which requires that content still to be present. Yjs solves this with a per-item keep flag; ygo takes the conservative position of disabling automatic collection entirely for the lifetime of the undo manager.
+
+**Manual — tombstone reclamation.** `crdt.RunGC(doc)` is the explicit entry point, and remains available when auto-GC is suspended. It does two passes: it replaces deleted item content with lightweight `ContentDeleted` tombstones, then **merges adjacent tombstones from the same client into single nodes**, compacting the linked list so future origin lookups traverse fewer items. Both the structural position information CRDT correctness depends on and the tombstone lengths survive; only the content is discarded. `RunGC` is a no-op when GC is disabled.
+
+Reclamation is destructive with respect to history: after `RunGC`, `RestoreDocument` can no longer reconstruct states that predate the collected deletions. Take any snapshots you need first.
 
 ---
 
 ## Compatibility testing
 
-`testutil/gen_fixtures.js` generates canonical `.bin` files from the JS Yjs reference implementation. These are committed to `testutil/fixtures/` and loaded by `TestCompat_*` tests, which assert exact document state and — for encoding tests — byte-for-byte output equality.
+Two layers, answering different questions.
+
+**Fixtures — do we agree with Yjs on known cases?** `testutil/gen_fixtures.js` generates canonical `.bin` files from the JS Yjs reference implementation. These are committed to `testutil/fixtures/` and loaded by `TestCompat_*` tests, which assert exact document state and — for encoding tests — byte-for-byte output equality.
+
+**Fuzzing — do we agree on cases nobody wrote down?** `testutil/fuzz/` generates randomised multi-peer scenarios (insert/delete/push/map/xml, optionally moves, across 3–5 peers with random sync order) and replays them through several oracles in `crdt/fuzz_test.go`:
+
+| Test | Oracle | Needs node |
+|---|---|---|
+| `TestFuzzConvergence` | all peers converge to the same state (Go vs Go) | no |
+| `TestFuzzConvergenceMoves` | same, with `YArray.Move` enabled | no |
+| `TestFuzzCrossImpl` | each scenario replayed against real Yjs; ygo must match it logically and round-trip its encoded update | yes |
+| `TestFuzzCorpus` | every frozen minimized reproducer under `testutil/fuzz/corpus` still converges | no |
+
+Moves are an ygo wire extension Yjs cannot decode, which is why they are validated by Go-internal convergence rather than against Yjs — and `TestFuzzConvergenceMoves` is what caught the `YArray.Move` divergence fixed in v1.40.0. `TestFuzzCrossImpl` skips when node/yjs is unavailable; set `YGO_REQUIRE_NODE=1` to make that a hard failure instead. The two convergence sweeps default to 1000 seeds each and honour `FUZZ_ITER` for a soak run (`TestFuzzCrossImpl` is fixed at 200 seeds); any failure prints the `FUZZ_SEED` that replays it through `TestFuzzSeed`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,20 +9,21 @@ provider/webhook                                        mobile/
        │                                                    │
        ▼                                                    ▼
 provider/websocket ────────────────────────────────── provider/client        provider/http
-       │                                                    │                       │
-       ├──────────────────┬───────────────┬─────────────────┤                       │
-       ▼                  ▼               ▼                 ▼                       │
+       │                                                                            │
+       ├──────────────────┬───────────────┤                                         │
+       ▼                  ▼               ▼                                         │
      sync/            cluster/       persistence/                                   │
-       │                  │                │                                        │
-       │                  ▼                │                                        │
-       │             awareness/            │                                        │
-       │                                    │                                        │
-       └────────────────────────┬───────────┘                                        │
-                                 ▼                                                    │
-                               crdt/ ◄──────────────────────────────────────────────────┘
-                                 │
-                                 ▼
-                             encoding/
+       │                  │               │                                         │
+       │                  ▼               │                                         │
+       │             awareness/           │                                         │
+  ┌────┼──────────────────┘               │                                         │
+  │    │                                  │                                         │
+  │    └─────────────────────────┬────────┘                                         │
+  │                              ▼                                                  │
+  │                            crdt/ ◄──────────────────────────────────────────────┘
+  │                              │
+  │                              ▼
+  └─────────────────────────►encoding/
 ```
 
 **Rule:** no upward imports. `encoding/` has zero runtime dependencies. `crdt/` depends only on `encoding/`. `sync/` depends on `crdt/` and `encoding/`; `persistence/` depends only on `crdt/`; `cluster/` depends on `awareness/` and `crdt/`. `awareness/` is the one exception to the otherwise-neat layering: it depends only on `encoding/`, not `crdt/`, despite sitting next to packages that do. `provider/websocket` and `provider/client` both import `sync/`, `awareness/`, `cluster/`, and `persistence/` directly; `provider/http` skips that whole tier and depends on `crdt/` directly. `provider/webhook` and `mobile/` sit one layer up, wrapping `provider/websocket` and `provider/client` respectively — but each also imports lower tiers directly for its own use: `provider/webhook` imports `crdt/`, and `mobile/` imports both `awareness/` and `crdt/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,16 +5,27 @@ ygo is a pure-Go implementation of the [Yjs](https://github.com/yjs/yjs) CRDT al
 ## Package dependency graph
 
 ```
-provider/{websocket,http}
-         │
-        sync/ ── awareness/
-         │
-        crdt/
-         │
-      encoding/
+provider/webhook                                        mobile/
+       │                                                    │
+       ▼                                                    ▼
+provider/websocket ────────────────────────────────── provider/client        provider/http
+       │                                                    │                       │
+       ├──────────────────┬───────────────┬─────────────────┤                       │
+       ▼                  ▼               ▼                 ▼                       │
+     sync/            cluster/       persistence/                                   │
+       │                  │                │                                        │
+       │                  ▼                │                                        │
+       │             awareness/            │                                        │
+       │                                    │                                        │
+       └────────────────────────┬───────────┘                                        │
+                                 ▼                                                    │
+                               crdt/ ◄──────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+                             encoding/
 ```
 
-**Rule:** no upward imports. `encoding/` has zero runtime dependencies. `crdt/` depends only on `encoding/`. `sync/` and `awareness/` depend on `crdt/` and `encoding/`. Providers depend on `sync/` and `awareness/`.
+**Rule:** no upward imports. `encoding/` has zero runtime dependencies. `crdt/` depends only on `encoding/`. `sync/` depends on `crdt/` and `encoding/`; `persistence/` depends only on `crdt/`; `cluster/` depends on `awareness/` and `crdt/`. `awareness/` is the one exception to the otherwise-neat layering: it depends only on `encoding/`, not `crdt/`, despite sitting next to packages that do. `provider/websocket` and `provider/client` both import `sync/`, `awareness/`, `cluster/`, and `persistence/` directly; `provider/http` skips that whole tier and depends on `crdt/` directly. `provider/webhook` and `mobile/` sit one layer up, wrapping `provider/websocket` and `provider/client` respectively — but each also imports lower tiers directly for its own use: `provider/webhook` imports `crdt/`, and `mobile/` imports both `awareness/` and `crdt/`.
 
 > **Note**: Since v1.0, the library has added several mechanisms not detailed here — the pending-structs queue for out-of-order delivery, structured logging via `slog`, per-peer broadcast queues, and context-aware methods. See [CHANGELOG.md](../CHANGELOG.md) for the per-release picture.
 
@@ -171,6 +182,18 @@ Separate from document updates. Stores `map[ClientID]AwarenessState{Clock uint64
 
 ---
 
+## `persistence/` — versioned storage layer
+
+Depends only on `crdt/`. Layers an **append-only, versioned** store on top of the provider's `LoadDoc`/`StoreUpdate` primitive: every incremental update becomes a numbered `Version`, `MaterializeAt(v)` rebuilds the document at any past version via `crdt.MergeUpdatesV1`, and named snapshots plus crash-safe pruning/compaction round out the log.
+
+Ships two reference implementations — `NewMemoryPersistence()` (in-process maps) and `NewFilePersistence(dir)` (atomic temp+rename writes to one directory per store) — plus `persistence/sqlite`, a pure-Go (CGo-free) SQLite backend. `LegacyAdapter` bridges a `VersionedPersistence` back to the provider's `PersistenceAdapter` shape without either package importing the other, avoiding a cycle. See [PERSISTENCE.md](PERSISTENCE.md) for the full interface and a conformance suite external adapters can run against.
+
+## `cluster/` — cross-node relay
+
+Depends on `awareness/` and `crdt/`. Defines the `Relay`/`Sink` abstraction that fans document updates **and** awareness out across multiple `provider/websocket` (or `provider/client`) processes sharing rooms, superseding the older persistence-adapter-as-pub/sub pattern. `MemRelay` is the in-process reference implementation, used by tests and single-process multi-server simulations; production deployments plug in `cluster/redis` or an equivalent backend. See [CLUSTERING.md](CLUSTERING.md).
+
+---
+
 ## `provider/` — transport handlers
 
 ### `provider/websocket/`
@@ -184,7 +207,7 @@ type PersistenceAdapter interface {
     StoreUpdate(room string, update []byte) error
 }
 ```
-Pass an implementation to `NewServerWithPersistence(p)`. The built-in `MemoryPersistence` (returned by `NewMemoryPersistence()`) merges updates in memory and is suitable for single-process deployments.
+Pass an implementation to `NewServerWithPersistence(p)`. The built-in `MemoryPersistence` (returned by `NewMemoryPersistence()`) appends updates in memory and periodically folds a room's backlog (`CompactEvery`, default 500) rather than re-merging on every write; suitable for single-process deployments.
 
 ### `provider/http/`
 
@@ -192,6 +215,20 @@ Pass an implementation to `NewServerWithPersistence(p)`. The built-in `MemoryPer
 |--------|------|-----------|
 | `GET` | `/doc/{room}?sv=<base64>` | Return binary update diff |
 | `POST` | `/doc/{room}` | Apply binary update from request body |
+
+### `provider/webhook/`
+
+Wraps a `provider/websocket` server with outbound HTTP callbacks — HMAC-SHA256-signed, debounced/coalesced, retried with backoff on transient failure — fired on room lifecycle and document-update events, so an external service can react to changes without holding a live connection.
+
+### `provider/client/`
+
+The embeddable, offline-first counterpart to `provider/websocket`: a Go peer (not a server) that hydrates a `*crdt.Doc` from local storage, lets the caller edit it immediately regardless of connectivity, and runs a background dial loop that reconciles with a `provider/websocket`-served (or Hocuspocus-compatible) endpoint whenever one is reachable. Speaks the same wire protocol `provider/websocket` serves. See [CLIENT.md](CLIENT.md).
+
+---
+
+## `mobile/` — Go Mobile bindings
+
+A `gomobile bind`-safe façade over `crdt/`, `awareness/`, and `provider/client`, for embedding ygo natively in iOS/Android apps with no JavaScript runtime and no CGo. Because `gomobile bind` only supports a restricted set of cross-language types, every exported method uses only `string`, `int64`, `bool`, `[]byte`, `error`, and the bound pointer types `*Doc`/`*Awareness`/`*SyncClient`; the package translates ygo's internal `uint64` IDs and maps at the boundary. `SyncClient` is the mobile-facing wrapper around `provider/client`'s dial/sync loop.
 
 ---
 

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -59,9 +59,17 @@ O(document²) over a session (#186).
 
 It bounds that append log itself: once a room accumulates `CompactEvery`
 writes (default 500, matching `provider/client`'s own compaction default) it
-folds the room's backlog into a single blob. `LoadDoc` also folds first, so a
-load always returns a coherent V1 snapshot regardless of where the room sits
-in its append cycle.
+folds the room's backlog into a single blob. `LoadDoc` also folds first —
+materialising the room's records is what makes a load coherent regardless of
+where the room sits in its append cycle; the fold only makes the *next* load
+cheap again, since a load always merges whatever records are present whether
+or not it folds first.
+
+One behaviour change worth knowing if you handle `LoadDoc`'s error: it could
+previously never return an error, and now can — an unmergeable append log
+surfaces at load time rather than at write time. `StoreUpdate`/`AppendUpdate`
+validate each update as it is written, so there is no practical way to reach
+this in normal operation, but the failure mode has moved.
 
 Measured per-write cost, old merge-on-write vs. append-then-compact, at three
 room sizes:

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -644,13 +644,15 @@ count. Since v1.49.0 (#229) that separation is enforced:
 > **Then, provided `Shutdown` returns `nil`:** for every room that was present
 > in the server and had finished loading when `Shutdown` began, any commit
 > whose `Transact` returned before `Shutdown` returned has been handed to the
-> adapter, and the adapter reported success. That is a completed, successful
-> persistence attempt — not an unconditional durability claim: a non-nil
-> return (for example `context.DeadlineExceeded`) means a final flush may
-> still have been in flight when `Shutdown` gave up on waiting for it, and
-> even on a `nil` return, an adapter error or panic encountered while storing
-> a commit is logged, not propagated — `Shutdown` has no way to see it or
-> report it.
+> adapter — the write attempt completed and was not abandoned mid-flight.
+> Whether the adapter *accepted* that write is a separate question this
+> guarantee does not answer: adapter errors and panics are logged, not
+> propagated, so a `nil` return does not mean every one of those writes
+> succeeded at the adapter, only that none of them were left in flight when
+> `Shutdown` returned. A non-nil return (for example
+> `context.DeadlineExceeded`) means even that weaker claim does not hold — a
+> final flush may still have been in flight when `Shutdown` gave up on
+> waiting for it.
 
 Every clause here is load-bearing.
 
@@ -674,15 +676,18 @@ actually resolved by the work completing rather than by the clock running out.
 See "What adapters must now tolerate" below for the two independent things
 that can produce that deadline error.
 
-**Why "the adapter reported success."** The observer that performs a commit's
-write — whether the room's normal persistence worker or, for a straggler, the
-committing goroutine itself via `persistStranded` — has no caller to report a
-failure to: an adapter error or a recovered panic is logged and the write is
-abandoned, not surfaced through `Shutdown`'s return value. A `nil` `Shutdown`
-therefore tells you every in-scope commit reached the adapter and the adapter
-did not report a problem; it cannot tell you the adapter's own report was
-correct, or that no adapter call failed silently underneath a logging call you
-weren't watching.
+**Why "handed to the adapter," not "the adapter accepted it."** The observer
+that performs a commit's write — whether the room's normal persistence worker
+or, for a straggler, the committing goroutine itself via `persistStranded` —
+has no caller to report a failure to: an adapter error or a recovered panic is
+logged and the write is abandoned right there, never surfaced through
+`Shutdown`'s return value (see `persistStranded`'s own doc: "Errors are
+logged, not returned"). That is exactly why the guarantee cannot say
+"succeeded" — a `nil` `Shutdown` return tells you every in-scope commit's
+write attempt completed without being abandoned mid-flight, and nothing about
+whether the adapter itself accepted it. A caller who needs that stronger
+property has to get it from the adapter directly: its own error/logging
+surface, or a read-back via `LoadDoc`/`Compact`.
 
 **Why the guarantee is still not losslessness.** **`Shutdown` is not lossless
 and cannot be made so.** A transaction that *begins* committing after `Shutdown`

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -52,12 +52,52 @@ http.Handle("/yjs/{room}", srv)
 
 ## Built-in: MemoryPersistence
 
-`MemoryPersistence` merges all incremental updates into a single V1 snapshot
-per room and stores it in process memory.  It is useful for tests and
-single-process deployments where durability across restarts is not required.
+`MemoryPersistence` stores room state in process memory. It **appends** each
+incremental update — an O(update) write — rather than re-merging the whole
+document on every call, which used to cost O(document) per write and
+O(document²) over a session (#186).
+
+It bounds that append log itself: once a room accumulates `CompactEvery`
+writes (default 500, matching `provider/client`'s own compaction default) it
+folds the room's backlog into a single blob. `LoadDoc` also folds first, so a
+load always returns a coherent V1 snapshot regardless of where the room sits
+in its append cycle.
+
+Measured per-write cost, old merge-on-write vs. append-then-compact, at three
+room sizes:
+
+| Updates already in room | Before | After | Improvement |
+|---|---|---|---|
+| 100 | 13,975 ns/op | 1,457 ns/op | 9.6× |
+| 1,000 | 132,871 ns/op | 1,710 ns/op | 77.7× |
+| 10,000 | 1,676,329 ns/op | 4,653 ns/op | 360× |
+
+The growth constant is divided by `CompactEvery`, **not eliminated**: per-write
+cost is still `append + O(document)/CompactEvery`, so it keeps growing with
+document size, just ~500× more slowly. Flat, constant-time writes are not
+achievable for this storage model — see the trade below.
+
+The trade this makes explicit: `LoadDoc` is no longer O(1). It folds whatever
+records the room still holds — bounded by `CompactEvery` — and persists that
+fold, so subsequent loads are cheap again until the log builds back up.
+Writes are continuous and loads happen once per room residency, so the
+direction is right, but folding is inherently O(document) — there is no way
+to keep returning one V1 blob from `LoadDoc` without periodically paying for
+it. This is still primarily for tests and single-process deployments; a
+multi-process deployment wants `persistence/sqlite` or another
+`VersionedPersistence`.
 
 ```go
 srv := websocket.NewServerWithPersistence(websocket.NewMemoryPersistence())
+```
+
+To change the compaction threshold, set `CompactEvery` on the adapter before
+serving:
+
+```go
+adapter := websocket.NewMemoryPersistence()
+adapter.CompactEvery = 2000 // fold less often; more memory, fewer folds
+srv := websocket.NewServerWithPersistence(adapter)
 ```
 
 ---

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -637,15 +637,32 @@ count. Since v1.49.0 (#229) that separation is enforced:
 
 ### The guarantee, stated exactly
 
-> Any commit whose `Transact` returned before `Shutdown` returned is durable.
+> **Precondition:** you have stopped accepting new WebSocket connections before
+> calling `Shutdown` (shut down your `http.Server`, or otherwise stop routing to
+> the handler).
+>
+> **Then:** for every room that was present in the server and had finished
+> loading when `Shutdown` began, any commit whose `Transact` returned before
+> `Shutdown` returned is durable.
 
-That is the whole of it. **`Shutdown` is not lossless and cannot be made so.** A
-transaction that *begins* committing after `Shutdown` has observed its last
-in-flight write is not covered: the producers are peer read loops and any code
-holding a `*crdt.Doc`, none of which the server can join, and inventing a join
-would risk a `Shutdown` that never returns — a worse failure than the one being
-fixed. Stop your traffic before calling `Shutdown` if you need more than the
-guarantee above.
+Both halves are load-bearing.
+
+**Why the precondition.** `Shutdown` snapshots the room set once, and skips any
+room still mid-load at that instant. `ServeHTTP` has no shutdown gate, so a
+connection accepted while `Shutdown` is running can create a room, or finish
+loading one, *after* that snapshot. `Shutdown` never waits on such a room's
+persistence worker, so a commit into it can return from `Transact` with the
+update merely buffered — and the usual `Shutdown(ctx); return` shape then kills
+the drain. This is not new in v1.49.0; what is new is that the rest of this
+section would otherwise read as promising against it. Stop accepting
+connections first and the room set cannot grow underneath `Shutdown`.
+
+**Why the second half is still not losslessness.** **`Shutdown` is not lossless
+and cannot be made so.** A transaction that *begins* committing after `Shutdown`
+has observed its last in-flight write is not covered: the producers are peer
+read loops and any code holding a `*crdt.Doc`, none of which the server can
+join, and inventing a join would risk a `Shutdown` that never returns — a worse
+failure than the one being fixed.
 
 ### What adapters must now tolerate
 
@@ -656,6 +673,13 @@ guarantee above.
   `context.DeadlineExceeded` where it previously returned `nil` — by discarding
   your data. The honest error replaces a silent lie, but it is a behaviour
   change if you have a `Shutdown` deadline.
+- **A second, unrelated cause of that same `DeadlineExceeded`:** a *sustained*
+  producer. `Shutdown` waits for the in-flight commit count to reach zero, and
+  that count covers every committing goroutine, not only the ones performing a
+  write themselves. Code that holds a retained `*crdt.Doc` and commits in a
+  tight loop can keep it above zero for as long as it runs, so `Shutdown` burns
+  its whole deadline with no wedged adapter anywhere. Stop your writers, not
+  just your connections, if you want `Shutdown` to return early.
 - **Writes for a room the server already considers gone.** Nothing calls
   `doc.Destroy` on teardown, so a caller that retains the `*crdt.Doc` (from
   `GetDoc`, or from an `OnLoadDocument` hook) keeps its persistence observer

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -609,7 +609,11 @@ func (p *PostgresAdapter) storeUpdate(ctx context.Context, room string, update [
 
 During `Server.Shutdown`, the in-flight `ExecContext` call sees the context cancellation and returns early instead of waiting for the database driver's default timeout.
 
-### Cancellation never costs you a committed transaction (v1.49.0+)
+This pattern mirrors `io.WriterTo`, `http.CloseNotifier`, and `database/sql/driver.QueryerContext` in the standard library — extension interfaces that callers can opt into without breaking older implementations.
+
+---
+
+## Shutdown durability, and what it does not promise (v1.49.0+)
 
 Cancellation exists to unwedge a slow adapter, not to decide which writes
 count. Since v1.49.0 (#229) that separation is enforced:
@@ -626,13 +630,46 @@ count. Since v1.49.0 (#229) that separation is enforced:
   adapter.** Peer read loops keep committing for the whole
   close-connections-and-join window, so the room's persistence worker publishes
   its retirement before its final drain; a commit that arrives too late for
-  that drain is written by the committing goroutine itself rather than being
-  parked in an unread buffer. Such a write is synchronous for that caller and
-  bypasses coalescing, auto-versioning, and compaction — it is a straggler
-  being made durable, not a new steady state.
+  that drain is written by the committing goroutine itself.
+- **`Shutdown` joins those writes** (bounded by the caller's context) before
+  returning, so `srv.Shutdown(ctx)` followed by exiting the process does not
+  kill a write in flight.
 
-An adapter must therefore still tolerate a `StoreUpdate` call arriving late in,
-or immediately after, `Shutdown`.
+### The guarantee, stated exactly
 
-This pattern mirrors `io.WriterTo`, `http.CloseNotifier`, and `database/sql/driver.QueryerContext` in the standard library — extension interfaces that callers can opt into without breaking older implementations.
-```
+> Any commit whose `Transact` returned before `Shutdown` returned is durable.
+
+That is the whole of it. **`Shutdown` is not lossless and cannot be made so.** A
+transaction that *begins* committing after `Shutdown` has observed its last
+in-flight write is not covered: the producers are peer read loops and any code
+holding a `*crdt.Doc`, none of which the server can join, and inventing a join
+would risk a `Shutdown` that never returns — a worse failure than the one being
+fixed. Stop your traffic before calling `Shutdown` if you need more than the
+guarantee above.
+
+### What adapters must now tolerate
+
+- **A `StoreUpdate` arriving late in, or just after, `Shutdown`.**
+- **A blocking `StoreUpdate` costing the caller its deadline.** Because the
+  final flush runs under `context.Background()`, an adapter that never returns
+  wedges that room's worker at exit and `Shutdown` returns
+  `context.DeadlineExceeded` where it previously returned `nil` — by discarding
+  your data. The honest error replaces a silent lie, but it is a behaviour
+  change if you have a `Shutdown` deadline.
+- **Writes for a room the server already considers gone.** Nothing calls
+  `doc.Destroy` on teardown, so a caller that retains the `*crdt.Doc` (from
+  `GetDoc`, or from an `OnLoadDocument` hook) keeps its persistence observer
+  alive and its later commits are written directly — indefinitely. Before
+  v1.49.0 those commits were silently dropped.
+- **`Compact` overlapping a `StoreUpdate` for the same room NAME.** The
+  provider serialises `Compact` with `StoreUpdate` per room *instance*, not per
+  name, and the point above widens that window. If your `Compact` mutates state
+  keyed by name, serialise inside the adapter. Every store this repo ships
+  behind `LegacyAdapter` already does, each with one mutex over all operations:
+  `persistence.MemoryPersistence`, `persistence.FilePersistence`, and
+  `persistence/sqlite`.
+
+Straggler writes also bypass coalescing, auto-versioning and compaction, and
+delay that update's relay fan-out (the persistence observer runs before the
+relay observers). All of this is scoped to room retirement — except the
+retained-`*crdt.Doc` case, which is not.

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -641,11 +641,18 @@ count. Since v1.49.0 (#229) that separation is enforced:
 > calling `Shutdown` (shut down your `http.Server`, or otherwise stop routing to
 > the handler).
 >
-> **Then:** for every room that was present in the server and had finished
-> loading when `Shutdown` began, any commit whose `Transact` returned before
-> `Shutdown` returned is durable.
+> **Then, provided `Shutdown` returns `nil`:** for every room that was present
+> in the server and had finished loading when `Shutdown` began, any commit
+> whose `Transact` returned before `Shutdown` returned has been handed to the
+> adapter, and the adapter reported success. That is a completed, successful
+> persistence attempt — not an unconditional durability claim: a non-nil
+> return (for example `context.DeadlineExceeded`) means a final flush may
+> still have been in flight when `Shutdown` gave up on waiting for it, and
+> even on a `nil` return, an adapter error or panic encountered while storing
+> a commit is logged, not propagated — `Shutdown` has no way to see it or
+> report it.
 
-Both halves are load-bearing.
+Every clause here is load-bearing.
 
 **Why the precondition.** `Shutdown` snapshots the room set once, and skips any
 room still mid-load at that instant. `ServeHTTP` has no shutdown gate, so a
@@ -657,7 +664,27 @@ the drain. This is not new in v1.49.0; what is new is that the rest of this
 section would otherwise read as promising against it. Stop accepting
 connections first and the room set cannot grow underneath `Shutdown`.
 
-**Why the second half is still not losslessness.** **`Shutdown` is not lossless
+**Why "provided `Shutdown` returns `nil`."** Every wait inside `Shutdown` —
+the persistence join, `waitStranded`, the relay-lane join — is bounded by the
+caller's `ctx`, not by the work actually finishing. A deadline that fires mid-
+drain makes `Shutdown` return `ctx.Err()` while a final flush or a stranded
+write is still in flight; that write may still land, but `Shutdown` returning
+gives you no way to know whether it did. Only a `nil` return means every wait
+actually resolved by the work completing rather than by the clock running out.
+See "What adapters must now tolerate" below for the two independent things
+that can produce that deadline error.
+
+**Why "the adapter reported success."** The observer that performs a commit's
+write — whether the room's normal persistence worker or, for a straggler, the
+committing goroutine itself via `persistStranded` — has no caller to report a
+failure to: an adapter error or a recovered panic is logged and the write is
+abandoned, not surfaced through `Shutdown`'s return value. A `nil` `Shutdown`
+therefore tells you every in-scope commit reached the adapter and the adapter
+did not report a problem; it cannot tell you the adapter's own report was
+correct, or that no adapter call failed silently underneath a logging call you
+weren't watching.
+
+**Why the guarantee is still not losslessness.** **`Shutdown` is not lossless
 and cannot be made so.** A transaction that *begins* committing after `Shutdown`
 has observed its last in-flight write is not covered: the producers are peer
 read loops and any code holding a `*crdt.Doc`, none of which the server can

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -689,9 +689,12 @@ failure than the one being fixed.
   provider serialises `Compact` with `StoreUpdate` per room *instance*, not per
   name, and the point above widens that window. If your `Compact` mutates state
   keyed by name, serialise inside the adapter. Every store this repo ships
-  behind `LegacyAdapter` already does, each with one mutex over all operations:
-  `persistence.MemoryPersistence`, `persistence.FilePersistence`, and
-  `persistence/sqlite`.
+  behind `LegacyAdapter` already does, each serialising its writers under a
+  single mutex: `persistence.MemoryPersistence` and `persistence.FilePersistence`
+  do so for every operation, reads included; `persistence/sqlite`'s reads are
+  deliberately lock-free instead and consistent by other means, but its
+  `Compact` and `AppendUpdate` are both writers serialised under its own
+  mutex — the property this section actually relies on.
 
 Straggler writes also bypass coalescing, auto-versioning and compaction, and
 delay that update's relay fan-out (the persistence observer runs before the

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -609,5 +609,30 @@ func (p *PostgresAdapter) storeUpdate(ctx context.Context, room string, update [
 
 During `Server.Shutdown`, the in-flight `ExecContext` call sees the context cancellation and returns early instead of waiting for the database driver's default timeout.
 
+### Cancellation never costs you a committed transaction (v1.49.0+)
+
+Cancellation exists to unwedge a slow adapter, not to decide which writes
+count. Since v1.49.0 (#229) that separation is enforced:
+
+- **Every final flush uses `context.Background()`**, on both the coalescing and
+  the per-update path, so the last write is never aborted by the very signal
+  that triggered it. Before v1.49.0 the per-update path passed the cancellable
+  context to its shutdown drain, and a ctx-aware adapter discarded the whole
+  tail.
+- **A store aborted by cancellation is retained, not dropped.** The update is
+  re-stored on the exit path under a background context — the same
+  retain-and-re-flush rule that already applied to a coalesced batch.
+- **A transaction committed while `Shutdown` is running still reaches the
+  adapter.** Peer read loops keep committing for the whole
+  close-connections-and-join window, so the room's persistence worker publishes
+  its retirement before its final drain; a commit that arrives too late for
+  that drain is written by the committing goroutine itself rather than being
+  parked in an unread buffer. Such a write is synchronous for that caller and
+  bypasses coalescing, auto-versioning, and compaction — it is a straggler
+  being made durable, not a new steady state.
+
+An adapter must therefore still tolerate a `StoreUpdate` call arriving late in,
+or immediately after, `Shutdown`.
+
 This pattern mirrors `io.WriterTo`, `http.CloseNotifier`, and `database/sql/driver.QueryerContext` in the standard library — extension interfaces that callers can opt into without breaking older implementations.
 ```

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -1,15 +1,23 @@
-// Package mobile provides a gomobile-bindable façade over ygo's crdt and
-// awareness packages, for embedding ygo natively in iOS and Android apps via
-// `gomobile bind` — no JavaScript runtime, no CGo.
+// Package mobile provides a gomobile-bindable façade over ygo's crdt,
+// awareness, and provider/client packages, for embedding ygo natively in iOS
+// and Android apps via `gomobile bind` — no JavaScript runtime, no CGo.
 //
 // # gomobile-safe surface
 //
 // gomobile bind only supports a restricted set of types across the language
 // boundary. Every exported function and method in this package therefore uses
-// ONLY: string, int64, bool, []byte, error, and the bound pointers *Doc and
-// *Awareness. It never exposes unsigned ints, maps, non-byte slices, `any`,
-// variadics, or callbacks. (crdt/awareness use uint64 IDs, maps, and []uint64
-// internally; this package translates at the boundary.)
+// ONLY: string, int64, bool, []byte, error, the bound pointers *Doc,
+// *Awareness, *SyncClient and *Subscription, and the observer interfaces
+// DocObserver, AwarenessObserver and SyncStatusObserver. It never exposes
+// unsigned ints, maps, non-byte slices, `any`, variadics, or Go func values.
+// (crdt/awareness use uint64 IDs, maps, and []uint64 internally; this package
+// translates at the boundary.)
+//
+// Callbacks cross the boundary as those interfaces rather than as func values,
+// which is the only form gomobile can bind in that direction: the platform
+// implements the interface in Swift or Kotlin and passes it in. See
+// DocObserver, AwarenessObserver and SyncStatusObserver for the threading
+// rules each one imposes.
 //
 // # Threading
 //

--- a/mobile/syncclient.go
+++ b/mobile/syncclient.go
@@ -267,6 +267,25 @@ func NewSyncClient(url, dbPath, token string) (*SyncClient, error) {
 // Close too: Close stops syncing and releases the network/store, but never
 // closes the Doc itself, so previously-synced or offline-edited content is
 // never taken away by tearing down the connection.
+//
+// # Do not call Doc().Close() while this SyncClient is still connected
+//
+// Doc().Close() only tears down THIS wrapper: it nils this Doc's own d field
+// and detaches this Doc's own change-observer subscriptions (see Doc.Close's
+// own doc) — it has no way to reach, and does not touch, the underlying
+// provider/client.Client's sync loop, which was handed the exact same
+// *crdt.Doc pointer at construction (see NewSyncClient's rawDoc) and keeps
+// its own, entirely separate Doc.OnUpdate registration on it for as long as
+// this SyncClient stays connected. So calling Doc().Close() while connected
+// orphans the sync loop rather than stopping it: remote updates keep
+// arriving and getting applied and persisted (crdt.ApplyUpdateV1 runs
+// directly against the underlying *crdt.Doc from provider/client's own
+// handleFrame, never through this wrapper), local edits already queued keep
+// getting flushed, and awareness keeps being kept alive — none of it
+// reachable from the app anymore, because every mobile.Doc method now
+// returns ErrClosed or a zero value. The only way to actually stop that work
+// is SyncClient.Close, which is also the right call to make FIRST if an app
+// wants to shed both the sync loop and the Doc together (#228).
 func (s *SyncClient) Doc() *Doc {
 	return s.doc
 }

--- a/provider/client/backoff.go
+++ b/provider/client/backoff.go
@@ -31,11 +31,19 @@ const maxBackoffShift = 32
 // spread grow with repeated failures, and no two clients following the same
 // schedule are likely to retry at the same instant.
 //
-// The zero value is directly usable — attempt starts at 0 as the zero int
-// already gives — but base and max must be set by the caller; there is no
-// sensible default for either baked in here (the reconnect loop's choice of
+// Only the attempt field has a meaningful zero value (0, meaning "the first
+// attempt hasn't happened yet"). base and max do NOT: a zero-value
+// backoff{} has max == 0, and next()'s limit can never exceed max, so every
+// call would return time.Duration(randFloat()*0) == 0 forever — exactly the
+// hot reconnect loop this type exists to prevent, not a usable default (#228:
+// an earlier version of this doc claimed "the zero value is directly
+// usable" and then immediately contradicted that very claim in its own next
+// clause, which said base and max still had to be set). base and max MUST be
+// set by the caller; there is no sensible
+// default for either baked in here (the reconnect loop's choice of
 // 500ms/Options.MaxBackoff belongs to loop.go, not to this general-purpose
-// type).
+// type — see runReconnectLoop's own construction, the only production call
+// site, which always sets both).
 //
 // backoff is not safe for concurrent use. It doesn't need to be: exactly one
 // goroutine (the reconnect loop in loop.go) ever owns one.

--- a/provider/client/backoff_test.go
+++ b/provider/client/backoff_test.go
@@ -12,6 +12,28 @@ import (
 // restores the real generator on cleanup. This is what makes the backoff
 // tests deterministic assertions on exact durations rather than statistical
 // claims about a real PRNG (see backoff.go's randFloat doc).
+//
+// # Correctness here rests on two facts, not one (#228)
+//
+// First, t.Cleanup's LIFO ordering — which IS documented ("Cleanup functions
+// will be called in last added, first called order", testing.T.Cleanup) —
+// is what makes NESTED calls in one test (e.g. two withFixedRand calls in
+// the same test body, as TestBackoff_NextSaturatesAtMax does) restore
+// correctly: each call captures whatever randFloat currently is as `orig`
+// before overwriting it, so the LAST call's cleanup must run FIRST to hand
+// back its immediate predecessor's value, chaining back to the real
+// generator only once every call's cleanup has run in reverse order. An
+// earlier version of this comment called that ordering "undocumented" — it
+// isn't; Go's own doc states it plainly.
+//
+// Second, and this is the part actually worth calling out: randFloat is
+// PACKAGE-LEVEL, mutable, shared state, and this helper's set/restore has no
+// locking of its own. That is safe today only because nothing in this test
+// package calls t.Parallel — every test that uses this helper runs to
+// completion (cleanup included) before the next one starts. Adding
+// t.Parallel to any test in this file, now or later, would let two tests'
+// set/restore pairs interleave on the same var: a genuine data race, not
+// merely a flaky assertion.
 func withFixedRand(t *testing.T, v float64) {
 	t.Helper()
 	orig := randFloat

--- a/provider/client/client.go
+++ b/provider/client/client.go
@@ -409,7 +409,19 @@ type Client struct {
 	// Store this Client's Close is responsible for closing. A Store supplied
 	// directly via Options.Store is never tracked here and is never closed
 	// by Close — see Options.StorePath's doc and Close's ownership rule.
-	ownedStore *SQLiteStore
+	//
+	// Typed as the unexported closableStore interface, not the concrete
+	// *SQLiteStore New always assigns it in production, purely so
+	// close_test.go can substitute a store whose Close deterministically
+	// returns a chosen error (see TestClient_Close_SecondCallReturnsFirstCloseError,
+	// #228) — a REAL *SQLiteStore's Close forwards straight to
+	// database/sql.DB.Close(), which that package's own doc and source
+	// guarantee is idempotent (always nil after the first call), so there is
+	// no way to make an actual owned SQLite store's Close fail on demand from
+	// outside package sqlite. New still only ever assigns a genuine
+	// *SQLiteStore here in production; nothing about this interface changes
+	// what ownedStore holds when Options.StorePath was used.
+	ownedStore closableStore
 
 	statusMu       sync.Mutex
 	statusSubs     []statusSub
@@ -419,12 +431,39 @@ type Client struct {
 	syncedOnce sync.Once
 	closed     chan struct{}
 	closeOnce  sync.Once
+	// closeErr caches the result of ownedStore.Close() from the one call to
+	// Close that actually ran closeOnce.Do's body, so EVERY call to Close —
+	// not just the first — returns it (#228: an earlier version declared
+	// closeErr as a local variable inside Close itself, which a second call
+	// re-declares fresh and initialises to nil, then never touches because
+	// closeOnce.Do is a no-op on a repeat call — so a second Close always
+	// returned nil regardless of what the first one's owned-store Close
+	// actually returned). Written at most once, inside closeOnce.Do; read by
+	// every call to Close after Do returns. sync.Once.Do's own documented
+	// guarantee — a Do call that finds the work already done does not return
+	// until the FIRST call's function has itself returned — is what makes
+	// reading this field safe without its own lock: that guarantee is
+	// exactly the synchronisation edge a bare field read would otherwise
+	// need. See TestClient_Close_SecondCallReturnsFirstCloseError for the
+	// proof.
+	closeErr error
 
 	// statsDropped backs Stats.Dropped. The other three Stats fields are read
 	// straight off the lane (see Stats), which is the only place that
 	// accounting actually happens; duplicating them here would just be a
 	// second copy to keep in step.
 	statsDropped atomic.Uint64
+}
+
+// closableStore is the exact shape Close needs from an owned store:
+// LocalStore's LoadDoc/StoreUpdate (so the *SQLiteStore New opens for
+// Options.StorePath can still double as this Client's own LocalStore — see
+// New's o.Store = ss assignment) plus Close. See ownedStore's own doc for
+// why this is an interface rather than binding the field directly to
+// *SQLiteStore.
+type closableStore interface {
+	LocalStore
+	Close() error
 }
 
 // roomFromURL extracts the room/document name from a y-websocket URL: the
@@ -497,7 +536,19 @@ func New(o Options) (*Client, error) {
 	// Connect) so a failure to open it is reported synchronously from New,
 	// exactly like every other Options validation above, rather than
 	// surfacing later from inside Connect's hydrate step.
-	var owned *SQLiteStore
+	//
+	// owned is declared as closableStore (the interface, not *SQLiteStore)
+	// from the start, and assigned to only inside the StorePath branch below.
+	// That ordering matters: assigning a typed nil *SQLiteStore to an
+	// interface variable produces a NON-nil interface (it carries a type
+	// descriptor even though its value is nil — the classic Go "nil
+	// interface" trap), which would break ownedStore's "non-nil exactly when
+	// Options.StorePath was used" contract and Close's `if c.ownedStore !=
+	// nil` check the moment StorePath is empty. Leaving owned untouched in
+	// that case keeps it at the interface's genuine zero value instead —
+	// nil in every sense — because no conversion from *SQLiteStore to
+	// closableStore ever happens on that path.
+	var owned closableStore
 	if o.StorePath != "" {
 		ss, err := OpenSQLiteStore(o.StorePath)
 		if err != nil {
@@ -845,16 +896,34 @@ func (c *Client) Connect(ctx context.Context) error {
 		}
 	}()
 
-	// runReconnectLoop returns nil in the ordinary case — it only stops
-	// because loopCtx is done (see its own doc) — with every connection
-	// failure along the way already reported through OnStatus as it
-	// happened, so there is nothing left to inspect once it returns nil.
+	// runReconnectLoop returns nil whenever loopCtx is done (see its own
+	// doc's ctx.Err() != nil branch, loop.go) — but that covers two
+	// interleavings this comment must not conflate (#228: an earlier
+	// version claimed the stronger one unconditionally, which is false of
+	// the second):
+	//
+	//   - the ORDINARY case: nothing was in flight when loopCtx became
+	//     done, or the last attempt's own failure was reported via
+	//     OnStatus, with its real error, before runReconnectLoop returned.
+	//   - a RACE this package accepts rather than closes: the last
+	//     attempt's failure and loopCtx becoming done can land at almost
+	//     the same moment. runReconnectLoop's own ctx.Err() != nil branch
+	//     takes that failure and — by its own doc's words — treats it as
+	//     "a deliberate stop [that] is not something to report as a
+	//     failure": it drains the lane and returns nil WITHOUT ever
+	//     calling emitStatus for that error. In THIS interleaving the
+	//     failure is not "already reported with its real error"; it is
+	//     silently absorbed by the shutdown path.
+	//
 	// The final, unconditional emission below is the bookend
-	// StateDisconnected's own doc describes ("after Close") — it is
-	// deliberately Err: nil even if the very last attempt before the stop
-	// had failed, because THAT failure was already reported with its real
-	// error by runReconnectLoop; this one specifically means "and now the
-	// client is stopped, on purpose."
+	// StateDisconnected's own doc describes ("after Close") — Err: nil
+	// either way, because the ordinary case genuinely has nothing else to
+	// report, and the race case has already made its choice (fast,
+	// deterministic shutdown over surfacing a failure whose connection is
+	// gone regardless) one level down, in runReconnectLoop. A subscriber
+	// must not read a bare StateDisconnected{Err: nil} that follows Close
+	// as proof the very last attempt itself succeeded or ended cleanly —
+	// this bookend cannot, and does not try to, tell the two cases apart.
 	//
 	// A non-nil return is the one exception (#165 Task 9): a terminal
 	// failure — currently only ErrAuthRejected — that runReconnectLoop
@@ -1153,6 +1222,7 @@ func (c *Client) dropRemoteAwareness() {
 //     asynchronous or buffered the way provider/websocket's persistence
 //     worker is, so there is no separate flush step to wait for beyond "no
 //     goroutine that could still call onDocUpdate is running."
+//
 //  2. Unsubscribe the Doc and Awareness observers, so a Doc/Awareness pair
 //     that outlives this Client stops writing to the Store and stops
 //     queueing anything onto a lane nothing will ever drain again. Placed
@@ -1174,6 +1244,7 @@ func (c *Client) dropRemoteAwareness() {
 //     that window structurally: nothing can land on the lane through the
 //     observer path anymore by the time step 3 runs, so whatever step 3
 //     finds is everything there will ever be to find).
+//
 //  3. Catch-all: count whatever is STILL on the outbound lane as Dropped
 //     (see dropLaneRemainder). This is a no-op in the ordinary case — the
 //     loop's own teardown (step 1) already drained or counted everything —
@@ -1181,6 +1252,7 @@ func (c *Client) dropRemoteAwareness() {
 //     case: Connect was never called, or every attempt failed during
 //     hydration (see Connect's "does not latch" doc), so nothing else in
 //     this Client will ever get a chance to touch the lane again.
+//
 //  4. Close the store, but ONLY if this Client opened it itself (Options.
 //     StorePath, tracked via ownedStore — see Options.StorePath's doc and
 //     ownedStore's own). A Store supplied directly via Options.Store
@@ -1188,11 +1260,41 @@ func (c *Client) dropRemoteAwareness() {
 //     or simply keep it open past this one's lifetime; closing it here
 //     would take that choice away.
 //
-// Close's own return value surfaces ownedStore.Close's error, if any;
+//     # Not fenced against an in-flight onDocUpdate (#228, disclosed hazard)
+//
+//     Step 2's unsubscribe removes onDocUpdate from Doc's dispatch table, so
+//     no NEW Transact call will invoke it once unsubObserver returns — but
+//     it does not, and cannot without crdt.Doc itself exposing a join
+//     primitive it does not have (every observer type in this package works
+//     this same way: see OnStatus's own "no lock held during callbacks" doc
+//     for the pattern this mirrors), wait for a call to onDocUpdate that a
+//     concurrent Transact on some OTHER goroutine had ALREADY started before
+//     the unsubscribe took effect. Such a call can still be sitting inside
+//     c.opts.Store.StoreUpdate when this step closes the owned store out
+//     from under it. The realistic outcome is a "database is closed" (or
+//     equivalent) error from that StoreUpdate call — database/sql.DB is
+//     documented safe for concurrent use including a concurrent Close, so
+//     this is an ordinary error return, not a data race a test could catch
+//     under -race — which onDocUpdate's existing handling already logs and
+//     counts as Stats().Dropped, EXACTLY as it would a genuine disk failure
+//     (see onDocUpdate's own doc, finding 2). No update is lost silently:
+//     the same Doc.Transact call that produced the update already applied
+//     it in memory, and Dropped correctly reflects that this one write did
+//     not make it to disk. The gap is narrower than "may lose data": it is
+//     that this one straggler failure is indistinguishable, after the fact,
+//     from a real disk failure landing at the same unlucky moment — which is
+//     the honest, and only, thing to say about it without adding a
+//     join-observer-callbacks mechanism this package deliberately has
+//     nowhere else, for a window this narrow (unsubscribe removal is a
+//     single map/slice mutation under a lock; the store-close call that
+//     follows it is a handful of statements later with no I/O in between).
+//
+// Close's own return value surfaces ownedStore.Close's error, if any — and
+// does so consistently across repeat calls: see closeErr's own doc for why
+// that requires a Client field rather than a variable local to this method.
 // Connect's return value (observed separately, via whatever channel the
 // caller used to receive it) is unaffected by this method.
 func (c *Client) Close() error {
-	var closeErr error
 	c.closeOnce.Do(func() {
 		close(c.closed)
 		// Read connectStarted under connectMu — the SAME lock Connect's
@@ -1234,16 +1336,26 @@ func (c *Client) Close() error {
 		closePreDrainHook()
 		c.dropLaneRemainder()
 		if c.ownedStore != nil {
-			closeErr = c.ownedStore.Close()
+			c.closeErr = c.ownedStore.Close()
 		}
 	})
-	return closeErr
+	return c.closeErr
 }
 
 // closePreDrainHook is Close's test-only synchronisation seam; see its one
 // call site's doc for what it is for and why it exists. Always nil (a no-op)
 // in production.
 var closePreDrainHook = func() {}
+
+// maybeCompactConsumeHook is maybeCompact's test-only synchronisation seam
+// (#228), fired strictly between its threshold check (storeWrites.Load())
+// and its atomic consume of that threshold's worth of writes (storeWrites.
+// Add(-threshold)) — exactly the window a concurrent onDocUpdate's
+// storeWrites.Add(1) must land in to prove the consume step does not lose
+// it. Same "package-level indirection purely for test determinism" pattern
+// as closePreDrainHook above and loop.go's closeDrainHook/closeDrainTimeout.
+// Always nil (a no-op) in production.
+var maybeCompactConsumeHook = func() {}
 
 // countUndeliverable increments Stats().Dropped for a payload that has just
 // left the outbound lane without ever reaching the wire — UNLESS something
@@ -1348,10 +1460,32 @@ func (c *Client) maybeCompact(ctx context.Context) {
 	if c.compactor == nil {
 		return
 	}
-	if c.storeWrites.Load() < uint64(c.opts.CompactEvery) {
+	threshold := uint64(c.opts.CompactEvery)
+	if c.storeWrites.Load() < threshold {
 		return
 	}
-	c.storeWrites.Store(0)
+	maybeCompactConsumeHook()
+	// Subtract exactly threshold rather than resetting to 0 (#228). A
+	// storeWrites.Add(1) from a concurrent onDocUpdate call — any goroutine
+	// that called Transact, including the caller's own, since storeWrites is
+	// incremented from both sides (see its own doc) — can land in the window
+	// between the Load above and this line. An unconditional Store(0) here
+	// would discard such an Add(1) outright: whatever value the counter holds
+	// AT THE MOMENT Store(0) executes, including one that landed after our
+	// Load, is overwritten with 0 and gone. Add(-threshold) instead reads
+	// and writes atomically as one step, so it always subtracts threshold
+	// from whatever value is actually there when it runs — a concurrent
+	// Add(1) either happened before it (and is included in what gets
+	// decremented, ending up correctly reflected in the result) or after it
+	// (and is untouched, exactly as if the two operations had not
+	// overlapped). Either way nothing is lost. The impact of the old bug was
+	// compaction cadence drift, not lost data: storeWrites only gates WHEN
+	// Compact runs, never whether a StoreUpdate itself succeeded or was
+	// counted — see TestClient_MaybeCompact_ConcurrentIncrementSurvivesConsume
+	// for a deterministic proof, using maybeCompactConsumeHook to land the
+	// racing Add exactly in this window instead of trying to win a real
+	// scheduling race.
+	c.storeWrites.Add(-threshold)
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("ygo/client: Compact panic for room %q: %v", c.room, r)

--- a/provider/client/client_test.go
+++ b/provider/client/client_test.go
@@ -145,10 +145,16 @@ func TestClient_Connect_HydrationFailureDoesNotLatch(t *testing.T) {
 	if err := c.Connect(context.Background()); !errors.Is(err, store.err) {
 		t.Fatalf("Connect returned %v, want the store's load error", err)
 	}
-	// The guard must have been released: a retry gets past it and fails on
-	// the store again, rather than being refused as already-connected.
-	if err := c.Connect(context.Background()); errors.Is(err, ErrAlreadyConnected) {
-		t.Fatal("Connect latched after a hydration failure; the failed call started nothing")
+	// The guard must have been released: a retry gets PAST it and re-runs
+	// hydration for real, failing on the store's actual error again — not
+	// merely "whatever error, as long as it isn't ErrAlreadyConnected" (#228:
+	// an earlier version of this assertion was errors.Is(err,
+	// ErrAlreadyConnected) inverted, which also passes for a nil err, or for
+	// any OTHER error entirely, none of which would prove the retry actually
+	// reached hydration rather than, say, short-circuiting somewhere else).
+	if err := c.Connect(context.Background()); !errors.Is(err, store.err) {
+		t.Fatalf("Connect after a released guard returned %v, want the store's load error again "+
+			"(proving the retry actually re-ran hydration, not merely that it avoided ErrAlreadyConnected)", err)
 	}
 }
 
@@ -373,7 +379,12 @@ func TestClient_HydratesBeforeDial(t *testing.T) {
 	}
 
 	// The hydrated update must not have been re-persisted: it carried the
-	// remote-origin sentinel, so the local-persist hook must have skipped it.
+	// hydrate-origin sentinel (NOT remoteOrigin — see onDocUpdate's origin
+	// table and hydrateOrigin's own doc for why hydration needs a sentinel
+	// of its own, distinct from a server-received update's remoteOrigin,
+	// which by contrast MUST be persisted), so the local-persist hook must
+	// have skipped it (#228: an earlier version of this comment named the
+	// wrong sentinel).
 	if got := store.count(); got != 1 {
 		t.Fatalf("store.count() after hydration = %d, want 1 (hydrated update must not be re-persisted)", got)
 	}

--- a/provider/client/close_test.go
+++ b/provider/client/close_test.go
@@ -3,10 +3,13 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1018,4 +1021,191 @@ func TestClient_Close_SendsWebSocketCloseFrame(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("server never observed the connection close")
 	}
+}
+
+// blockingWriteConn wraps a real net.Conn, passing every method through
+// unchanged (Read, Close, deadlines, ...) until Arm is called, after which
+// every subsequent Write blocks until the deadline most recently set via
+// SetWriteDeadline, then returns a timeout-shaped error — never touching the
+// real underlying socket for that write at all. See dialNetDialContext's own
+// doc (loop.go) for why this package's tests reproduce "the peer is alive
+// but never reads" this way instead of actually exhausting a real OS socket
+// buffer: doing it for real turned out to depend on this machine's buffer
+// sizing AND, once one write on a gorilla Conn times out, every later write
+// on that SAME Conn short-circuits with the cached failure regardless of
+// its own deadline (gorilla's writeFatal/writeErr) — so the real-buffer
+// approach can only ever time the FIRST write to overflow, never the
+// second. Arming with nothing yet written sidesteps both: the close frame
+// becomes the first (and only) write this Conn ever has to block on.
+//
+// WriteCount, read via a test's quiescence poll (see this test's own doc),
+// tells it when it is safe to Arm: the HTTP upgrade handshake itself writes
+// through this same Conn (dialNetDialContext hands gorilla's Dialer this
+// wrapper before the handshake even starts), and gorilla's client-mode
+// WriteMessage always issues that as one Write call, so "the handshake AND
+// SyncStep1 have both finished" is exactly "WriteCount stopped changing" —
+// counting writes rather than waiting for a single specific one, since which
+// write is "the last one before the main select loop" is otherwise an
+// internal detail of gorilla's Dialer this test has no business depending
+// on. Arming before that point is a real, observed flake (caught under
+// `go test -race`, which schedules slowly enough to lose the race
+// regularly): it makes one of THOSE writes the one that blocks instead of
+// the close frame, which has nothing to do with what this test targets and
+// would misreport as this bug even after it is fixed.
+type blockingWriteConn struct {
+	net.Conn
+	armed atomic.Bool
+
+	mu       sync.Mutex
+	deadline time.Time
+
+	writeCount atomic.Int64
+}
+
+func (b *blockingWriteConn) Arm() { b.armed.Store(true) }
+
+func (b *blockingWriteConn) WriteCount() int64 { return b.writeCount.Load() }
+
+func (b *blockingWriteConn) SetWriteDeadline(t time.Time) error {
+	b.mu.Lock()
+	b.deadline = t
+	b.mu.Unlock()
+	return b.Conn.SetWriteDeadline(t)
+}
+
+func (b *blockingWriteConn) Write(p []byte) (int, error) {
+	if !b.armed.Load() {
+		n, err := b.Conn.Write(p)
+		b.writeCount.Add(1)
+		return n, err
+	}
+	b.mu.Lock()
+	dl := b.deadline
+	b.mu.Unlock()
+	wait := time.Minute // no caller in this package ever writes with a zero deadline
+	if !dl.IsZero() {
+		wait = time.Until(dl)
+	}
+	if wait > 0 {
+		time.Sleep(wait)
+	}
+	return 0, fmt.Errorf("blockingWriteConn: simulated deadline exceeded")
+}
+
+// withDialNetDialContext installs fn as loop.go's package-level
+// dialNetDialContext for the duration of the calling test, restoring the nil
+// (production) default on cleanup — see that var's own doc.
+func withDialNetDialContext(t *testing.T, fn func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	t.Helper()
+	orig := dialNetDialContext
+	dialNetDialContext = fn
+	t.Cleanup(func() { dialNetDialContext = orig })
+}
+
+// TestClient_Close_CloseFrameUsesCloseDrainTimeoutNotWriteTimeout is #229/#228
+// final-review Important B's regression test: runLoop's teardown defer wrote
+// the close frame with the 10s writeTimeout const instead of
+// closeDrainTimeout (2s), even though closeDrainTimeout's own doc states its
+// entire reason for existing is that "a write attempted this late, with
+// nothing left to retry it, should fail fast rather than sit on an
+// already-doomed socket" — and the close frame write runs strictly LATER
+// than the drain that reasoning was written for. Client.Close joins the loop
+// goroutine (see Close's own doc), so a backpressured-but-alive peer could
+// add up to 10s to Close's return latency where the design intent says 2s.
+//
+// TestClient_Close_CountsUndeliveredOutboundAsDropped's wedge does not catch
+// this, despite looking similar: it sets closeDrainTimeout to -1s (a
+// deadline already in the past), so every write on that path — including,
+// incidentally, the close frame's own — fails INSTANTLY regardless of which
+// const or var backs it. That test (and TestClient_Close_SendsWebSocketCloseFrame
+// above, whose peer reads immediately) both complete in well under a second
+// no matter which timeout the close frame uses, so neither can distinguish
+// the two — and see blockingWriteConn's own doc for why "just exhaust a real
+// OS socket buffer instead" was tried and rejected as a substitute.
+//
+// The connection is real — a genuine WebSocket handshake against a real
+// httptest server that accepts and then never reads, matching the peer this
+// bug actually needs — but the CLIENT's own outbound net.Conn is
+// blockingWriteConn, armed right before Close so the close frame is the
+// FIRST write this connection ever has to block on (flushLane's own
+// close-time drain finds nothing queued and returns immediately either
+// way, so it never contends for that "first write" slot).
+//
+// Bound chosen well below the bug's ~10s and comfortably above the fix's
+// near-0s (flushLane's empty drain) + ~2s (the close frame itself), so this
+// test fails RED against writeTimeout and passes GREEN against
+// closeDrainTimeout.
+func TestClient_Close_CloseFrameUsesCloseDrainTimeoutNotWriteTimeout(t *testing.T) {
+	upgrader := gws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{})
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		close(accepted)
+		// Alive, handshake complete, but never reads and never writes — the
+		// peer this bug needs, as opposed to the wedge tests above.
+		<-release
+		_ = conn.Close()
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		close(release)
+		ts.Close()
+	})
+
+	connCh := make(chan *blockingWriteConn, 1)
+	withDialNetDialContext(t, func(ctx context.Context, network, addr string) (net.Conn, error) {
+		raw, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		w := &blockingWriteConn{Conn: raw}
+		connCh <- w
+		return w, nil
+	})
+
+	c, err := New(Options{
+		URL: "ws" + strings.TrimPrefix(ts.URL, "http") + "/wedged-alive",
+		Doc: crdt.New(),
+	})
+	require.NoError(t, err)
+
+	waitConnected := statusWaiter(t, c, StateConnected)
+	connect(t, c)
+	waitConnected()
+	<-accepted
+
+	var wrapped *blockingWriteConn
+	select {
+	case wrapped = <-connCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dialNetDialContext was never invoked — the client did not dial through our hook")
+	}
+	// Wait for the write count to go quiet — the HTTP upgrade handshake AND
+	// SyncStep1 both write through wrapped, and arming before they finish
+	// races runLoop's own goroutine (see WriteCount's own doc). Two
+	// consecutive equal, non-zero samples 50ms apart is comfortably longer
+	// than either write takes against a real, unarmed, tiny-payload conn.
+	var lastCount int64 = -1
+	require.Eventually(t, func() bool {
+		n := wrapped.WriteCount()
+		settled := n > 0 && n == lastCount
+		lastCount = n
+		return settled
+	}, 2*time.Second, 50*time.Millisecond,
+		"write count on the dial-hook conn never settled — handshake/SyncStep1 never finished")
+	wrapped.Arm()
+
+	start := time.Now()
+	require.NoError(t, c.Close())
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 6*time.Second,
+		"Close() took %s; the close frame write must be bounded by closeDrainTimeout (2s), not "+
+			"writeTimeout (10s) — a backpressured-but-alive peer must not add up to 10s to Close's "+
+			"return latency", elapsed)
 }

--- a/provider/client/close_test.go
+++ b/provider/client/close_test.go
@@ -166,6 +166,68 @@ func TestClient_CompactionTrigger_DeletesAfterThreshold(t *testing.T) {
 	require.NoError(t, c.Close())
 }
 
+// noopCompactStore is a minimal LocalStore + CompactableStore that does
+// nothing: it exists purely so a test can give a Client a non-nil
+// c.compactor (see New's own doc: asserted once from Options.Store) without
+// the overhead, and unrelated behaviour, of a real *SQLiteStore — the test
+// that uses this cares only about maybeCompact's storeWrites bookkeeping,
+// never about what Compact itself does.
+type noopCompactStore struct{}
+
+func (noopCompactStore) LoadDoc(string) ([]byte, error)        { return nil, nil }
+func (noopCompactStore) StoreUpdate(string, []byte) error      { return nil }
+func (noopCompactStore) Compact(context.Context, string) error { return nil }
+
+// TestClient_MaybeCompact_ConcurrentIncrementSurvivesConsume is #228's proof
+// for the "maybeCompact loses concurrent increments" finding: the OLD
+// maybeCompact read storeWrites via Load() and then unconditionally reset it
+// to 0 via Store(0), which discards ANY Add(1) that lands in between —
+// including one from a concurrent onDocUpdate call on another goroutine,
+// exactly the situation storeWrites' own doc says can happen (incremented
+// from either the caller's own Transact goroutine or the loop goroutine).
+//
+// Reproducing that window via real goroutine scheduling would be exactly
+// the kind of flake this package's own docs warn against (see
+// closePreDrainHook's doc for the same argument in Close's own drain-
+// ordering test). maybeCompactConsumeHook exists so this test can land the
+// racing Add(1) deterministically, at the exact point maybeCompact's fixed
+// version now protects with an atomic subtract instead of a destructive
+// reset.
+func TestClient_MaybeCompact_ConcurrentIncrementSurvivesConsume(t *testing.T) {
+	c, err := New(Options{
+		URL:          "ws://127.0.0.1:1/room",
+		Doc:          crdt.New(),
+		Store:        noopCompactStore{},
+		CompactEvery: 5,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.storeWrites.Store(5) // exactly at threshold
+
+	landed := make(chan struct{})
+	orig := maybeCompactConsumeHook
+	maybeCompactConsumeHook = func() {
+		// Simulates onDocUpdate's storeWrites.Add(1) (see its own doc) firing
+		// on another goroutine, landing exactly between maybeCompact's
+		// threshold check and its atomic consume of that threshold.
+		c.storeWrites.Add(1)
+		close(landed)
+	}
+	t.Cleanup(func() { maybeCompactConsumeHook = orig })
+
+	c.maybeCompact(context.Background())
+
+	select {
+	case <-landed:
+	default:
+		t.Fatal("maybeCompactConsumeHook never fired; test did not exercise the race window it exists to test")
+	}
+	require.Equal(t, uint64(1), c.storeWrites.Load(),
+		"a storeWrites.Add(1) landing between maybeCompact's threshold check and its atomic "+
+			"consume must survive the consume, not be silently discarded by it (#228)")
+}
+
 // TestClient_Close_JoinsLoopBeforeReturning is #165 Task 10's test (b), the
 // "loop goroutine exited" half: Close must not return until Connect's own
 // goroutine — which owns runReconnectLoop/runLoop, and is therefore the
@@ -847,4 +909,113 @@ func TestClient_Close_Idempotent(t *testing.T) {
 	require.NoError(t, c.Close())
 	require.NoError(t, c.Close())
 	require.NoError(t, c.Close())
+}
+
+// erroringCloseStore is a LocalStore whose Close deterministically returns a
+// fixed error — proving TestClient_Close_SecondCallReturnsFirstCloseError
+// without needing a REAL owned SQLite store's Close to fail on demand, which
+// (per closableStore's own doc) it cannot: database/sql.DB.Close is
+// documented and implemented as unconditionally idempotent, always nil after
+// the first call.
+type erroringCloseStore struct{ err error }
+
+func (erroringCloseStore) LoadDoc(string) ([]byte, error)   { return nil, nil }
+func (erroringCloseStore) StoreUpdate(string, []byte) error { return nil }
+func (s erroringCloseStore) Close() error                   { return s.err }
+
+// TestClient_Close_SecondCallReturnsFirstCloseError is #228's proof for the
+// "a second Close() always returns nil" finding: closeErr used to be a
+// variable local to Close, which a repeat call re-declares fresh (and never
+// touches, since closeOnce.Do is a no-op the second time around) rather than
+// reading back whatever the FIRST call's owned-store Close actually
+// returned. Directly assigns a fake closableStore to c.ownedStore
+// (white-box, same package) rather than going through Options.StorePath,
+// since a real *SQLiteStore's Close cannot be made to fail on demand — see
+// erroringCloseStore's own doc.
+func TestClient_Close_SecondCallReturnsFirstCloseError(t *testing.T) {
+	c, err := New(Options{URL: "ws://127.0.0.1:1/room", Doc: crdt.New()})
+	require.NoError(t, err)
+
+	wantErr := errors.New("disk gone at close time")
+	c.ownedStore = erroringCloseStore{err: wantErr}
+
+	got1 := c.Close()
+	require.ErrorIs(t, got1, wantErr, "first Close must surface the owned store's close error")
+
+	got2 := c.Close()
+	require.ErrorIs(t, got2, wantErr,
+		"a second Close call must return the SAME error the first one did, not silently swallow "+
+			"it as nil (#228: closeErr must be cached on the Client, not merely a local variable "+
+			"inside the closeOnce.Do body)")
+}
+
+// TestClient_Close_SendsWebSocketCloseFrame is #228's proof for the
+// "teardown sends no WebSocket close frame" finding: without a
+// WriteControl(CloseMessage) before conn.Close(), the peer sees only an
+// abrupt TCP socket close — indistinguishable, from ReadMessage's point of
+// view, from a crash or a severed network path — which is exactly what
+// makes a server log an abnormal closure (code 1006) instead of recognising
+// a deliberate, graceful disconnect this client actually performed on
+// purpose.
+//
+// Proved on a raw, hand-rolled WebSocket server (not ygo's own
+// provider/websocket.Server, whose own close-code handling is not this
+// test's concern), mirroring auth_test.go's
+// TestClient_Auth_EmptyTokenSendsNoAuthFrame: gorilla only ever returns a
+// *websocket.CloseError from ReadMessage when it has actually parsed a close
+// frame off the wire (see gorilla's ReadMessage/NextReader doc); an ordinary
+// severed TCP connection surfaces as a plain I/O error instead. Observing a
+// *websocket.CloseError server-side, carrying CloseNormalClosure, is direct
+// proof this client sent a graceful close frame before dropping the
+// connection — not an inference from reading loop.go's source.
+func TestClient_Close_SendsWebSocketCloseFrame(t *testing.T) {
+	upgrader := gws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	readErrCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				readErrCh <- err
+				return
+			}
+		}
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	c, err := New(Options{
+		URL: "ws" + strings.TrimPrefix(ts.URL, "http") + "/close-frame",
+		Doc: crdt.New(),
+	})
+	require.NoError(t, err)
+
+	// Armed before Connect starts (see statusWaiter's own doc for why): wait
+	// for the connection to actually be established — StateConnected fires
+	// as soon as the WebSocket upgrade completes, before the sync handshake
+	// even starts — so Close below has a live socket to send a close frame
+	// on, rather than racing a dial still in flight.
+	waitConnected := statusWaiter(t, c, StateConnected)
+	connect(t, c)
+	waitConnected()
+
+	require.NoError(t, c.Close())
+
+	select {
+	case err := <-readErrCh:
+		var closeErr *gws.CloseError
+		require.ErrorAs(t, err, &closeErr,
+			"server's ReadMessage returned %v (%T), want a *websocket.CloseError — this client's "+
+				"teardown must send a WebSocket close frame before dropping the TCP connection, not "+
+				"just close the socket and leave the peer to see an abrupt, abnormal-looking closure",
+			err, err)
+		require.Equal(t, gws.CloseNormalClosure, closeErr.Code)
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never observed the connection close")
+	}
 }

--- a/provider/client/loop.go
+++ b/provider/client/loop.go
@@ -120,8 +120,14 @@ const reconnectBackoffBase = 500 * time.Millisecond
 // either side) is not by itself fatal — the NEXT ping still has a full
 // interval to succeed before the deadline expires — while two consecutive
 // misses fires well before an embedding application would notice anything
-// wrong on its own. This mirrors y-websocket's own ping-every-30s,
-// terminate-at-2x convention (#165).
+// wrong on its own. The 30s/2x pairing is chosen to match the
+// WIDELY-DOCUMENTED y-websocket convention (ping every 30s, terminate after
+// 2 missed intervals) as a reasonable interoperability default (#165). This
+// repo does not vendor or otherwise check against y-websocket's actual JS
+// source, so read that as "chosen to be compatible with," not
+// "independently verified against," that implementation (#228: an earlier
+// version of this doc cited the convention as an established fact this repo
+// had confirmed, which it cannot).
 const readDeadlineMultiplier = 2
 
 // session is one connection's worth of loop state: the socket, and whatever
@@ -266,9 +272,21 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	conn, resp, err := dialer.DialContext(ctx, c.opts.URL, c.opts.Header)
 	if resp != nil && resp.Body != nil {
 		// gorilla hands back the HTTP response on a rejected upgrade (e.g. a
-		// 401 from provider/websocket's Authorize hook). Nothing here reads
-		// it, but leaving it open would leak the connection out of the
-		// transport's pool.
+		// 401 from provider/websocket's Authorize hook). By this point
+		// resp.Body is NOT a connection checked out of an http.Transport's
+		// pool — there is no net/http.Transport in a WebSocket dial at all;
+		// gorilla's Dialer opens and owns the raw net.Conn itself, and on
+		// any failed handshake it substitutes resp.Body with an in-memory
+		// io.NopCloser wrapping a short diagnostic read-ahead buffer, having
+		// already closed the real network connection in its own deferred
+		// cleanup before this line ever runs (see gorilla's client.go: the
+		// dial's own `defer` closes netConn unless the handshake fully
+		// succeeded). Closing it here is therefore just tidying up an
+		// already-inert NopCloser — harmless, and the idiomatic "always
+		// close what you were handed" habit — not a fix for an actual
+		// connection or socket leak (#228: an earlier version of this
+		// comment blamed "the transport's pool", which doesn't exist on
+		// this path).
 		_ = resp.Body.Close()
 	}
 	if err != nil {
@@ -357,13 +375,50 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 			}
 		}
 	}()
-	// Tear down in the order that actually unblocks the pump: cancel releases
-	// a pump parked on the frames send, Close releases one parked in
-	// ReadMessage, and only then is it safe to wait. Joining the goroutine
-	// (rather than letting it drift) is what keeps `go test -race` from
-	// attributing a later connection's activity to a leaked pump, and what
-	// makes "no goroutine outlives Connect" checkable.
+	// Tear down in the order that actually unblocks the pump: send a
+	// WebSocket-level close frame FIRST (#228), then cancel releases a pump
+	// parked on the frames send, Close releases one parked in ReadMessage,
+	// and only then is it safe to wait. Joining the goroutine (rather than
+	// letting it drift) is what keeps `go test -race` from attributing a
+	// later connection's activity to a leaked pump, and what makes "no
+	// goroutine outlives Connect" checkable.
+	//
+	// # Why the close frame (#228)
+	//
+	// Without it, every exit from this function — including the ordinary
+	// "Close was called" case — looked identical, from the PEER's side, to
+	// this connection simply vanishing: conn.Close() below only tears down
+	// the local TCP socket, it does not tell the other end anything.
+	// ygo's own server (and any other implementation of the ordinary
+	// WebSocket close handshake) logs that as an abnormal closure (code
+	// 1006) and has no way to distinguish it from a crash, a network
+	// partition, or a hung process — even though this client, on the
+	// ordinary Close path, knows perfectly well that it is leaving on
+	// purpose. Sending CloseNormalClosure here first — the same thing a
+	// graceful gorilla/websocket client is documented to do before dropping
+	// its connection — makes the peer's ReadMessage return a proper
+	// *websocket.CloseError instead of a bare I/O error, which is what lets
+	// its disconnect handling log (and act on) a clean close rather than an
+	// abnormal one. See TestClient_Close_SendsWebSocketCloseFrame (close_test.go)
+	// for the proof, observed server-side on a raw WebSocket peer rather
+	// than inferred from this comment.
+	//
+	// WriteControl, not writeWithDeadline/WriteMessage: this runs on the
+	// loop goroutine, the same one every DATA frame write already runs on
+	// (see session's single-writer doc), so nothing else could be mid-write
+	// here regardless — but WriteControl is what every other control frame
+	// this file sends (session.ping) already uses, and matching that
+	// convention costs nothing. The error is deliberately ignored: on every
+	// path that reaches this defer except the clean ctx-cancelled one, the
+	// connection is already failing or already gone, so a failed close
+	// write here reveals nothing conn.Close() below doesn't already make
+	// moot; on the clean path, a failure here just means the peer (or the
+	// network) tore the socket down first, which conn.Close() handles the
+	// same way regardless of why.
 	defer func() {
+		_ = conn.WriteControl(gws.CloseMessage,
+			gws.FormatCloseMessage(gws.CloseNormalClosure, ""),
+			time.Now().Add(writeTimeout))
 		connCancel()
 		_ = conn.Close()
 		<-readerDone
@@ -734,10 +789,19 @@ func (s *session) handleFrame(frame []byte) error {
 			// shared Awareness sees it at the moment handleDisconnect
 			// runs — unbumped. Against our own server, a SINGLE Heartbeat
 			// here already clears that removal unconditionally: Heartbeat's
-			// own +1 (from our pre-disconnect clock — this client's OWN
-			// local clock is untouched by a removal broadcast, since a
-			// disconnecting peer never receives its own removal notice)
-			// makes our re-announcement strictly NEWER than any removal our
+			// own +1 (from our pre-disconnect clock — under the ORDINARY
+			// interleaving this client's OWN local clock is untouched by a
+			// removal broadcast, because the disconnecting connection is
+			// already torn down by the time handleDisconnect's broadcast
+			// fires, so there is no live socket of ours left to receive it
+			// on. That is not a universal rule, though (#228: an earlier
+			// version of this comment stated it as one): that broadcast's
+			// excludeSelf is false — see peer.go's
+			// broadcastAwarenessFromRoom — so a peer that has already
+			// RECONNECTED under the SAME clientID before the broadcast
+			// fires, a genuine race rather than the ordinary case, IS a
+			// live recipient of its own removal notice) makes our
+			// re-announcement strictly NEWER than any removal our
 			// server could have synthesised from that same base, so
 			// Awareness.ApplyUpdate's ordinary newer-clock path — not the
 			// equal-clock one — admits it every time, regardless of

--- a/provider/client/loop.go
+++ b/provider/client/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -105,6 +106,31 @@ var (
 // history of relying on that race instead. Always nil (a no-op call site
 // below simply does nothing) in production.
 var closeDrainHook = func() {}
+
+// dialNetDialContext, when non-nil, replaces gws.Dialer's own network-dial
+// function (see runLoop's dialer construction) for the calling test's
+// duration — the same "package-level indirection purely for test
+// determinism" pattern as closeDrainHook above. Nil in production, which
+// leaves gorilla's own default (plain net.Dial) untouched.
+//
+// It exists because #228/#229 final-review Important B needs a peer whose
+// writes deterministically block past a specific deadline, and this
+// package's own regression tests (see close_test.go's
+// blockingWriteConn/withDialNetDialContext) showed that trying to get there
+// by exhausting a REAL OS socket buffer is not a viable substitute: which of
+// two successive writes overflows first depends on this machine's buffer
+// sizing (observed to vary by roughly an order of magnitude — from
+// comfortably-succeeds to blocks-for-the-full-deadline within one machine's
+// own 640KB-to-800KB window during this package's own test development), and
+// gorilla/websocket caches the FIRST write failure on a connection
+// (writeFatal) and short-circuits every later write with that cached error
+// forever after — so whichever write happens to overflow first "uses up" the
+// only failure this connection will ever produce, making the SECOND write's
+// own deadline unobservable. A test-controlled net.Conn sidesteps both
+// problems: it blocks exactly the write it is told to, for exactly the
+// deadline that write's caller supplies, regardless of any real socket's
+// buffer state.
+var dialNetDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 // reconnectBackoffBase is the Full Jitter base duration runReconnectLoop
 // constructs its backoff with. Unlike MaxBackoff, this is not an Options
@@ -266,6 +292,10 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	dialer := &gws.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: dialHandshakeTimeout,
+		// Always nil in production (see dialNetDialContext's own doc), which
+		// is exactly gorilla's own "NetDialContext nil -> plain net.Dial"
+		// default — this field's mere presence changes nothing here.
+		NetDialContext: dialNetDialContext,
 	}
 	// c.opts.Header was defensively copied by New, so a caller mutating their
 	// own map after construction cannot change what this dial sends.
@@ -403,6 +433,17 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	// for the proof, observed server-side on a raw WebSocket peer rather
 	// than inferred from this comment.
 	//
+	// This defer fires on EVERY exit from runLoop, not only the deliberate
+	// Close one — a rejected-auth exit and a read-error exit send the exact
+	// same CloseNormalClosure code, because the alternative (threading a
+	// more accurate code through every return path above) buys little: the
+	// peer's read loop has usually already seen — or is about to see — its
+	// own error from whatever actually went wrong (a dropped connection, an
+	// unauthorized close code it sent itself), so CloseNormalClosure here is
+	// read as "this side is done writing," not as a claim about why. Treat
+	// the CODE this frame carries as exactly that and nothing more (#229/#228
+	// final whole-branch review, Important E).
+	//
 	// WriteControl, not writeWithDeadline/WriteMessage: this runs on the
 	// loop goroutine, the same one every DATA frame write already runs on
 	// (see session's single-writer doc), so nothing else could be mid-write
@@ -415,10 +456,20 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	// moot; on the clean path, a failure here just means the peer (or the
 	// network) tore the socket down first, which conn.Close() handles the
 	// same way regardless of why.
+	//
+	// closeDrainTimeout, not writeTimeout: this write runs strictly AFTER
+	// the ctx.Done() case's own flushLane(ctx, closeDrainTimeout) drain (see
+	// that var's doc for why 2s, not the 10s handshake-path writeTimeout,
+	// backs a write this late) — and Client.Close joins this goroutine
+	// before returning, so using writeTimeout here let a backpressured but
+	// still-alive peer add up to 10s to Close's return latency where the
+	// drain immediately above it was already bounded at 2s (#229/#228 final
+	// whole-branch review, Important B; see
+	// TestClient_Close_CloseFrameUsesCloseDrainTimeoutNotWriteTimeout).
 	defer func() {
 		_ = conn.WriteControl(gws.CloseMessage,
 			gws.FormatCloseMessage(gws.CloseNormalClosure, ""),
-			time.Now().Add(writeTimeout))
+			time.Now().Add(closeDrainTimeout))
 		connCancel()
 		_ = conn.Close()
 		<-readerDone

--- a/provider/websocket/export_test.go
+++ b/provider/websocket/export_test.go
@@ -1,0 +1,22 @@
+package websocket
+
+import "context"
+
+// MemoryPersistenceRecordCount reports how many stored records a room holds.
+// Test-only: the record count is the only way to tell a real compaction from
+// a KeepVersions=0 no-op, which preserves content either way (#186).
+func MemoryPersistenceRecordCount(m *MemoryPersistence, room string) int {
+	vs, err := m.adapter.Store().ListVersions(context.Background(), room)
+	if err != nil {
+		return -1
+	}
+	return len(vs)
+}
+
+// MemoryPersistencePendingRooms reports how many rooms hold un-compacted
+// bookkeeping. Test-only: proves the pending map is deleted, not zeroed.
+func MemoryPersistencePendingRooms(m *MemoryPersistence) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.pending)
+}

--- a/provider/websocket/export_test.go
+++ b/provider/websocket/export_test.go
@@ -30,7 +30,7 @@ func StrandedWritesInFlight(s *Server) int64 { return s.strandedInFlight.Load() 
 func MemoryPersistencePendingRooms(m *MemoryPersistence) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return len(m.pending)
+	return len(m.rooms)
 }
 
 // MemoryPersistencePendingCount reports room's outstanding (un-folded) write
@@ -41,7 +41,11 @@ func MemoryPersistencePendingRooms(m *MemoryPersistence) int {
 func MemoryPersistencePendingCount(m *MemoryPersistence, room string) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.pending[room]
+	l := m.rooms[room]
+	if l == nil {
+		return 0
+	}
+	return int(l.outstanding())
 }
 
 // NewMemoryPersistenceForTest builds a MemoryPersistence around an arbitrary
@@ -51,5 +55,5 @@ func MemoryPersistencePendingCount(m *MemoryPersistence, room string) int {
 // making the window between MemoryPersistence.Compact's pending snapshot and
 // the fold completing deterministic to hit, without sleeps or timing luck.
 func NewMemoryPersistenceForTest(adapter *persistence.LegacyAdapter) *MemoryPersistence {
-	return &MemoryPersistence{adapter: adapter, pending: make(map[string]int)}
+	return &MemoryPersistence{adapter: adapter, rooms: make(map[string]*compactLedger)}
 }

--- a/provider/websocket/export_test.go
+++ b/provider/websocket/export_test.go
@@ -13,6 +13,14 @@ func MemoryPersistenceRecordCount(m *MemoryPersistence, room string) int {
 	return len(vs)
 }
 
+// StrandedWritesInFlight reports how many committing goroutines are registered
+// in the stranded-write path — the #229 counter Shutdown joins on. Test-only,
+// and the only way to SEQUENCE a shutdown-join test deterministically: a test
+// must know the committer has registered before it lets the worker exit,
+// otherwise it is asserting against the acknowledged residual (a commit that
+// starts after Shutdown has read the counter) rather than against the join.
+func StrandedWritesInFlight(s *Server) int64 { return s.strandedInFlight.Load() }
+
 // MemoryPersistencePendingRooms reports how many rooms hold un-compacted
 // bookkeeping. Test-only: proves the pending map is deleted, not zeroed.
 func MemoryPersistencePendingRooms(m *MemoryPersistence) int {

--- a/provider/websocket/export_test.go
+++ b/provider/websocket/export_test.go
@@ -1,6 +1,10 @@
 package websocket
 
-import "context"
+import (
+	"context"
+
+	"github.com/reearth/ygo/persistence"
+)
 
 // MemoryPersistenceRecordCount reports how many stored records a room holds.
 // Test-only: the record count is the only way to tell a real compaction from
@@ -27,4 +31,25 @@ func MemoryPersistencePendingRooms(m *MemoryPersistence) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.pending)
+}
+
+// MemoryPersistencePendingCount reports room's outstanding (un-folded) write
+// count, 0 if the room has no entry. Test-only: distinguishes "no un-folded
+// writes" from "the bookkeeping entry was erased while a write it did not
+// fold was in flight" (PR #230 review, server.go:435) — MemoryPersistencePendingRooms
+// only reports how many rooms have an entry, not what each one holds.
+func MemoryPersistencePendingCount(m *MemoryPersistence, room string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pending[room]
+}
+
+// NewMemoryPersistenceForTest builds a MemoryPersistence around an arbitrary
+// *persistence.LegacyAdapter, bypassing NewMemoryPersistence's fixed
+// persistence.NewMemoryPersistence() store. Test-only: lets a test park
+// inside the wrapped store's Compact via a custom persistence.VersionedPersistence,
+// making the window between MemoryPersistence.Compact's pending snapshot and
+// the fold completing deterministic to hit, without sleeps or timing luck.
+func NewMemoryPersistenceForTest(adapter *persistence.LegacyAdapter) *MemoryPersistence {
+	return &MemoryPersistence{adapter: adapter, pending: make(map[string]int)}
 }

--- a/provider/websocket/memory_persistence_bench_test.go
+++ b/provider/websocket/memory_persistence_bench_test.go
@@ -28,19 +28,26 @@ func buildSingleOpUpdates(tb testing.TB, n int) [][]byte {
 	return updates
 }
 
-// BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize times a SINGLE
-// StoreUpdate against a room already holding N updates. MemoryPersistence
-// (provider/websocket/server.go) folds every write into one accumulated V1
-// snapshot via crdt.MergeUpdatesV1(existing, update) — merging against the
-// WHOLE document on every call. Under that merge-on-write design the
-// per-call cost grows with N (#186), so a session of N updates costs
-// O(N²) overall even though each update is O(1)-sized. Under a future
-// append-then-compact design the per-call cost must stay flat apart from
-// the amortised cost of periodic compaction.
+// BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize times repeated
+// StoreUpdate calls against a room already holding N updates. MemoryPersistence
+// (provider/websocket/server.go) delegates to persistence.LegacyAdapter +
+// persistence.MemoryPersistence (KeepVersions = 1): each StoreUpdate call
+// APPENDS the update — O(update), not O(document) — and only folds the
+// room's backlog into one blob once every CompactEvery appends (default 500,
+// #186). That fold is still O(document); it is just paid once per
+// CompactEvery calls instead of on every one, so per-call cost keeps growing
+// with document size, only far more slowly (see this repo's godoc on
+// MemoryPersistence and RELEASE_NOTES.md for the honest framing).
 //
-// N is seeded and pre-merged OUTSIDE the timer (b.ResetTimer below); only the
-// single extra StoreUpdate call per b.N iteration is timed, isolating the
-// per-call flush cost as N grows.
+// b.N in a Go benchmark is normally far larger than CompactEvery, so the
+// reported ns/op here AVERAGES many cheap O(update) appends together with
+// the rare O(document) fold that lands roughly once every CompactEvery
+// iterations — that averaging is why the numbers below read as close to flat
+// across seed sizes; it is not evidence that any single call is cost-capped.
+//
+// N is seeded and APPENDED (not merged) OUTSIDE the timer (b.ResetTimer
+// below); only the StoreUpdate calls inside the b.N loop are timed,
+// isolating the per-call cost as N grows.
 func BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize(b *testing.B) {
 	for _, n := range []int{100, 1_000, 10_000} {
 		n := n

--- a/provider/websocket/memory_persistence_bench_test.go
+++ b/provider/websocket/memory_persistence_bench_test.go
@@ -1,0 +1,66 @@
+package websocket_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// buildSingleOpUpdates returns n incremental V1 updates, each one single-char
+// insert, mirroring persistence/scale_bench_test.go's helper of the same
+// shape: the state vector is captured immediately BEFORE each transaction so
+// every update carries only the diff introduced by its own commit, not a
+// growing copy of the whole document.
+func buildSingleOpUpdates(tb testing.TB, n int) [][]byte {
+	tb.Helper()
+	doc := crdt.New()
+	txt := doc.GetText("t")
+	updates := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		sv := doc.StateVector()
+		doc.Transact(func(txn *crdt.Transaction) {
+			txt.Insert(txn, txt.Len(), "a", nil)
+		})
+		updates[i] = crdt.EncodeStateAsUpdateV1(doc, sv)
+	}
+	return updates
+}
+
+// BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize times a SINGLE
+// StoreUpdate against a room already holding N updates. MemoryPersistence
+// (provider/websocket/server.go) folds every write into one accumulated V1
+// snapshot via crdt.MergeUpdatesV1(existing, update) — merging against the
+// WHOLE document on every call. Under that merge-on-write design the
+// per-call cost grows with N (#186), so a session of N updates costs
+// O(N²) overall even though each update is O(1)-sized. Under a future
+// append-then-compact design the per-call cost must stay flat apart from
+// the amortised cost of periodic compaction.
+//
+// N is seeded and pre-merged OUTSIDE the timer (b.ResetTimer below); only the
+// single extra StoreUpdate call per b.N iteration is timed, isolating the
+// per-call flush cost as N grows.
+func BenchmarkWSMemoryPersistence_StoreUpdateVsDocSize(b *testing.B) {
+	for _, n := range []int{100, 1_000, 10_000} {
+		n := n
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			seed := buildSingleOpUpdates(b, n)
+			extra := buildSingleOpUpdates(b, 1)[0]
+			p := ygws.NewMemoryPersistence()
+			const room = "room"
+			for _, u := range seed {
+				if err := p.StoreUpdate(room, u); err != nil {
+					b.Fatalf("seed StoreUpdate: %v", err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := p.StoreUpdate(room, extra); err != nil {
+					b.Fatalf("StoreUpdate: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -191,6 +191,176 @@ func TestUnit_MemoryPersistence_CompactPreservesConcurrentPendingIncrement(t *te
 			"toward the next threshold (PR #230 review, server.go:435)")
 }
 
+// pairedCompactStore parks the first TWO calls to Compact independently, each
+// on its own gate, so a test can interleave two OVERLAPPING
+// websocket.MemoryPersistence.Compact calls for one room deterministically.
+// blockingCompactStore above parks only the first call, which is enough for
+// the single-Compact race but cannot express this one. Every other
+// VersionedPersistence method delegates straight through, unblocked, so a
+// concurrent StoreUpdate proceeds while both folds are parked.
+type pairedCompactStore struct {
+	*persistence.MemoryPersistence
+	calls   atomic.Int32
+	entered [2]chan struct{}
+	proceed [2]chan struct{}
+}
+
+func newPairedCompactStore() *pairedCompactStore {
+	s := &pairedCompactStore{MemoryPersistence: persistence.NewMemoryPersistence()}
+	for i := range s.entered {
+		s.entered[i] = make(chan struct{})
+		s.proceed[i] = make(chan struct{})
+	}
+	return s
+}
+
+func (b *pairedCompactStore) Compact(ctx context.Context, room string, keep int) (int, error) {
+	if n := int(b.calls.Add(1)) - 1; n < len(b.entered) {
+		close(b.entered[n])
+		<-b.proceed[n]
+	}
+	return b.MemoryPersistence.Compact(ctx, room, keep)
+}
+
+// waitEntered fails the test rather than hanging if a fold never arrives.
+func waitEntered(t *testing.T, ch <-chan struct{}, which string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s never reached the wrapped store", which)
+	}
+}
+
+// Two OVERLAPPING compactions must not let the later one erase a write neither
+// of them folded (PR #230 review, second round). The first round of this bug
+// deleted the room's bookkeeping entry outright; the fix snapshotted the count
+// and subtracted only the snapshot, which is still wrong once two Compact
+// calls overlap: both snapshot the same count, the first consumes it, a write
+// lands, and the second consumes its now-stale snapshot on top — erasing the
+// new write's contribution again. The room can then sit above CompactEvery
+// with no further compaction.
+//
+// The interleaving below is exactly that, made deterministic:
+//
+//	C1 reads its mark (3) ────────► parks in the store, before folding
+//	C2 reads the SAME mark (3) ───► parks in the store, before folding
+//	C1 released ──────────────────► folds, reports its mark
+//	a concurrent write lands ─────► outstanding must become 1
+//	C2 released ──────────────────► folds, reports its now-stale mark
+//	                                outstanding must STILL be 1
+//
+// Two overlapping Compact calls for one room are reachable inside a plain
+// Server, not only through direct use of this exported type: LoadDoc compacts
+// before materialising, and since v1.39 room loading runs off the global
+// room-map lock, so a load can overlap the previous residency's on-unload
+// compaction of the same room.
+//
+// CompactEvery is set high so StoreUpdate's own threshold never fires and the
+// folds below are driven only by the explicit Compact calls — otherwise the
+// concurrent write would recurse into a third, nested fold and the test would
+// be asserting on the wrong mechanism.
+func TestUnit_MemoryPersistence_OverlappingCompactsPreserveConcurrentWrite(t *testing.T) {
+	store := newPairedCompactStore()
+	adapter := persistence.NewLegacyAdapter(store)
+	adapter.KeepVersions = 1 // matches websocket.NewMemoryPersistence's own setup
+	p := ygws.NewMemoryPersistenceForTest(adapter)
+	p.CompactEvery = 1_000_000 // never self-compact; drive both folds explicitly
+
+	storeN(t, p, "room", 3) // 3 outstanding, no auto-compact at this threshold
+
+	first := make(chan error, 1)
+	go func() { first <- p.Compact(context.Background(), "room") }()
+	waitEntered(t, store.entered[0], "the first Compact")
+
+	// Started only after the first has parked, so it reads the SAME
+	// outstanding count the first one did — the overlap this test is about.
+	second := make(chan error, 1)
+	go func() { second <- p.Compact(context.Background(), "room") }()
+	waitEntered(t, store.entered[1], "the second Compact")
+
+	close(store.proceed[0])
+	select {
+	case err := <-first:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the first Compact never returned")
+	}
+
+	// Lands after the first fold reported and while the second is still
+	// parked, so neither fold's mark covers it.
+	concurrentDoc := crdt.New()
+	concurrentTxt := concurrentDoc.GetText("t")
+	concurrentDoc.Transact(func(txn *crdt.Transaction) { concurrentTxt.Insert(txn, 0, "b", nil) })
+	require.NoError(t, p.StoreUpdate("room", crdt.EncodeStateAsUpdateV1(concurrentDoc, nil)))
+	require.Equal(t, 1, ygws.MemoryPersistencePendingCount(p, "room"),
+		"precondition: the concurrent write is outstanding before the second fold reports")
+
+	close(store.proceed[1])
+	select {
+	case err := <-second:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the second Compact never returned")
+	}
+
+	require.Equal(t, 1, ygws.MemoryPersistenceRecordCount(p, "room"),
+		"both folds must succeed and leave the room at one record")
+	require.Equal(t, 1, ygws.MemoryPersistencePendingCount(p, "room"),
+		"the concurrent write must still count toward the next threshold: the "+
+			"second Compact reports a mark it read BEFORE this write existed, "+
+			"and a mark may only advance the folded count, never consume a "+
+			"later write's contribution (PR #230 review, second round)")
+}
+
+// The bookkeeping entry must not be dropped while a compaction is still in
+// flight for that room. Dropping it would reset the room's append count to
+// zero underneath the in-flight call, whose already-read mark would then be
+// applied against a fresh ledger and read as a large phantom debt — the
+// reason compactLedger carries an inflight count rather than being deleted
+// the moment nothing is outstanding.
+func TestUnit_MemoryPersistence_LedgerSurvivesInflightCompact(t *testing.T) {
+	store := newPairedCompactStore()
+	adapter := persistence.NewLegacyAdapter(store)
+	adapter.KeepVersions = 1
+	p := ygws.NewMemoryPersistenceForTest(adapter)
+	p.CompactEvery = 1_000_000
+
+	storeN(t, p, "room", 3)
+
+	first := make(chan error, 1)
+	go func() { first <- p.Compact(context.Background(), "room") }()
+	waitEntered(t, store.entered[0], "the first Compact")
+
+	second := make(chan error, 1)
+	go func() { second <- p.Compact(context.Background(), "room") }()
+	waitEntered(t, store.entered[1], "the second Compact")
+
+	// Release the first and let it fully report. Nothing is outstanding now,
+	// but the second is still in flight holding a mark.
+	close(store.proceed[0])
+	select {
+	case err := <-first:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the first Compact never returned")
+	}
+	require.Equal(t, 1, ygws.MemoryPersistencePendingRooms(p),
+		"the entry must be retained while a compaction is still in flight for it")
+
+	close(store.proceed[1])
+	select {
+	case err := <-second:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the second Compact never returned")
+	}
+	require.Equal(t, 0, ygws.MemoryPersistencePendingRooms(p),
+		"once the last in-flight compaction reports and nothing is outstanding, "+
+			"the entry must be deleted, not zeroed — rooms come and go, and a map "+
+			"only ever zeroed grows with churn")
+}
+
 // Interface satisfaction is load-bearing: the server type-asserts for these at
 // runtime, so gaining or losing one silently changes which persistence-worker
 // code path runs.

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -102,12 +102,13 @@ func TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces(t *testing.T) {
 	require.True(t, isAdapter)
 	require.False(t, isCtx,
 		"deliberately NOT a PersistenceAdapterContext: this adapter's append has "+
-			"nothing to abort, so implementing it would only cost writes — it would "+
-			"switch the server onto the cancellable-ctx path, and on the "+
-			"coalescing-disabled path the final shutdown drain reuses a ctx a "+
-			"separate goroutine cancels concurrently, discarding a still-queued "+
-			"committed write with only a log line (measured: 51-151/200 dropped "+
-			"across trials, #186)")
+			"nothing to abort, so implementing it would switch the server onto the "+
+			"cancellable-ctx path purely to gain a cancellation it can only act on "+
+			"by discarding the write (persistence.MemoryPersistence.AppendUpdate "+
+			"returns ctx.Err() at entry). #229 has since made the worker side of "+
+			"that safe — final flushes use a background ctx and a cancelled store "+
+			"is retained and re-stored — so this is no longer a loss hazard, just "+
+			"a pointless code path (#186)")
 	require.True(t, isCompactable)
 	require.False(t, isVersionable,
 		"deliberately NOT a VersionableAdapter: auto-versioning an in-memory test adapter is scope creep (#186)")
@@ -121,26 +122,28 @@ func TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces(t *testing.T) {
 // well-formed, committed update the instant ctx is already cancelled — with
 // no partial write, no retry, nothing but the returned error. This is why
 // giving websocket.MemoryPersistence a StoreUpdateContext was the wrong move:
-// the server's persistence worker cancels its ctx the moment shutdown begins
-// (startPersistenceWorker's doc, persistence.go) with no ordering guarantee
-// against "drain and store what's still queued," so any context-aware adapter
-// with nothing to actually abort just loses writes for free.
+// an adapter with nothing to actually abort gains nothing from cancellation
+// and can only respond to it by throwing the write away.
 //
 // An end-to-end Server.Shutdown-races-concurrent-Apply test was attempted
-// first, per this hazard's own writeup, and abandoned: it reproduces write
-// loss on BOTH current and pre-#186 code (verified against the pre-#186
-// commit directly, with and without -race), because provider/websocket's
-// strict-path shutdown drain has its own separate, pre-existing gap — it
-// drains persistCh exactly once and returns, so an update landing in the
-// channel microseconds after that one-shot drain is never persisted,
-// regardless of which PersistenceAdapter is behind it. That gap predates
-// #186, is not specific to MemoryPersistence, and is out of scope for this
-// fix wave (flagged separately). Any test built on that end-to-end race would
-// fail unpredictably even on a correctly-fixed #186, which would misreport
-// this hazard as unresolved. This test isolates the ACTUAL mechanism #186
-// introduced instead: no goroutines, no sleeps, no scheduling luck — it calls
-// the exact vulnerable method with an already-cancelled ctx and asserts the
-// write is gone.
+// first, per this hazard's own writeup, and abandoned at the time: it
+// reproduced write loss on BOTH current and pre-#186 code (verified against
+// the pre-#186 commit directly, with and without -race), because
+// provider/websocket's shutdown drain had its own separate, pre-existing gap —
+// it drained persistCh exactly once and returned, so an update landing in the
+// channel after that one-shot drain was never persisted, regardless of which
+// PersistenceAdapter was behind it. A test built on that race would have
+// failed unpredictably even on a correctly-fixed #186 and misreported this
+// hazard as unresolved.
+//
+// That gap is #229, and it is fixed on this branch — see
+// persistence_shutdown_test.go, which now DOES assert the end-to-end property
+// (a commit during Shutdown reaches the adapter) deterministically, by parking
+// the worker rather than racing it. This test is still worth keeping as the
+// narrow, isolated statement of the mechanism: no goroutines, no sleeps, no
+// scheduling luck — it calls the exact method with an already-cancelled ctx
+// and asserts the write is gone, which is why the server must never hand a
+// cancelled ctx to a final flush.
 func TestUnit_PersistenceLegacyAdapterStoreUpdateContext_DiscardsOnCancelledCtx(t *testing.T) {
 	store := persistence.NewMemoryPersistence()
 	adapter := persistence.NewLegacyAdapter(store)

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -1,0 +1,72 @@
+package websocket_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// docTextAfterReload applies whatever LoadDoc returns to a fresh Doc and reads
+// the "t" text — asserting on CONTENT, never on stored bytes, because the
+// storage shape is exactly what this change alters.
+func docTextAfterReload(t *testing.T, p *ygws.MemoryPersistence, room string) string {
+	t.Helper()
+	blob, err := p.LoadDoc(room)
+	require.NoError(t, err)
+	d := crdt.New()
+	if len(blob) > 0 {
+		require.NoError(t, crdt.ApplyUpdateV1(d, blob, nil))
+	}
+	return d.GetText("t").ToString()
+}
+
+// storeN writes n single-char updates and returns the expected final text.
+func storeN(t *testing.T, p *ygws.MemoryPersistence, room string, n int) string {
+	t.Helper()
+	doc := crdt.New()
+	txt := doc.GetText("t")
+	var sv crdt.StateVector
+	for i := 0; i < n; i++ {
+		doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, txt.Len(), "a", nil) })
+		require.NoError(t, p.StoreUpdate(room, crdt.EncodeStateAsUpdateV1(doc, sv)))
+		sv = doc.StateVector()
+	}
+	return txt.ToString()
+}
+
+// Writing far past several CompactEvery boundaries must reload identically to
+// writing without crossing any — compaction is a storage detail, never a
+// content change (#186).
+func TestUnit_MemoryPersistence_RoundTripsAcrossCompactionBoundaries(t *testing.T) {
+	p := ygws.NewMemoryPersistence()
+	p.CompactEvery = 4
+	want := storeN(t, p, "room", 21) // crosses the boundary 5 times
+	require.Equal(t, want, docTextAfterReload(t, p, "room"))
+}
+
+// The context-aware write path must exist and behave like StoreUpdate: the
+// server prefers it, and the wrapped adapter already has it.
+func TestUnit_MemoryPersistence_StoreUpdateContextPersists(t *testing.T) {
+	p := ygws.NewMemoryPersistence()
+	doc := crdt.New()
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	require.NoError(t, p.StoreUpdateContext(context.Background(),
+		"room", crdt.EncodeStateAsUpdateV1(doc, nil)))
+	require.Equal(t, "hi", docTextAfterReload(t, p, "room"))
+}
+
+// Explicit Compact must be safe on an unknown room and must not lose state on
+// a known one.
+func TestUnit_MemoryPersistence_CompactIsSafeAndLossless(t *testing.T) {
+	p := ygws.NewMemoryPersistence()
+	require.NoError(t, p.Compact(context.Background(), "never-seen"))
+
+	want := storeN(t, p, "room", 7)
+	require.NoError(t, p.Compact(context.Background(), "room"))
+	require.Equal(t, want, docTextAfterReload(t, p, "room"))
+}

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/persistence"
 	ygws "github.com/reearth/ygo/provider/websocket"
 )
 
@@ -46,18 +47,6 @@ func TestUnit_MemoryPersistence_RoundTripsAcrossCompactionBoundaries(t *testing.
 	p.CompactEvery = 4
 	want := storeN(t, p, "room", 21) // crosses the boundary 5 times
 	require.Equal(t, want, docTextAfterReload(t, p, "room"))
-}
-
-// The context-aware write path must exist and behave like StoreUpdate: the
-// server prefers it, and the wrapped adapter already has it.
-func TestUnit_MemoryPersistence_StoreUpdateContextPersists(t *testing.T) {
-	p := ygws.NewMemoryPersistence()
-	doc := crdt.New()
-	txt := doc.GetText("t")
-	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
-	require.NoError(t, p.StoreUpdateContext(context.Background(),
-		"room", crdt.EncodeStateAsUpdateV1(doc, nil)))
-	require.Equal(t, "hi", docTextAfterReload(t, p, "room"))
 }
 
 // Explicit Compact must be safe on an unknown room and must not lose state on
@@ -102,7 +91,8 @@ func TestUnit_MemoryPersistence_ThresholdCompactsAndDropsBookkeeping(t *testing.
 }
 
 // Interface satisfaction is load-bearing: the server type-asserts for these at
-// runtime, so losing one silently disables a feature.
+// runtime, so gaining or losing one silently changes which persistence-worker
+// code path runs.
 func TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces(t *testing.T) {
 	var p any = ygws.NewMemoryPersistence()
 	_, isAdapter := p.(ygws.PersistenceAdapter)
@@ -110,8 +100,91 @@ func TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces(t *testing.T) {
 	_, isCompactable := p.(ygws.CompactableAdapter)
 	_, isVersionable := p.(ygws.VersionableAdapter)
 	require.True(t, isAdapter)
-	require.True(t, isCtx)
+	require.False(t, isCtx,
+		"deliberately NOT a PersistenceAdapterContext: this adapter's append has "+
+			"nothing to abort, so implementing it would only cost writes — it would "+
+			"switch the server onto the cancellable-ctx path, and on the "+
+			"coalescing-disabled path the final shutdown drain reuses a ctx a "+
+			"separate goroutine cancels concurrently, discarding a still-queued "+
+			"committed write with only a log line (measured: 51-151/200 dropped "+
+			"across trials, #186)")
 	require.True(t, isCompactable)
 	require.False(t, isVersionable,
 		"deliberately NOT a VersionableAdapter: auto-versioning an in-memory test adapter is scope creep (#186)")
+}
+
+// This is the deterministic, isolated reproduction of the ACTUAL mechanism the
+// reviewer identified: persistence.MemoryPersistence.AppendUpdate (reached via
+// persistence.LegacyAdapter.StoreUpdateContext, exactly the method
+// websocket.MemoryPersistence's removed StoreUpdateContext would have
+// forwarded to) checks ctx.Err() at entry and discards an otherwise
+// well-formed, committed update the instant ctx is already cancelled — with
+// no partial write, no retry, nothing but the returned error. This is why
+// giving websocket.MemoryPersistence a StoreUpdateContext was the wrong move:
+// the server's persistence worker cancels its ctx the moment shutdown begins
+// (startPersistenceWorker's doc, persistence.go) with no ordering guarantee
+// against "drain and store what's still queued," so any context-aware adapter
+// with nothing to actually abort just loses writes for free.
+//
+// An end-to-end Server.Shutdown-races-concurrent-Apply test was attempted
+// first, per this hazard's own writeup, and abandoned: it reproduces write
+// loss on BOTH current and pre-#186 code (verified against the pre-#186
+// commit directly, with and without -race), because provider/websocket's
+// strict-path shutdown drain has its own separate, pre-existing gap — it
+// drains persistCh exactly once and returns, so an update landing in the
+// channel microseconds after that one-shot drain is never persisted,
+// regardless of which PersistenceAdapter is behind it. That gap predates
+// #186, is not specific to MemoryPersistence, and is out of scope for this
+// fix wave (flagged separately). Any test built on that end-to-end race would
+// fail unpredictably even on a correctly-fixed #186, which would misreport
+// this hazard as unresolved. This test isolates the ACTUAL mechanism #186
+// introduced instead: no goroutines, no sleeps, no scheduling luck — it calls
+// the exact vulnerable method with an already-cancelled ctx and asserts the
+// write is gone.
+func TestUnit_PersistenceLegacyAdapterStoreUpdateContext_DiscardsOnCancelledCtx(t *testing.T) {
+	store := persistence.NewMemoryPersistence()
+	adapter := persistence.NewLegacyAdapter(store)
+	adapter.KeepVersions = 1 // matches websocket.NewMemoryPersistence's own setup
+
+	doc := crdt.New()
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *crdt.Transaction) { txt.Insert(txn, 0, "hi", nil) })
+	update := crdt.EncodeStateAsUpdateV1(doc, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the shutdown drain observing an already-cancelled ctx
+
+	err := adapter.StoreUpdateContext(ctx, "room", update)
+	require.Error(t, err, "a context-aware store must refuse an already-cancelled ctx")
+	require.ErrorIs(t, err, context.Canceled)
+
+	blob, loadErr := adapter.LoadDoc("room")
+	require.NoError(t, loadErr)
+	require.Empty(t, blob,
+		"the update must NOT have been stored — this is the write-loss mechanism "+
+			"#186 measured (51-151/200 dropped over 20 trials) when "+
+			"websocket.MemoryPersistence exposed StoreUpdateContext; it now only "+
+			"implements the ctx-ignoring PersistenceAdapter, so the persistence "+
+			"worker never reaches this method for this adapter (see "+
+			"TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces)")
+}
+
+// The zero value of MemoryPersistence (e.g. &MemoryPersistence{CompactEvery:
+// 2000}, natural now that CompactEvery is an exported field inviting a
+// composite literal) has a nil internal adapter. Every method must report
+// that clearly rather than nil-dereferencing — the server's persistence
+// worker recovers panics from StoreUpdate, so an unguarded nil deref would
+// present as total silent write loss with nothing but a log line, not a
+// crash that points at the real cause.
+func TestUnit_MemoryPersistence_ZeroValueReturnsErrorNotPanic(t *testing.T) {
+	p := &ygws.MemoryPersistence{CompactEvery: 2000}
+
+	_, err := p.LoadDoc("room")
+	require.Error(t, err, "LoadDoc on the zero value must error, not panic")
+
+	err = p.StoreUpdate("room", []byte("x"))
+	require.Error(t, err, "StoreUpdate on the zero value must error, not panic")
+
+	err = p.Compact(context.Background(), "room")
+	require.Error(t, err, "Compact on the zero value must error, not panic")
 }

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -70,3 +70,48 @@ func TestUnit_MemoryPersistence_CompactIsSafeAndLossless(t *testing.T) {
 	require.NoError(t, p.Compact(context.Background(), "room"))
 	require.Equal(t, want, docTextAfterReload(t, p, "room"))
 }
+
+// Compaction must actually collapse stored records, not merely preserve
+// content. With KeepVersions at its 0 default, Compact is a silent no-op that
+// still passes every content-level assertion — so assert the record count.
+func TestUnit_MemoryPersistence_CompactionActuallyCollapsesRecords(t *testing.T) {
+	p := ygws.NewMemoryPersistence()
+	p.CompactEvery = 1_000_000 // never self-compact; drive it explicitly
+	storeN(t, p, "room", 12)
+
+	require.Greater(t, ygws.MemoryPersistenceRecordCount(p, "room"), 1,
+		"precondition: appended updates must be stored as separate records")
+
+	require.NoError(t, p.Compact(context.Background(), "room"))
+	require.Equal(t, 1, ygws.MemoryPersistenceRecordCount(p, "room"),
+		"Compact must fold the room to a single record; a KeepVersions=0 no-op would leave them all")
+}
+
+// The self-compaction threshold must fire, and must DELETE its bookkeeping
+// entry rather than zero it — a map keyed by room name that is only zeroed
+// grows without bound as rooms churn (idle eviction makes that routine).
+func TestUnit_MemoryPersistence_ThresholdCompactsAndDropsBookkeeping(t *testing.T) {
+	p := ygws.NewMemoryPersistence()
+	p.CompactEvery = 5
+	storeN(t, p, "room", 5)
+
+	require.Equal(t, 1, ygws.MemoryPersistenceRecordCount(p, "room"),
+		"reaching CompactEvery must trigger the fold")
+	require.Zero(t, ygws.MemoryPersistencePendingRooms(p),
+		"the pending entry must be deleted after compaction, not zeroed")
+}
+
+// Interface satisfaction is load-bearing: the server type-asserts for these at
+// runtime, so losing one silently disables a feature.
+func TestUnit_MemoryPersistence_SatisfiesExpectedInterfaces(t *testing.T) {
+	var p any = ygws.NewMemoryPersistence()
+	_, isAdapter := p.(ygws.PersistenceAdapter)
+	_, isCtx := p.(ygws.PersistenceAdapterContext)
+	_, isCompactable := p.(ygws.CompactableAdapter)
+	_, isVersionable := p.(ygws.VersionableAdapter)
+	require.True(t, isAdapter)
+	require.True(t, isCtx)
+	require.True(t, isCompactable)
+	require.False(t, isVersionable,
+		"deliberately NOT a VersionableAdapter: auto-versioning an in-memory test adapter is scope creep (#186)")
+}

--- a/provider/websocket/memory_persistence_test.go
+++ b/provider/websocket/memory_persistence_test.go
@@ -2,7 +2,9 @@ package websocket_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -88,6 +90,105 @@ func TestUnit_MemoryPersistence_ThresholdCompactsAndDropsBookkeeping(t *testing.
 		"reaching CompactEvery must trigger the fold")
 	require.Zero(t, ygws.MemoryPersistencePendingRooms(p),
 		"the pending entry must be deleted after compaction, not zeroed")
+}
+
+// blockingCompactStore wraps a real persistence.MemoryPersistence and parks
+// the FIRST call to Compact until released, immediately BEFORE the actual
+// fold runs. It is the seam that makes deterministic (non-flaky) the race
+// the PR #230 review flagged at server.go:435: a concurrent StoreUpdate can
+// append and increment websocket.MemoryPersistence's pending[room]
+// bookkeeping in the window between Compact snapshotting that count and the
+// fold it guards actually completing. Only Compact is overridden; every
+// other VersionedPersistence method (AppendUpdate included) delegates
+// straight to the embedded store, unblocked, so a concurrent StoreUpdate
+// proceeds while the fold is parked.
+//
+// A CAS flag, not sync.Once: Once.Do blocks a second concurrent caller until
+// the first call's f returns, which this type's only caller in this test
+// (websocket.MemoryPersistence.Compact, called at most once here) never
+// triggers — but a CAS costs nothing extra and is the correct primitive for
+// "block the first caller only" if a test is ever extended to call Compact
+// more than once concurrently.
+type blockingCompactStore struct {
+	*persistence.MemoryPersistence
+	entered chan struct{}
+	proceed chan struct{}
+	parked  atomic.Bool
+}
+
+func newBlockingCompactStore() *blockingCompactStore {
+	return &blockingCompactStore{
+		MemoryPersistence: persistence.NewMemoryPersistence(),
+		entered:           make(chan struct{}),
+		proceed:           make(chan struct{}),
+	}
+}
+
+func (b *blockingCompactStore) Compact(ctx context.Context, room string, keep int) (int, error) {
+	if b.parked.CompareAndSwap(false, true) {
+		close(b.entered)
+		<-b.proceed
+	}
+	return b.MemoryPersistence.Compact(ctx, room, keep)
+}
+
+// A write that lands while a fold is parked mid-flight must still count
+// toward the NEXT threshold: Compact must not delete the whole pending[room]
+// entry just because IT triggered the fold, only subtract what it
+// snapshotted before folding (PR #230 review, server.go:435). Deleting it —
+// the pre-fix behaviour — erases the concurrent write's contribution, so the
+// un-folded record count can exceed CompactEvery indefinitely once writes
+// stop.
+//
+// CompactEvery is set high so StoreUpdate's own threshold check never fires:
+// the fold below is driven by an explicit p.Compact call instead. That
+// matters here — the concurrent write's own pending++ would otherwise also
+// cross the (low) threshold and recurse into a second, nested Compact call
+// on the same room while the first is still parked, folding the concurrent
+// write itself and making this test assert on the wrong mechanism.
+func TestUnit_MemoryPersistence_CompactPreservesConcurrentPendingIncrement(t *testing.T) {
+	store := newBlockingCompactStore()
+	adapter := persistence.NewLegacyAdapter(store)
+	adapter.KeepVersions = 1 // matches websocket.NewMemoryPersistence's own setup
+	p := ygws.NewMemoryPersistenceForTest(adapter)
+	p.CompactEvery = 1_000_000 // never self-compact; drive the fold explicitly below
+
+	storeN(t, p, "room", 3) // pending["room"] == 3, no auto-compact at this threshold
+
+	compactDone := make(chan error, 1)
+	go func() { compactDone <- p.Compact(context.Background(), "room") }()
+
+	select {
+	case <-store.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the explicit Compact never reached the wrapped store")
+	}
+
+	// A concurrent write lands while that fold is parked — after Compact has
+	// snapshotted pending["room"] but before the fold it guards has run. It
+	// must be a well-formed V1 update (a fresh doc's own insert) so the fold
+	// that eventually runs can still succeed.
+	concurrentDoc := crdt.New()
+	concurrentTxt := concurrentDoc.GetText("t")
+	concurrentDoc.Transact(func(txn *crdt.Transaction) { concurrentTxt.Insert(txn, 0, "b", nil) })
+	require.NoError(t, p.StoreUpdate("room", crdt.EncodeStateAsUpdateV1(concurrentDoc, nil)))
+
+	close(store.proceed) // release the parked fold
+
+	select {
+	case err := <-compactDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the parked Compact never returned")
+	}
+
+	require.Equal(t, 1, ygws.MemoryPersistenceRecordCount(p, "room"),
+		"the fold must still succeed and collapse the room to one record")
+	require.Equal(t, 1, ygws.MemoryPersistencePendingCount(p, "room"),
+		"the concurrent write's increment must survive: Compact snapshots the "+
+			"pending count before folding and must subtract only that snapshot, "+
+			"not delete the entry outright, or this write stops contributing "+
+			"toward the next threshold (PR #230 review, server.go:435)")
 }
 
 // Interface satisfaction is load-bearing: the server type-asserts for these at

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -4,18 +4,94 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/reearth/ygo/crdt"
 )
 
+// persistStranded is the durable destination for updates a room's persistence
+// worker can no longer take (#229). It is called from the doc.OnUpdate observer
+// registered in loadRoom, on the two paths where the worker has begun retiring:
+// an update that could not be enqueued at all (passed as extra), and updates
+// that were enqueued but may have missed the worker's final drain.
+//
+// It first waits for the worker to be completely gone (persistDone). That wait
+// is what lets it call the adapter without a lock the worker also holds: the
+// adapter contract promises calls for one room are serialised, and after
+// persistDone the worker is issuing none. The wait cannot deadlock — the worker
+// never waits on a producer, and Shutdown/eviction wait on persistDone too, not
+// on this function.
+//
+// Anything still stranded in persistCh is stored FIRST, then extra, so the
+// adapter sees the room's updates in commit order. Errors are logged, not
+// returned: the observer has no caller to report to. Auto-versioning and
+// compaction are deliberately NOT re-run here — the worker already performed
+// its final maybeVersion/maybeCompact, and a stranded update is by definition a
+// late straggler, not a new steady state.
+//
+// Callers pay for this synchronously, on the committing goroutine. That is the
+// intended trade: it happens only during and after room retirement, and the
+// alternative — the pre-#229 behaviour — was silent data loss.
+func (s *Server) persistStranded(r *room, name string, extra []byte) {
+	<-r.persistDone
+
+	r.persistFallbackMu.Lock()
+	defer r.persistFallbackMu.Unlock()
+
+	store := func(update []byte) {
+		defer func() {
+			if rv := recover(); rv != nil {
+				log.Printf("ygo/websocket: StoreUpdate panic for retired room %q: %v", name, rv)
+			}
+		}()
+		// context.Background, never the worker's ctx: that ctx is cancelled by
+		// the very signal (shutdown / stop) that retired the worker, so using it
+		// would make every ctx-aware adapter discard exactly the writes this
+		// function exists to save.
+		var err error
+		if pac, ok := s.persistence.(PersistenceAdapterContext); ok {
+			err = pac.StoreUpdateContext(context.Background(), name, update)
+		} else {
+			err = s.persistence.StoreUpdate(name, update)
+		}
+		if err != nil {
+			log.Printf("ygo/websocket: StoreUpdate for retired room %q: %v", name, err)
+		}
+	}
+
+	for {
+		select {
+		case update := <-r.persistCh:
+			store(update)
+		default:
+			if extra != nil {
+				store(extra)
+			}
+			return
+		}
+	}
+}
+
 // startPersistenceWorker spawns the goroutine that drains r.persistCh and
 // forwards each update to the PersistenceAdapter. It must be called with
-// r.persistCh, r.persistStop, and r.persistDone already initialised.
+// r.persistCh, r.persistStop, r.persistRetire, and r.persistDone already
+// initialised.
 //
 // The worker exits when either r.persistStop or s.shutdownCh is closed,
 // draining any buffered updates before returning so that no committed
 // transaction is silently lost.
+//
+// That guarantee needs a handshake with the producer, not just a final drain
+// (#229). A drain is one-shot: producers — peer read loops above all — keep
+// committing throughout Shutdown, and Shutdown closes shutdownCh long before it
+// closes the peer connections. So the FIRST act of every exit path is to close
+// r.persistRetire, publishing "I am leaving" before the final drain rather than
+// after it. loadRoom's doc.OnUpdate observer reads that latch and either relies
+// on the final drain (its send completed while the latch was open, so the drain
+// necessarily follows it) or performs the write itself via persistStranded.
+// Without the latch, everything committed after the drain landed in an unread
+// 256-slot buffer and vanished.
 //
 // When coalescing is enabled (see resolveCoalesceConfig / Server.PersistCoalesceWindow),
 // bursts of updates are debounced into a single merged write: each new update
@@ -24,12 +100,12 @@ import (
 //
 // If s.persistence implements PersistenceAdapterContext, store calls are made
 // via StoreUpdateContext with a ctx that is cancelled when shutdown or stop
-// fires. On the coalescing path the final stop/shutdown flush is the exception:
-// it uses context.Background() so the last batched write is not aborted by the
-// very signal that triggers it. On the disabled (per-update) path the final
-// drain uses the cancellable ctx — matching pre-v1.36 behaviour — so a
-// context-aware adapter may still see cancellation during that drain.
-// Otherwise falls back to StoreUpdate (existing behaviour).
+// fires — that cancellation exists so a blocking adapter cannot wedge Shutdown
+// indefinitely. Every FINAL flush is the exception, on both paths: it uses
+// context.Background() so the last write is not aborted by the very signal that
+// triggers it (#229 — the strict path used to pass the cancellable ctx here,
+// which made ctx-aware adapters discard the whole tail). Otherwise falls back
+// to StoreUpdate (existing behaviour).
 //
 // When s.persistence also implements CompactableAdapter, Compact is invoked
 // on room unload (including server shutdown) and, when s.CompactEvery > 0,
@@ -66,6 +142,23 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 
 	go func() {
 		defer close(r.persistDone)
+
+		// retire publishes "this worker is leaving" to the doc.OnUpdate producer
+		// (#229). Ordering is load-bearing in two directions:
+		//
+		//   - it must run BEFORE the final drain, so a send that completed while
+		//     the latch was open is guaranteed to be picked up by that drain;
+		//   - it must run BEFORE close(r.persistDone), so a producer that sees
+		//     the latch and blocks on persistDone is released only once the
+		//     worker really is finished with the adapter.
+		//
+		// The defer is the backstop for an exit no explicit call covers (a panic
+		// escaping the loop): deferred calls run LIFO, so this fires before the
+		// close(r.persistDone) registered above it. sync.Once keeps the explicit
+		// exit-path calls and this backstop from double-closing.
+		var retireOnce sync.Once
+		retire := func() { retireOnce.Do(func() { close(r.persistRetire) }) }
+		defer retire()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -202,16 +295,38 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 			return store(ctx, merged) == nil
 		}
 
-		// Strict per-update path (coalescing disabled): unchanged behaviour.
+		// Strict per-update path (coalescing disabled): one store per update.
 		if !enabled {
+			// pending holds updates whose store was ABORTED by ctx cancellation
+			// rather than rejected by the adapter. Cancellation is a shutdown/stop
+			// signal, not a verdict on the data, so the update is retained and
+			// re-stored on the exit path under a background ctx — the same
+			// retain-and-re-flush discipline the coalescing path already applies to
+			// an unflushed batch. Without it a ctx-aware adapter loses every update
+			// the worker happens to pick up in the window between shutdown
+			// cancelling the ctx and the worker reaching its exit case (#229).
+			// Mutated only from this goroutine.
+			var pending [][]byte
+
+			// storeRetaining is store() plus that retention rule.
+			storeRetaining := func(c context.Context, update []byte) bool {
+				if err := store(c, update); err != nil {
+					if c.Err() != nil {
+						pending = append(pending, update)
+					}
+					return false
+				}
+				return true
+			}
+
 			// drain stores everything currently buffered and reports whether every
 			// store succeeded, so an on-demand flush can act as a durability barrier.
-			drain := func() bool {
+			drain := func(c context.Context) bool {
 				ok := true
 				for {
 					select {
 					case update := <-r.persistCh:
-						if store(ctx, update) != nil {
+						if !storeRetaining(c, update) {
 							ok = false
 						}
 					default:
@@ -219,22 +334,34 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 					}
 				}
 			}
+			// exit runs the shared retire-then-drain sequence for both exit
+			// triggers. retire() FIRST (see the retire comment above), then the
+			// retained updates and the final drain under a BACKGROUND ctx so a
+			// ctx-aware adapter is not handed the context that shutdown itself
+			// just cancelled (#229 — this path used to pass the cancellable one).
+			exit := func() {
+				retire()
+				retained := pending
+				pending = nil
+				for _, u := range retained {
+					_ = store(context.Background(), u)
+				}
+				drain(context.Background())
+				maybeVersion(true)
+				maybeCompact()
+			}
 			for {
 				select {
 				case update := <-r.persistCh:
-					_ = store(ctx, update)
+					_ = storeRetaining(ctx, update)
 				case ack := <-r.flushReq:
-					ok := drain() // store everything currently buffered
+					ok := drain(ctx) // store everything currently buffered
 					ack <- ok
 				case <-r.persistStop:
-					drain()
-					maybeVersion(true)
-					maybeCompact()
+					exit()
 					return
 				case <-s.shutdownCh:
-					drain()
-					maybeVersion(true)
-					maybeCompact()
+					exit()
 					return
 				}
 			}
@@ -265,6 +392,19 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 					return
 				}
 			}
+		}
+		// exit runs the shared retire-then-drain-then-flush sequence for both
+		// exit triggers. retire() must come FIRST so the doc.OnUpdate producer
+		// can never hand an update to a channel this worker has already swept
+		// for the last time (#229); the flush uses a background ctx so the last
+		// batched write survives the very signal that triggered the exit.
+		exit := func() {
+			retire()
+			drainBuffered()
+			flush(context.Background(), batch)
+			clearTimers() // release any pending timers before exit
+			maybeVersion(true)
+			maybeCompact()
 		}
 
 		for {
@@ -328,18 +468,10 @@ func (s *Server) startPersistenceWorker(r *room, name string) {
 				// ack is buffered (cap 1) by every caller, so this never blocks.
 				ack <- ok
 			case <-r.persistStop:
-				drainBuffered()
-				flush(context.Background(), batch) // non-cancelled: survive shutdown
-				clearTimers()                      // release any pending timers before exit
-				maybeVersion(true)
-				maybeCompact()
+				exit()
 				return
 			case <-s.shutdownCh:
-				drainBuffered()
-				flush(context.Background(), batch)
-				clearTimers() // release any pending timers before exit
-				maybeVersion(true)
-				maybeCompact()
+				exit()
 				return
 			}
 		}

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -10,6 +10,54 @@ import (
 	"github.com/reearth/ygo/crdt"
 )
 
+// strandedEnter registers a committing goroutine as a potential stranded
+// writer. It MUST be called before the observer inspects r.persistRetire: the
+// whole point is to be visible to Shutdown from before the decision to write is
+// taken, not from after it (#229). Cheap enough to sit on every commit — one
+// atomic add.
+func (s *Server) strandedEnter() { s.strandedInFlight.Add(1) }
+
+// strandedLeave balances strandedEnter and wakes a waiting Shutdown. The
+// non-blocking send is correct even when it drops: a waiter parked on the
+// channel leaves the buffer empty, so a later decrement's send lands.
+func (s *Server) strandedLeave() {
+	s.strandedInFlight.Add(-1)
+	if s.strandedWake == nil {
+		return
+	}
+	select {
+	case s.strandedWake <- struct{}{}:
+	default:
+	}
+}
+
+// waitStranded blocks until no committing goroutine is in the stranded-write
+// path, or ctx expires. Called by Shutdown after the persistence workers have
+// been joined — a stranded writer is by construction waiting on a worker that
+// has already exited, so this is the only remaining hop between a committed
+// transaction and the adapter.
+//
+// This is a bound, not a guarantee of losslessness. It cannot cover a
+// transaction that begins committing AFTER the counter is observed at zero:
+// the producers are peer read loops and any holder of a *crdt.Doc, none of
+// which the server can join. What it does guarantee is that Shutdown never
+// returns while a write it can see is still in flight.
+func (s *Server) waitStranded(ctx context.Context) {
+	if s.strandedWake == nil {
+		return
+	}
+	for s.strandedInFlight.Load() > 0 {
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case <-s.strandedWake:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // persistStranded is the durable destination for updates a room's persistence
 // worker can no longer take (#229). It is called from the doc.OnUpdate observer
 // registered in loadRoom, on the two paths where the worker has begun retiring:
@@ -23,16 +71,32 @@ import (
 // never waits on a producer, and Shutdown/eviction wait on persistDone too, not
 // on this function.
 //
-// Anything still stranded in persistCh is stored FIRST, then extra, so the
-// adapter sees the room's updates in commit order. Errors are logged, not
-// returned: the observer has no caller to report to. Auto-versioning and
-// compaction are deliberately NOT re-run here — the worker already performed
-// its final maybeVersion/maybeCompact, and a stranded update is by definition a
-// late straggler, not a new steady state.
+// Anything still stranded in persistCh is stored FIRST, then extra, so a single
+// stranded call writes in commit order. That is best-effort ordering WITHIN one
+// call only: two committing goroutines can be in the observer at once (see
+// room.persistFallbackMu), so across concurrent stranded calls the adapter may
+// see the room's updates out of commit order. Harmless for a CRDT log — updates
+// merge order-independently — but do not read it as a stronger promise than it
+// is. Errors are logged, not returned: the observer has no caller to report to.
+// Auto-versioning and compaction are deliberately NOT re-run here — the worker
+// already performed its final maybeVersion/maybeCompact, and a stranded update
+// is by definition a late straggler, not a new steady state.
 //
 // Callers pay for this synchronously, on the committing goroutine. That is the
 // intended trade: it happens only during and after room retirement, and the
-// alternative — the pre-#229 behaviour — was silent data loss.
+// alternative — the pre-#229 behaviour — was silent data loss. Two consequences
+// worth stating rather than discovering:
+//
+//   - crdt.buildPhase2 fires OnUpdate observers in registration order and
+//     loadRoom registers persistence BEFORE the relay observers, so a stranded
+//     write delays that update's cluster fan-out for as long as the adapter
+//     takes. Bounded to room retirement, and a publish onto an already-retired
+//     lane is counted in RelayStats().Dropped rather than lost silently — but
+//     it does stretch the "no blocking I/O on the commit path" convention
+//     further than the rest of the package does.
+//   - It writes for a room name the server may already consider gone, and can
+//     do so indefinitely if a caller retains the *crdt.Doc. See
+//     CompactableAdapter's godoc for what that means for adapters.
 func (s *Server) persistStranded(r *room, name string, extra []byte) {
 	<-r.persistDone
 

--- a/provider/websocket/persistence.go
+++ b/provider/websocket/persistence.go
@@ -17,41 +17,67 @@ import (
 // atomic add.
 func (s *Server) strandedEnter() { s.strandedInFlight.Add(1) }
 
-// strandedLeave balances strandedEnter and wakes a waiting Shutdown. The
-// non-blocking send is correct even when it drops: a waiter parked on the
-// channel leaves the buffer empty, so a later decrement's send lands.
+// strandedLeave balances strandedEnter and releases any waiting Shutdown when
+// this was the last committer in flight.
 func (s *Server) strandedLeave() {
-	s.strandedInFlight.Add(-1)
-	if s.strandedWake == nil {
-		return
-	}
-	select {
-	case s.strandedWake <- struct{}{}:
-	default:
+	if s.strandedInFlight.Add(-1) == 0 {
+		s.strandedBroadcast()
 	}
 }
 
-// waitStranded blocks until no committing goroutine is in the stranded-write
-// path, or ctx expires. Called by Shutdown after the persistence workers have
-// been joined — a stranded writer is by construction waiting on a worker that
-// has already exited, so this is the only remaining hop between a committed
-// transaction and the adapter.
+// strandedBroadcast publishes a 1→0 transition by closing the current latch and
+// installing a fresh one. A close, not a token: Shutdown may be called
+// concurrently (shutdownOnce implies the API tolerates it), and a single wake
+// token would be consumed by whichever caller got there first, leaving the
+// others parked until their contexts expired. Closing wakes all of them.
 //
-// This is a bound, not a guarantee of losslessness. It cannot cover a
-// transaction that begins committing AFTER the counter is observed at zero:
-// the producers are peer read loops and any holder of a *crdt.Doc, none of
-// which the server can join. What it does guarantee is that Shutdown never
-// returns while a write it can see is still in flight.
-func (s *Server) waitStranded(ctx context.Context) {
-	if s.strandedWake == nil {
+// The mutex is taken only on this transition, never on the per-commit
+// increment/decrement, so the hot path stays lock-free.
+func (s *Server) strandedBroadcast() {
+	s.strandedZeroMu.Lock()
+	ch := s.strandedZero
+	if ch == nil { // zero-value Server; nothing waits on it
+		s.strandedZeroMu.Unlock()
 		return
 	}
-	for s.strandedInFlight.Load() > 0 {
-		if ctx.Err() != nil {
+	s.strandedZero = make(chan struct{})
+	s.strandedZeroMu.Unlock()
+	close(ch)
+}
+
+// waitStranded blocks until no committing goroutine is inside the persistence
+// observer, or ctx expires. Called by Shutdown after the persistence workers
+// have been joined — a stranded writer is by construction waiting on a worker
+// that has already exited, so this is the only remaining hop between a
+// committed transaction and the adapter.
+//
+// Latch-then-check is the order that makes this free of lost wakeups: the latch
+// is read BEFORE the counter, so any 1→0 transition that happens after the read
+// necessarily closes the very channel this goroutine is about to wait on, and
+// any transition before it is caught by the counter read. Safe for concurrent
+// waiters, since a close releases all of them.
+//
+// This is a bound, not a guarantee of losslessness. It cannot cover a
+// transaction that begins committing AFTER the counter is observed at zero: the
+// producers are peer read loops and any holder of a *crdt.Doc, none of which
+// the server can join. Nor does it cover a room Shutdown never enumerated —
+// one created, or finishing its load, after Shutdown snapshotted s.rooms; see
+// Shutdown's own comment. Conversely, because the counter covers every commit
+// rather than only the stranded ones, a sustained writer can hold this here
+// until ctx expires with nothing actually stuck.
+func (s *Server) waitStranded(ctx context.Context) {
+	for {
+		s.strandedZeroMu.Lock()
+		ch := s.strandedZero
+		s.strandedZeroMu.Unlock()
+		if ch == nil { // zero-value Server; no producer can have registered
+			return
+		}
+		if s.strandedInFlight.Load() == 0 {
 			return
 		}
 		select {
-		case <-s.strandedWake:
+		case <-ch:
 		case <-ctx.Done():
 			return
 		}

--- a/provider/websocket/persistence_shutdown_test.go
+++ b/provider/websocket/persistence_shutdown_test.go
@@ -1,0 +1,399 @@
+package websocket_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	ygws "github.com/reearth/ygo/provider/websocket"
+)
+
+// gateAdapter is a PersistenceAdapter + CompactableAdapter whose Compact call
+// can be held open by the test. Compact is the seam that makes the #229 race
+// deterministic: the persistence worker calls it on its exit path AFTER its
+// final drain of r.persistCh and immediately BEFORE returning, so a test that
+// commits a transaction while Compact is parked is guaranteed to hit the exact
+// window the bug is about — an update handed to a channel whose reader has
+// already swept it for the last time.
+type gateAdapter struct {
+	mu      sync.Mutex
+	updates [][]byte
+
+	compactEntered chan struct{}
+	releaseCompact chan struct{}
+	compactOnce    sync.Once
+}
+
+func newGateAdapter() *gateAdapter {
+	return &gateAdapter{
+		compactEntered: make(chan struct{}),
+		releaseCompact: make(chan struct{}),
+	}
+}
+
+func (a *gateAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+
+func (a *gateAdapter) StoreUpdate(_ string, update []byte) error {
+	cp := append([]byte(nil), update...)
+	a.mu.Lock()
+	a.updates = append(a.updates, cp)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *gateAdapter) Compact(context.Context, string) error {
+	a.compactOnce.Do(func() {
+		close(a.compactEntered)
+		<-a.releaseCompact
+	})
+	return nil
+}
+
+// merged returns every stored update applied to a fresh doc, so assertions are
+// on CONTENT rather than on the adapter's storage shape.
+func (a *gateAdapter) text(t *testing.T, key string) string {
+	t.Helper()
+	a.mu.Lock()
+	all := make([][]byte, len(a.updates))
+	copy(all, a.updates)
+	a.mu.Unlock()
+
+	d := crdt.New()
+	for _, u := range all {
+		require.NoError(t, crdt.ApplyUpdateV1(d, u, nil))
+	}
+	return d.GetText(key).ToString()
+}
+
+// TestPersistenceShutdown_CommitDuringShutdownIsNotLost is the #229 regression
+// gate. A transaction committed while Shutdown is in flight — after the
+// persistence worker's final drain, before Shutdown returns — must reach the
+// adapter rather than being parked forever in an unread 256-slot buffer.
+//
+// Deterministic by construction: the worker is parked inside Compact (its last
+// act before returning) when the test commits, so the "after the final sweep"
+// ordering is forced, not raced.
+func TestPersistenceShutdown_CommitDuringShutdownIsNotLost(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+	}{
+		{"coalescing enabled (default)", 0},
+		{"coalescing disabled", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newGateAdapter()
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+
+			ctx := context.Background()
+			require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+				transact(func(txn *crdt.Transaction) {
+					txn.GetText("t").Insert(txn, 0, "before", nil)
+				})
+			}))
+
+			doc := s.GetDoc("room")
+			require.NotNil(t, doc)
+
+			shutdownDone := make(chan error, 1)
+			go func() {
+				sctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				shutdownDone <- s.Shutdown(sctx)
+			}()
+
+			// The worker has drained for the last time and is parked in Compact.
+			// Everything after this point is strictly after that final drain.
+			<-a.compactEntered
+
+			// Commit while Shutdown is still running. This is the peer-read-loop
+			// commit the issue describes, reduced to a deterministic sequence.
+			// It runs on its own goroutine because the fixed code hands the
+			// update over synchronously and waits for the worker to finish —
+			// which cannot happen until Compact is released below.
+			committed := make(chan struct{})
+			go func() {
+				defer close(committed)
+				doc.Transact(func(txn *crdt.Transaction) {
+					txt := txn.GetText("t")
+					txt.Insert(txn, txt.Len(), "-during", nil)
+				})
+			}()
+
+			close(a.releaseCompact)
+			select {
+			case <-committed:
+			case <-time.After(10 * time.Second):
+				t.Fatal("commit during Shutdown never returned")
+			}
+
+			select {
+			case err := <-shutdownDone:
+				require.NoError(t, err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("Shutdown did not return")
+			}
+
+			require.Equal(t, "before-during", a.text(t, "t"),
+				"a transaction committed during Shutdown was silently dropped (#229)")
+		})
+	}
+}
+
+// ctxAdapter is context-aware: it honours cancellation the way the
+// PersistenceAdapterContext contract asks adapters to. #229's second defect is
+// that the strict path handed the worker's CANCELLABLE ctx to the stores it
+// issues from the moment shutdown fires onwards — including the final drain —
+// so an adapter like this one discarded the whole tail.
+//
+// The first store call parks on gate (signalling entered), which lets a test
+// pile updates up in the room's buffer before Shutdown fires.
+type ctxAdapter struct {
+	mu        sync.Mutex
+	updates   [][]byte
+	cancelled int
+
+	gate    chan struct{} // nil to disable the park
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (a *ctxAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+
+func (a *ctxAdapter) StoreUpdate(_ string, update []byte) error {
+	a.park()
+	cp := append([]byte(nil), update...)
+	a.mu.Lock()
+	a.updates = append(a.updates, cp)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *ctxAdapter) park() {
+	if a.gate == nil {
+		return
+	}
+	a.once.Do(func() {
+		close(a.entered)
+		<-a.gate
+	})
+}
+
+func (a *ctxAdapter) StoreUpdateContext(ctx context.Context, room string, update []byte) error {
+	a.park()
+	if err := ctx.Err(); err != nil {
+		a.mu.Lock()
+		a.cancelled++
+		a.mu.Unlock()
+		return err
+	}
+	return a.StoreUpdate(room, update)
+}
+
+func (a *ctxAdapter) text(t *testing.T, key string) string {
+	t.Helper()
+	a.mu.Lock()
+	all := make([][]byte, len(a.updates))
+	copy(all, a.updates)
+	a.mu.Unlock()
+
+	d := crdt.New()
+	for _, u := range all {
+		require.NoError(t, crdt.ApplyUpdateV1(d, u, nil))
+	}
+	return d.GetText(key).ToString()
+}
+
+// awaitShutdownRefusal blocks until s has begun shutting down, observed through
+// the public API: Apply refuses with ErrServerShutdown from the instant
+// shutdownCh closes, which is Shutdown's first act. Using a throwaway room
+// keeps the probe from touching the room under test.
+func awaitShutdownRefusal(t *testing.T, s *ygws.Server) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		err := s.Apply(context.Background(), "shutdown-probe", func(*crdt.Doc, func(func(*crdt.Transaction))) {})
+		if errors.Is(err, ygws.ErrServerShutdown) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("server never began shutting down")
+}
+
+// TestPersistenceShutdown_CtxAwareAdapterKeepsExitDrain covers #229's second
+// defect. Updates already queued when Shutdown fires must still reach a
+// ctx-aware adapter, on BOTH paths.
+//
+// Sequenced, not raced: the worker is parked inside its first store call while
+// the remaining updates are queued and Shutdown is confirmed to have started,
+// so the worker only ever resumes into a world where its ctx is already
+// cancelled — the exact condition the defect needs. Which of the 60 queued
+// updates the pre-fix worker consumed before taking its shutdown case was a
+// coin flip per update, so pre-fix survival of all of them had probability
+// 2**-60; the assertion is on content, which is what durability means.
+func TestPersistenceShutdown_CtxAwareAdapterKeepsExitDrain(t *testing.T) {
+	const queued = 60
+
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+	}{
+		{"coalescing enabled (default)", time.Millisecond},
+		{"coalescing disabled", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &ctxAdapter{gate: make(chan struct{}), entered: make(chan struct{})}
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+
+			ctx := context.Background()
+			want := ""
+			apply := func(mark string) {
+				require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+					transact(func(txn *crdt.Transaction) {
+						txt := txn.GetText("t")
+						txt.Insert(txn, txt.Len(), mark, nil)
+					})
+				}))
+				want += mark
+			}
+
+			apply("a")
+			<-a.entered // the worker is parked inside its first store
+
+			for i := 0; i < queued; i++ {
+				apply(fmt.Sprintf("%d", i%10))
+			}
+
+			shutdownDone := make(chan error, 1)
+			go func() {
+				sctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+				defer cancel()
+				shutdownDone <- s.Shutdown(sctx)
+			}()
+			awaitShutdownRefusal(t, s)
+
+			close(a.gate) // worker resumes with its ctx already cancelled
+
+			select {
+			case err := <-shutdownDone:
+				require.NoError(t, err)
+			case <-time.After(20 * time.Second):
+				t.Fatal("Shutdown did not return")
+			}
+
+			require.Equal(t, want, a.text(t, "t"),
+				"updates queued when Shutdown fired were dropped by ctx cancellation (#229)")
+		})
+	}
+}
+
+// TestPersistenceShutdown_ReturnsPromptlyWithoutProducers is the anti-hang
+// gate for #229: the failure mode of a wrong fix is a Shutdown that waits
+// forever for a producer that never appears. Rooms with no peers — idle
+// resident and Apply-created — must still let their workers exit.
+func TestPersistenceShutdown_ReturnsPromptlyWithoutProducers(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+		idle     time.Duration
+	}{
+		{"apply-created, coalescing", 0, 0},
+		{"apply-created, strict", -1, 0},
+		{"idle-resident, coalescing", 0, time.Hour},
+		{"idle-resident, strict", -1, time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &ctxAdapter{}
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+			s.RoomIdleTimeout = tc.idle
+
+			ctx := context.Background()
+			for _, room := range []string{"a", "b", "c"} {
+				require.NoError(t, s.Apply(ctx, room, func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+					transact(func(txn *crdt.Transaction) {
+						txn.GetText("t").Insert(txn, 0, room, nil)
+					})
+				}))
+			}
+
+			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			start := time.Now()
+			require.NoError(t, s.Shutdown(sctx), "Shutdown hung waiting for a producer that never appears (#229)")
+			require.Less(t, time.Since(start), 5*time.Second)
+		})
+	}
+}
+
+// TestPersistenceShutdown_ConcurrentCommitsRaceShutdown is the unsequenced
+// counterpart of the deterministic gate above: many goroutines commit while
+// Shutdown runs. It cannot prove the absence of loss on its own (which is why
+// the deterministic test exists), but under -race it exercises the producer /
+// worker handoff for interleavings a scripted test cannot reach, and it
+// asserts Shutdown still terminates.
+func TestPersistenceShutdown_ConcurrentCommitsRaceShutdown(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+	}{
+		{"coalescing enabled (default)", 0},
+		{"coalescing disabled", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &ctxAdapter{}
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+
+			ctx := context.Background()
+			require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+				transact(func(txn *crdt.Transaction) {
+					txn.GetText("t").Insert(txn, 0, "x", nil)
+				})
+			}))
+			doc := s.GetDoc("room")
+			require.NotNil(t, doc)
+
+			const writers = 8
+			const perWriter = 25
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			start := make(chan struct{})
+			for w := 0; w < writers; w++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					for i := 0; i < perWriter; i++ {
+						mu.Lock()
+						doc.Transact(func(txn *crdt.Transaction) {
+							txt := txn.GetText("t")
+							txt.Insert(txn, txt.Len(), "y", nil)
+						})
+						mu.Unlock()
+					}
+				}()
+			}
+
+			close(start)
+			sctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			require.NoError(t, s.Shutdown(sctx))
+			wg.Wait()
+
+			a.mu.Lock()
+			stored := len(a.updates)
+			a.mu.Unlock()
+			require.NotZero(t, stored)
+		})
+	}
+}

--- a/provider/websocket/persistence_shutdown_test.go
+++ b/provider/websocket/persistence_shutdown_test.go
@@ -305,6 +305,86 @@ func TestPersistenceShutdown_StrandedWaitIsBoundedByCtx(t *testing.T) {
 	close(a.releaseStore)
 }
 
+// TestPersistenceShutdown_ConcurrentShutdownCallersAllReturn covers the
+// stranded-write join under CONCURRENT Shutdown calls. shutdownOnce implies the
+// API tolerates them, and it does — but the join must release all of them, not
+// just whichever got there first. An earlier implementation woke waiters with a
+// single cap-1 token; the winner consumed it and every other caller sat until
+// its own context expired, turning a healthy shutdown into a spurious
+// DeadlineExceeded for all but one caller.
+//
+// Sequenced: the stranded write parks inside the adapter, which holds the
+// in-flight count above zero, so both callers are waiting on the same latch
+// before it is released.
+func TestPersistenceShutdown_ConcurrentShutdownCallersAllReturn(t *testing.T) {
+	const callers = 4
+
+	a := newStrandedGateAdapter()
+	s := ygws.NewServerWithPersistence(a)
+
+	ctx := context.Background()
+	require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+		transact(func(txn *crdt.Transaction) {
+			txn.GetText("t").Insert(txn, 0, "before", nil)
+		})
+	}))
+	doc := s.GetDoc("room")
+	require.NotNil(t, doc)
+
+	results := make(chan error, callers)
+	launch := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-launch
+			// Deliberately generous relative to the parked write below: a
+			// caller that returns DeadlineExceeded here did so because it was
+			// never woken, not because the work was slow.
+			sctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			results <- s.Shutdown(sctx)
+		}()
+	}
+	close(launch)
+
+	<-a.compactEntered
+
+	committed := make(chan struct{})
+	go func() {
+		defer close(committed)
+		doc.Transact(func(txn *crdt.Transaction) {
+			txt := txn.GetText("t")
+			txt.Insert(txn, txt.Len(), "-during", nil)
+		})
+	}()
+	awaitStrandedWriter(t, s)
+
+	close(a.releaseCompact)
+
+	select {
+	case <-a.storeEntered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the stranded write never reached the adapter")
+	}
+
+	// Every caller is now past the persistence join and parked on the
+	// stranded-write latch. Give the last of them time to get there, so the
+	// release below really does have to wake more than one.
+	time.Sleep(200 * time.Millisecond)
+	close(a.releaseStore)
+
+	for i := 0; i < callers; i++ {
+		select {
+		case err := <-results:
+			require.NoError(t, err,
+				"a concurrent Shutdown caller was never woken by the stranded-write join (#229)")
+		case <-time.After(15 * time.Second):
+			t.Fatal("a concurrent Shutdown caller never returned")
+		}
+	}
+	<-committed
+	require.Equal(t, "before-during", a.text(t, "t"))
+}
+
 // TestPersistenceShutdown_CommitDuringShutdownIsNotLost is the #229 regression
 // gate. A transaction committed while Shutdown is in flight — after the
 // persistence worker's final drain, before Shutdown returns — must reach the

--- a/provider/websocket/persistence_shutdown_test.go
+++ b/provider/websocket/persistence_shutdown_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,6 +70,239 @@ func (a *gateAdapter) text(t *testing.T, key string) string {
 		require.NoError(t, crdt.ApplyUpdateV1(d, u, nil))
 	}
 	return d.GetText(key).ToString()
+}
+
+// strandedGateAdapter parks in Compact (like gateAdapter) and then parks again
+// in the FIRST StoreUpdate that arrives after Compact was released — which, by
+// construction, is a stranded write performed by a committing goroutine rather
+// than by the worker. That second park is what lets a test ask the question
+// that matters to a caller: is Server.Shutdown still running while that write
+// is in flight, or has it already returned?
+type strandedGateAdapter struct {
+	mu      sync.Mutex
+	updates [][]byte
+
+	compactEntered chan struct{}
+	releaseCompact chan struct{}
+	compactOnce    sync.Once
+
+	armed        atomic.Bool
+	storeEntered chan struct{}
+	releaseStore chan struct{}
+	storeOnce    sync.Once
+}
+
+func newStrandedGateAdapter() *strandedGateAdapter {
+	return &strandedGateAdapter{
+		compactEntered: make(chan struct{}),
+		releaseCompact: make(chan struct{}),
+		storeEntered:   make(chan struct{}),
+		releaseStore:   make(chan struct{}),
+	}
+}
+
+func (a *strandedGateAdapter) LoadDoc(string) ([]byte, error) { return nil, nil }
+
+func (a *strandedGateAdapter) StoreUpdate(_ string, update []byte) error {
+	if a.armed.Load() {
+		a.storeOnce.Do(func() {
+			close(a.storeEntered)
+			<-a.releaseStore
+		})
+	}
+	cp := append([]byte(nil), update...)
+	a.mu.Lock()
+	a.updates = append(a.updates, cp)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *strandedGateAdapter) Compact(context.Context, string) error {
+	a.compactOnce.Do(func() {
+		close(a.compactEntered)
+		<-a.releaseCompact
+		a.armed.Store(true)
+	})
+	return nil
+}
+
+func (a *strandedGateAdapter) text(t *testing.T, key string) string {
+	t.Helper()
+	a.mu.Lock()
+	all := make([][]byte, len(a.updates))
+	copy(all, a.updates)
+	a.mu.Unlock()
+
+	d := crdt.New()
+	for _, u := range all {
+		require.NoError(t, crdt.ApplyUpdateV1(d, u, nil))
+	}
+	return d.GetText(key).ToString()
+}
+
+// awaitStrandedWriter blocks until at least one committing goroutine has
+// registered in the stranded-write path. Tests use it to order a commit ahead
+// of the worker's exit so they assert against Shutdown's join rather than
+// against the residual window the join cannot cover.
+func awaitStrandedWriter(t *testing.T, s *ygws.Server) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if ygws.StrandedWritesInFlight(s) > 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("no committing goroutine ever registered as a stranded writer")
+}
+
+// TestPersistenceShutdown_JoinsStrandedWrites asserts the property a caller can
+// actually rely on, which is stronger than "the write eventually happens":
+// Server.Shutdown must not return while a transaction committed during that
+// same Shutdown is still being written to the adapter.
+//
+// This distinction is not academic. The real producers are peer read loops,
+// which have no join point at all — nobody can wait for them on the caller's
+// behalf. The standard deployment shape is `srv.Shutdown(ctx)` and then return
+// from main; if Shutdown returns with a write in flight, the process exits and
+// the transaction is lost exactly as before, just through a narrower window.
+//
+// Deterministic in the GREEN direction: Shutdown provably cannot return while
+// the adapter is parked inside the stranded StoreUpdate. The RED direction uses
+// a bounded observation window — a Shutdown that does not join has nothing left
+// to do and returns immediately (with no relay attached it performs no further
+// work at all), so the window only has to be long enough to schedule it.
+func TestPersistenceShutdown_JoinsStrandedWrites(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+	}{
+		{"coalescing enabled (default)", 0},
+		{"coalescing disabled", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newStrandedGateAdapter()
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+
+			ctx := context.Background()
+			require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+				transact(func(txn *crdt.Transaction) {
+					txn.GetText("t").Insert(txn, 0, "before", nil)
+				})
+			}))
+
+			doc := s.GetDoc("room")
+			require.NotNil(t, doc)
+
+			shutdownDone := make(chan error, 1)
+			go func() {
+				sctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				shutdownDone <- s.Shutdown(sctx)
+			}()
+
+			<-a.compactEntered // worker is past its final drain
+
+			committed := make(chan struct{})
+			go func() {
+				defer close(committed)
+				doc.Transact(func(txn *crdt.Transaction) {
+					txt := txn.GetText("t")
+					txt.Insert(txn, txt.Len(), "-during", nil)
+				})
+			}()
+
+			// Sequence the commit ahead of the worker's exit. Without this the
+			// test would be measuring the acknowledged residual (a commit that
+			// starts after Shutdown reads the counter) instead of the join.
+			// Deterministic once observed: the committer registers before it
+			// can even read the retirement latch, and it then parks on a
+			// persistDone that cannot close until Compact is released below.
+			awaitStrandedWriter(t, s)
+
+			close(a.releaseCompact) // worker exits; the commit strands
+
+			select {
+			case <-a.storeEntered:
+			case <-time.After(10 * time.Second):
+				t.Fatal("the stranded write never reached the adapter")
+			}
+
+			// THE assertion: Shutdown is still running. Deliberately does NOT
+			// join the committing goroutine first — joining it would only prove
+			// the write happens eventually, which no caller can observe.
+			select {
+			case err := <-shutdownDone:
+				t.Fatalf("Shutdown returned (%v) while a transaction committed during "+
+					"that Shutdown was still in flight to the adapter (#229)", err)
+			case <-time.After(500 * time.Millisecond):
+			}
+
+			close(a.releaseStore)
+
+			select {
+			case err := <-shutdownDone:
+				require.NoError(t, err)
+			case <-time.After(30 * time.Second):
+				t.Fatal("Shutdown did not return after the stranded write completed")
+			}
+			<-committed
+
+			require.Equal(t, "before-during", a.text(t, "t"))
+		})
+	}
+}
+
+// TestPersistenceShutdown_StrandedWaitIsBoundedByCtx is the anti-hang half of
+// the join above, and the case with a producer actually present: a stranded
+// write that never completes must cost the caller its deadline and nothing
+// more — Shutdown reports ctx.Err() rather than blocking forever.
+func TestPersistenceShutdown_StrandedWaitIsBoundedByCtx(t *testing.T) {
+	a := newStrandedGateAdapter()
+	s := ygws.NewServerWithPersistence(a)
+
+	ctx := context.Background()
+	require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+		transact(func(txn *crdt.Transaction) {
+			txn.GetText("t").Insert(txn, 0, "before", nil)
+		})
+	}))
+	doc := s.GetDoc("room")
+	require.NotNil(t, doc)
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		sctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownDone <- s.Shutdown(sctx)
+	}()
+
+	<-a.compactEntered
+	go func() {
+		doc.Transact(func(txn *crdt.Transaction) {
+			txt := txn.GetText("t")
+			txt.Insert(txn, txt.Len(), "-during", nil)
+		})
+	}()
+	awaitStrandedWriter(t, s)
+	close(a.releaseCompact)
+
+	select {
+	case <-a.storeEntered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the stranded write never reached the adapter")
+	}
+
+	// The adapter is wedged. Shutdown must still come back on its deadline.
+	select {
+	case err := <-shutdownDone:
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"a wedged stranded write must surface as the caller's deadline, not as a lie")
+	case <-time.After(20 * time.Second):
+		t.Fatal("Shutdown hung on a stranded write that never completes (#229)")
+	}
+	close(a.releaseStore)
 }
 
 // TestPersistenceShutdown_CommitDuringShutdownIsNotLost is the #229 regression
@@ -336,11 +570,29 @@ func TestPersistenceShutdown_ReturnsPromptlyWithoutProducers(t *testing.T) {
 }
 
 // TestPersistenceShutdown_ConcurrentCommitsRaceShutdown is the unsequenced
-// counterpart of the deterministic gate above: many goroutines commit while
-// Shutdown runs. It cannot prove the absence of loss on its own (which is why
-// the deterministic test exists), but under -race it exercises the producer /
-// worker handoff for interleavings a scripted test cannot reach, and it
-// asserts Shutdown still terminates.
+// counterpart of the deterministic gates above: eight goroutines commit,
+// genuinely concurrently, while Shutdown runs. Under -race it exercises the
+// producer/worker handoff — and the contention on the fallback's own lock —
+// for interleavings a scripted test cannot reach.
+//
+// The producers are deliberately NOT serialised by a test-side mutex.
+// crdt.Doc.Transact is internally locked and the OnUpdate observers fire
+// outside that lock, so concurrent committers really are inside the observer
+// at once, which is the only way the post-retirement fallback's own
+// serialisation gets exercised at all.
+//
+// It asserts a property that IS sound under this race, rather than "something
+// was stored": every commit whose Transact had RETURNED before Shutdown
+// returned must be in the adapter. That follows from the design — by the time
+// the observer returns, the update has either been buffered while the
+// retirement latch was open (so the worker's final drain, which precedes
+// persistDone, which precedes Shutdown's own waits, takes it) or been written
+// synchronously by the committer. Commits still in flight when Shutdown
+// returns are excluded on purpose: that is the acknowledged residual, and a
+// test must not assert away a limit the code really has.
+//
+// Each commit sets a unique YMap key so persisted commits are individually
+// identifiable, which a shared YText cannot give.
 func TestPersistenceShutdown_ConcurrentCommitsRaceShutdown(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -357,16 +609,21 @@ func TestPersistenceShutdown_ConcurrentCommitsRaceShutdown(t *testing.T) {
 			ctx := context.Background()
 			require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
 				transact(func(txn *crdt.Transaction) {
-					txn.GetText("t").Insert(txn, 0, "x", nil)
+					txn.GetMap("m").Set(txn, "seed", "1")
 				})
 			}))
 			doc := s.GetDoc("room")
 			require.NotNil(t, doc)
 
+			// committed records keys whose Transact has already returned. It is
+			// appended to AFTER Transact returns, so a key present in a snapshot
+			// of it definitely finished committing before that snapshot.
+			var recMu sync.Mutex
+			committed := map[string]bool{"seed": true}
+
 			const writers = 8
 			const perWriter = 25
 			var wg sync.WaitGroup
-			var mu sync.Mutex
 			start := make(chan struct{})
 			for w := 0; w < writers; w++ {
 				wg.Add(1)
@@ -374,26 +631,105 @@ func TestPersistenceShutdown_ConcurrentCommitsRaceShutdown(t *testing.T) {
 					defer wg.Done()
 					<-start
 					for i := 0; i < perWriter; i++ {
-						mu.Lock()
+						key := fmt.Sprintf("w%d-%d", w, i)
 						doc.Transact(func(txn *crdt.Transaction) {
-							txt := txn.GetText("t")
-							txt.Insert(txn, txt.Len(), "y", nil)
+							txn.GetMap("m").Set(txn, key, "1")
 						})
-						mu.Unlock()
+						recMu.Lock()
+						committed[key] = true
+						recMu.Unlock()
 					}
 				}()
 			}
 
 			close(start)
-			sctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			sctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			require.NoError(t, s.Shutdown(sctx))
+
+			// Snapshot the instant Shutdown returns: everything in here had
+			// already finished committing, so all of it must be durable.
+			recMu.Lock()
+			mustBeDurable := make([]string, 0, len(committed))
+			for k := range committed {
+				mustBeDurable = append(mustBeDurable, k)
+			}
+			recMu.Unlock()
+
 			wg.Wait()
 
 			a.mu.Lock()
-			stored := len(a.updates)
+			all := make([][]byte, len(a.updates))
+			copy(all, a.updates)
 			a.mu.Unlock()
-			require.NotZero(t, stored)
+
+			d := crdt.New()
+			for _, u := range all {
+				require.NoError(t, crdt.ApplyUpdateV1(d, u, nil))
+			}
+			persisted := make(map[string]bool, len(d.GetMap("m").Keys()))
+			for _, k := range d.GetMap("m").Keys() {
+				persisted[k] = true
+			}
+			for _, k := range mustBeDurable {
+				require.True(t, persisted[k],
+					"commit %q returned before Shutdown returned but never reached the adapter (#229)", k)
+			}
+			require.NotEmpty(t, mustBeDurable)
+		})
+	}
+}
+
+// TestPersistence_PostTeardownCommitStillPersists characterises a real
+// behaviour change #229 makes, so it is not discovered by surprise.
+//
+// Before #229 the observer's escape hatch was `case <-r.persistStop:`, which
+// DROPPED the update; a room that had been torn down therefore never wrote
+// again. Nothing calls doc.Destroy on teardown, so a caller that retained the
+// *crdt.Doc (from GetDoc, or from an OnLoadDocument hook) keeps the observer
+// alive, and its later commits now reach the adapter instead of vanishing.
+//
+// That is the right behaviour — a committed transaction being silently
+// discarded is the bug this issue is about — but it widens the window in which
+// StoreUpdate can be called for a room name the server considers gone. See
+// CompactableAdapter's godoc for what that means for adapters.
+func TestPersistence_PostTeardownCommitStillPersists(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		coalesce time.Duration
+	}{
+		{"coalescing enabled (default)", 0},
+		{"coalescing disabled", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &ctxAdapter{}
+			s := ygws.NewServerWithPersistence(a)
+			s.PersistCoalesceWindow = tc.coalesce
+
+			ctx := context.Background()
+			require.NoError(t, s.Apply(ctx, "room", func(_ *crdt.Doc, transact func(func(*crdt.Transaction))) {
+				transact(func(txn *crdt.Transaction) {
+					txn.GetText("t").Insert(txn, 0, "before", nil)
+				})
+			}))
+
+			doc := s.GetDoc("room")
+			require.NotNil(t, doc)
+
+			require.NoError(t, s.CloseRoom("room", false))
+			require.Nil(t, s.GetDoc("room"), "the room is gone as far as the server is concerned")
+
+			doc.Transact(func(txn *crdt.Transaction) {
+				txt := txn.GetText("t")
+				txt.Insert(txn, txt.Len(), "-after", nil)
+			})
+
+			require.Equal(t, "before-after", a.text(t, "t"),
+				"a commit on a retained doc after teardown must be persisted, not dropped (#229)")
+
+			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			require.NoError(t, s.Shutdown(sctx))
 		})
 	}
 }

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -419,22 +419,49 @@ func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 // Compact folds the room's appended records into one, satisfying the optional
 // CompactableAdapter interface so the server's on-unload and CompactEvery
 // compaction work too (both are additive to this type's own threshold).
+//
+// The pending count folded is SNAPSHOTTED before the fold, and only that
+// snapshot is subtracted afterward — Compact never just deletes the entry.
+// MergeUpdatesV1 (invoked by the wrapped adapter, below) runs OUTSIDE m.mu, by
+// design: a large room's fold must never block another room's counter
+// update. That window is exactly what lets a concurrent StoreUpdate append
+// and increment pending[room] while this call is folding. That update was not
+// (or may not have been) included in the fold; deleting the entry regardless
+// — the pre-fix behaviour — erases its contribution, so the un-folded record
+// count can exceed CompactEvery indefinitely once writes stop (PR #230
+// review, reported against the line that used to read `delete(m.pending,
+// room)` unconditionally). Subtracting only the snapshot can occasionally
+// under-forgive the other way — a write that lands late enough to actually be
+// swept into this same fold still gets counted toward the next one — but that
+// is bounded (compacts at most one write early), never unbounded.
 func (m *MemoryPersistence) Compact(ctx context.Context, room string) error {
 	if m.adapter == nil {
 		return errMemoryPersistenceNotConstructed
 	}
+
+	m.mu.Lock()
+	snapshot := m.pending[room]
+	m.mu.Unlock()
+
 	err := m.adapter.Compact(ctx, room)
-	// Delete rather than zero: rooms come and go (idle eviction), and a map
-	// keyed by room name that is only ever zeroed grows with churn. Only on
-	// success — deleting after a failed fold would reset the counter and let
-	// records grow while the threshold never re-fires for a persistently
-	// failing fold.
-	if err == nil {
-		m.mu.Lock()
-		delete(m.pending, room)
-		m.mu.Unlock()
+	if err != nil {
+		// Best-effort per this type's own StoreUpdate doc: leave pending
+		// untouched on failure. Resetting it here would let records grow
+		// while the threshold never re-fires for a persistently failing fold.
+		return err
 	}
-	return err
+
+	m.mu.Lock()
+	// Delete rather than zero when nothing remains: rooms come and go (idle
+	// eviction), and a map keyed by room name that is only ever zeroed grows
+	// with churn.
+	if remaining := m.pending[room] - snapshot; remaining > 0 {
+		m.pending[room] = remaining
+	} else {
+		delete(m.pending, room)
+	}
+	m.mu.Unlock()
+	return nil
 }
 
 // room holds the shared document and awareness state for one named room.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -362,7 +362,11 @@ func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
 // with only a log line, because persistence.MemoryPersistence.AppendUpdate
 // returns ctx.Err() at entry. Measured impact of having implemented it: 51-151
 // of 200 concurrent writes dropped across trials during a concurrent Shutdown,
-// 0 dropped without it (#186).
+// attributable to this method (#186). This is not a claim that omitting it
+// makes such a Shutdown race lossless: a separate, pre-existing gap in the
+// coalescing-disabled shutdown drain (it drains its queue once and exits,
+// regardless of adapter) drops writes under the same repro shape and remains
+// open, filed separately.
 func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 	if m.adapter == nil {
 		return errMemoryPersistenceNotConstructed

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -272,8 +272,9 @@ const defaultMemoryCompactEvery = 500
 // The distinction is the point of #186: merging on every write costs
 // O(document) per flush and O(document²) over a session, which is exactly what
 // PersistenceAdapter's own doc warns adapters not to do. Appending costs
-// O(update); the O(document) fold is paid once per CompactEvery writes, so the
-// amortised per-write cost no longer grows with the document.
+// O(update); the O(document) fold is still paid, but only once per
+// CompactEvery writes rather than on every one — the O(document) cost is
+// divided by CompactEvery, not eliminated.
 //
 // It compacts ITSELF rather than waiting for Server.CompactEvery, which is off
 // by default (see that field's doc) — an adapter that only appended and waited
@@ -286,6 +287,10 @@ const defaultMemoryCompactEvery = 500
 //
 // Still primarily for tests and single-process deployments; a multi-process
 // deployment wants persistence/sqlite or another VersionedPersistence.
+//
+// Must be constructed with NewMemoryPersistence. The zero value has a nil
+// internal adapter; every method reports that with a plain error rather than
+// panicking, but there is no working zero value — always use the constructor.
 type MemoryPersistence struct {
 	adapter *persistence.LegacyAdapter
 
@@ -297,6 +302,15 @@ type MemoryPersistence struct {
 	mu      sync.Mutex
 	pending map[string]int // room → writes since that room last compacted
 }
+
+// errMemoryPersistenceNotConstructed is returned by every MemoryPersistence
+// method when called on the zero value (e.g. &MemoryPersistence{CompactEvery:
+// 2000}) instead of a value from NewMemoryPersistence. The zero value's
+// adapter field is nil; without this guard every method would nil-dereference,
+// and the persistence worker recovers panics from StoreUpdate, so an unguarded
+// panic here would present as total silent write loss with nothing but a log
+// line rather than an error that names the actual cause.
+var errMemoryPersistenceNotConstructed = errors.New("websocket: MemoryPersistence must be constructed with NewMemoryPersistence, not used as a zero value")
 
 // NewMemoryPersistence returns an empty MemoryPersistence.
 func NewMemoryPersistence() *MemoryPersistence {
@@ -318,9 +332,11 @@ func (m *MemoryPersistence) compactEvery() int {
 
 // LoadDoc returns the room's state as one V1 update, folding any outstanding
 // appended records first so later loads are cheap again. Compaction failure is
-// not fatal here: the fold is an optimisation, and the adapter can still
-// materialise the room from its records.
+// not fatal here: the adapter can still materialise the room from its records.
 func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
+	if m.adapter == nil {
+		return nil, errMemoryPersistenceNotConstructed
+	}
 	_ = m.Compact(context.Background(), room)
 	return m.adapter.LoadDoc(room)
 }
@@ -333,24 +349,25 @@ func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
 // persistence failures, and returning a compaction error would misreport a
 // successful write. This mirrors CompactableAdapter's own best-effort
 // contract. Callers who need the error can call Compact directly.
+//
+// This type deliberately does NOT implement PersistenceAdapterContext. An
+// in-memory append has nothing to abort, so a StoreUpdateContext forwarding to
+// the wrapped adapter would only cost writes: it would newly satisfy
+// PersistenceAdapterContext, switching the server's persistence worker onto
+// the ctx-aware path, and on the coalescing-disabled path the final shutdown
+// drain (see startPersistenceWorker's doc, persistence.go) reuses a ctx a
+// separate goroutine cancels concurrently with that same drain — no ordering
+// guarantee places "drain and store" before "cancel". A committed update still
+// sitting in the queue when that race goes the wrong way would be discarded
+// with only a log line, because persistence.MemoryPersistence.AppendUpdate
+// returns ctx.Err() at entry. Measured impact of having implemented it: 51-151
+// of 200 concurrent writes dropped across trials during a concurrent Shutdown,
+// 0 dropped without it (#186).
 func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
-	return m.storeThenMaybeCompact(context.Background(), room, update, false)
-}
-
-// StoreUpdateContext is the context-aware variant (PersistenceAdapterContext),
-// forwarded to the wrapped adapter so Shutdown can abort an in-flight write.
-func (m *MemoryPersistence) StoreUpdateContext(ctx context.Context, room string, update []byte) error {
-	return m.storeThenMaybeCompact(ctx, room, update, true)
-}
-
-func (m *MemoryPersistence) storeThenMaybeCompact(ctx context.Context, room string, update []byte, withCtx bool) error {
-	var err error
-	if withCtx {
-		err = m.adapter.StoreUpdateContext(ctx, room, update)
-	} else {
-		err = m.adapter.StoreUpdate(room, update)
+	if m.adapter == nil {
+		return errMemoryPersistenceNotConstructed
 	}
-	if err != nil {
+	if err := m.adapter.StoreUpdate(room, update); err != nil {
 		return err
 	}
 
@@ -361,7 +378,7 @@ func (m *MemoryPersistence) storeThenMaybeCompact(ctx context.Context, room stri
 	due := m.pending[room] >= m.compactEvery()
 	m.mu.Unlock()
 	if due {
-		_ = m.Compact(ctx, room) // best-effort; see this method's doc
+		_ = m.Compact(context.Background(), room) // best-effort; see this method's doc
 	}
 	return nil
 }
@@ -370,12 +387,20 @@ func (m *MemoryPersistence) storeThenMaybeCompact(ctx context.Context, room stri
 // CompactableAdapter interface so the server's on-unload and CompactEvery
 // compaction work too (both are additive to this type's own threshold).
 func (m *MemoryPersistence) Compact(ctx context.Context, room string) error {
+	if m.adapter == nil {
+		return errMemoryPersistenceNotConstructed
+	}
 	err := m.adapter.Compact(ctx, room)
 	// Delete rather than zero: rooms come and go (idle eviction), and a map
-	// keyed by room name that is only ever zeroed grows with churn.
-	m.mu.Lock()
-	delete(m.pending, room)
-	m.mu.Unlock()
+	// keyed by room name that is only ever zeroed grows with churn. Only on
+	// success — deleting after a failed fold would reset the counter and let
+	// records grow while the threshold never re-fires for a persistently
+	// failing fold.
+	if err == nil {
+		m.mu.Lock()
+		delete(m.pending, room)
+		m.mu.Unlock()
+	}
 	return err
 }
 

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -352,21 +352,20 @@ func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
 //
 // This type deliberately does NOT implement PersistenceAdapterContext. An
 // in-memory append has nothing to abort, so a StoreUpdateContext forwarding to
-// the wrapped adapter would only cost writes: it would newly satisfy
+// the wrapped adapter would buy nothing and would newly satisfy
 // PersistenceAdapterContext, switching the server's persistence worker onto
-// the ctx-aware path, and on the coalescing-disabled path the final shutdown
-// drain (see startPersistenceWorker's doc, persistence.go) reuses a ctx a
-// separate goroutine cancels concurrently with that same drain — no ordering
-// guarantee places "drain and store" before "cancel". A committed update still
-// sitting in the queue when that race goes the wrong way would be discarded
-// with only a log line, because persistence.MemoryPersistence.AppendUpdate
-// returns ctx.Err() at entry. Measured impact of having implemented it: 51-151
-// of 200 concurrent writes dropped across trials during a concurrent Shutdown,
-// attributable to this method (#186). This is not a claim that omitting it
-// makes such a Shutdown race lossless: a separate, pre-existing gap in the
-// coalescing-disabled shutdown drain (it drains its queue once and exits,
-// regardless of adapter) drops writes under the same repro shape and remains
-// open, filed separately.
+// its ctx-aware path purely to gain a cancellation this adapter cannot act on
+// — persistence.MemoryPersistence.AppendUpdate simply returns ctx.Err() at
+// entry, discarding the write.
+//
+// When this was briefly implemented during #186, that cost 51-151 of 200
+// concurrent writes across trials during a concurrent Shutdown, because the
+// shutdown drain then reused a ctx a separate goroutine cancels concurrently.
+// #229 has since fixed the worker side of that — every final flush now uses a
+// background ctx, and a store aborted by cancellation is retained and
+// re-stored rather than dropped, so a ctx-aware adapter no longer loses the
+// tail. The reason to stay off that path is now the plain one: cancellation
+// is a lever for adapters with something to abort, and this one has nothing.
 func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 	if m.adapter == nil {
 		return errMemoryPersistenceNotConstructed
@@ -439,6 +438,31 @@ type room struct {
 	persistCh   chan []byte   // buffered channel for serialised writes
 	persistStop chan struct{} // closed to signal goroutine to drain and exit
 	persistDone chan struct{} // closed when persistence goroutine exits
+
+	// persistRetire is closed by the persistence worker ITSELF as the first act
+	// of every exit path — before its final drain of persistCh, whatever
+	// triggered the exit (persistStop, or the server-wide shutdownCh). That
+	// ordering is the whole point, and it is what makes the handoff in
+	// loadRoom's doc.OnUpdate observer race-free (#229):
+	//
+	//	if a producer's send into persistCh completed while persistRetire was
+	//	still open, the worker's final drain — which strictly follows
+	//	close(persistRetire) — is guaranteed to see the buffered element;
+	//	otherwise the producer sees persistRetire closed and takes over the
+	//	write itself via persistStranded.
+	//
+	// Before #229 the worker exited on shutdownCh with no such latch, so every
+	// transaction committed after the one-shot drain landed in the 256-slot
+	// buffer with no reader and was lost without a trace — the exact opposite
+	// of the guarantee the package documents.
+	persistRetire chan struct{}
+
+	// persistFallbackMu serialises the post-retirement direct writes performed
+	// by persistStranded. doc.OnUpdate observers fire OUTSIDE the doc lock
+	// (crdt.buildPhase2), so two committing goroutines can be inside the
+	// observer at once; the adapter contract only promises serialised calls per
+	// room, so the fallback must provide that serialisation itself.
+	persistFallbackMu sync.Mutex
 
 	// flushReq requests an on-demand durable flush of the pending batch without
 	// stopping the worker. The worker drains persistCh, flushes with a
@@ -1470,12 +1494,40 @@ func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
 		r.persistCh = make(chan []byte, 256)
 		r.persistStop = make(chan struct{})
 		r.persistDone = make(chan struct{})
+		r.persistRetire = make(chan struct{})
 		r.flushReq = make(chan chan bool)
 		s.startPersistenceWorker(r, name)
 		r.doc.OnUpdate(func(update []byte, _ any) {
+			// #229 — handing the update to persistCh is only safe while the
+			// worker is still reading it. The worker publishes its retirement
+			// by closing persistRetire BEFORE its final drain, which gives this
+			// observer two airtight cases and no third one:
+			//
+			//   1. persistRetire is still open when the send completes. Then
+			//      close(persistRetire) — and therefore the final drain that
+			//      follows it — happens after the send, so the buffered element
+			//      is still there to be drained. Nothing to do.
+			//   2. persistRetire is already closed. A select whose case is a
+			//      closed channel is always ready, so the check below sees it
+			//      with certainty (no scheduling window), and this goroutine
+			//      takes over the write itself.
+			//
+			// The escape hatch must stay: without it a producer would block
+			// forever on a full 256-slot buffer once the worker has gone. What
+			// #229 changes is that the escape hatch now has a durable
+			// destination instead of dropping the update on the floor.
 			select {
 			case r.persistCh <- update:
-			case <-r.persistStop:
+				// Case 1 unless retirement began in between; re-check, since
+				// select picks uniformly among ready cases and may have taken
+				// the send even with persistRetire already closed.
+				select {
+				case <-r.persistRetire:
+					s.persistStranded(r, name, nil)
+				default:
+				}
+			case <-r.persistRetire:
+				s.persistStranded(r, name, update)
 			}
 		})
 	}

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -210,10 +210,30 @@ type PersistenceAdapterContext interface {
 // Server.CompactEvery > 0, after every N persistence flushes.
 //
 // Compact is invoked from the room's persistence worker goroutine, serialised
-// with StoreUpdate for that room, so implementations need no extra locking
-// against concurrent writes to the same room. It is best-effort: a returned
+// with StoreUpdate for that room INSTANCE, so implementations need no extra
+// locking against that worker's own writes. It is best-effort: a returned
 // error (or panic) is logged and does not abort persistence. Retention policy
 // (how much history to keep) is the adapter's concern.
+//
+// That serialisation is per room INSTANCE, not per room NAME — read this if
+// your Compact mutates shared state keyed by name. Two sources of overlap:
+//
+//   - Teardown followed by re-creation. A room's worker can still be in its
+//     exit-path Compact while a client reconnects and a brand-new room of the
+//     same name starts writing. This window predates #229 (see
+//     handleDisconnect's flush-then-evict sequence in peer.go).
+//   - A retained *crdt.Doc. Nothing calls doc.Destroy on teardown, so a caller
+//     holding the doc — from GetDoc, or from an OnLoadDocument hook — keeps its
+//     persistence observer alive, and every later commit is written directly by
+//     the committing goroutine (#229; before #229 those commits were silently
+//     dropped instead). Those writes are serialised among themselves, but not
+//     against a successor room of the same name, and they are unbounded in time.
+//
+// If your adapter's Compact is not safe against a concurrent StoreUpdate for
+// the same room name, serialise inside the adapter. Every store this repo ships
+// behind persistence.LegacyAdapter already does, each with a single mutex
+// covering all of its operations: persistence.MemoryPersistence,
+// persistence.FilePersistence, and persistence/sqlite.
 //
 // On room unload, Compact runs synchronously in the worker's exit path.
 // Compact is invoked with context.Background() (it is not cancelled by
@@ -610,6 +630,31 @@ type Server struct {
 
 	shutdownOnce sync.Once
 	shutdownCh   chan struct{} // closed by Shutdown
+
+	// strandedInFlight counts committing goroutines that are inside — or about
+	// to enter — the retirement branch of loadRoom's doc.OnUpdate observer,
+	// i.e. writes the room's persistence worker can no longer take and the
+	// committer must perform itself (#229). Shutdown waits for it to reach zero
+	// so it does not return while such a write is still on its way to the
+	// adapter; without that wait the fix would only NARROW the loss window,
+	// since the standard `srv.Shutdown(ctx); return` shape would let the process
+	// exit mid-write.
+	//
+	// It is incremented BEFORE the observer's outer select, not after the
+	// retirement branch is chosen. That ordering is required: an increment
+	// placed after the branch leaves a gap in which Shutdown could observe zero
+	// and return while a committer has already decided to write. The cost is
+	// two atomic adds on every committed transaction, which is deliberate —
+	// correctness of the shutdown join over a few nanoseconds on a path that
+	// already encodes an update and takes a channel.
+	//
+	// strandedWake (buffered, cap 1) wakes the waiter on each decrement. A
+	// dropped send is harmless: a waiter that is genuinely parked on the channel
+	// has by definition left the buffer empty, so the next decrement's send
+	// succeeds. A plain sync.WaitGroup is unusable here — producers appear at
+	// arbitrary times, so Add would race Wait.
+	strandedInFlight atomic.Int64
+	strandedWake     chan struct{}
 
 	// AuthFunc, if non-nil, is called before upgrading each incoming WebSocket
 	// connection. Return false to reject the connection; the server responds
@@ -1112,9 +1157,10 @@ func (s *Server) newPeerLimiter() *rate.Limiter {
 // NewServer returns a new Server with an empty room store and no persistence.
 func NewServer() *Server {
 	s := &Server{
-		rooms:       make(map[string]*room),
-		shutdownCh:  make(chan struct{}),
-		sweeperDone: make(chan struct{}),
+		rooms:        make(map[string]*room),
+		shutdownCh:   make(chan struct{}),
+		sweeperDone:  make(chan struct{}),
+		strandedWake: make(chan struct{}, 1),
 	}
 	s.upgrader = gws.Upgrader{CheckOrigin: s.checkOrigin}
 	return s
@@ -1212,6 +1258,27 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	case <-done:
 	case <-ctx.Done():
 	}
+
+	// Join the stranded writers (#229). A transaction committed during this
+	// Shutdown — peer read loops keep committing right through the connection
+	// closes above — may have arrived too late for its room's worker, in which
+	// case the committing goroutine performs the adapter write itself. It
+	// blocks on the same persistDone the loop above just waited for, so without
+	// this join Shutdown would routinely return with that write still in
+	// flight, and the usual `srv.Shutdown(ctx); return` shape would kill the
+	// process mid-write — the original bug through a narrower window.
+	//
+	// Placed HERE deliberately: after the persistence join (a stranded writer
+	// cannot even start until its worker has exited) and before the relay steps
+	// below, so #202's retire→drain→join→cancel ordering is untouched. Bounded
+	// by ctx like every other wait in this function, so a wedged adapter costs
+	// the caller its deadline and shows up as ctx.Err() rather than as a hang.
+	//
+	// This bounds what Shutdown can see; it is not a claim of losslessness. A
+	// commit that begins after the counter reads zero is not covered, and
+	// cannot be: peer read loops and any holder of a *crdt.Doc are producers
+	// the server has no way to join.
+	s.waitStranded(ctx)
 
 	// Wind down outbound relay delivery (#202), in three ordered steps. The
 	// peers are gone and the persistence drain is over, so nothing can feed
@@ -1516,6 +1583,16 @@ func (s *Server) loadRoom(ctx context.Context, r *room, name string) {
 			// forever on a full 256-slot buffer once the worker has gone. What
 			// #229 changes is that the escape hatch now has a durable
 			// destination instead of dropping the update on the floor.
+			//
+			// The enter/leave pair brackets the WHOLE observer, including the
+			// latch reads, so Shutdown can see this goroutine from before it
+			// decides whether it must write. Registering only inside the
+			// retirement branches would leave a gap in which Shutdown observes
+			// zero and returns while this goroutine is already committed to a
+			// write it has not started (see Server.strandedInFlight).
+			s.strandedEnter()
+			defer s.strandedLeave()
+
 			select {
 			case r.persistCh <- update:
 				// Case 1 unless retirement began in between; re-check, since

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -329,8 +329,60 @@ type MemoryPersistence struct {
 	// Set before serving; read without synchronisation.
 	CompactEvery int
 
-	mu      sync.Mutex
-	pending map[string]int // room → writes since that room last compacted
+	mu    sync.Mutex
+	rooms map[string]*compactLedger // room → append/fold bookkeeping
+}
+
+// compactLedger is MemoryPersistence's per-room compaction bookkeeping. The
+// two counters are MONOTONE and are never reset in place, which is what makes
+// concurrent compactions safe: appended only ever rises, and folded only ever
+// rises to a mark that was read BEFORE the fold that reports it began. The
+// outstanding (un-folded) count is the difference.
+//
+// The obvious alternative — one "writes since last compaction" counter that
+// each Compact snapshots and then subtracts from — is not safe under
+// concurrent compaction, because a snapshot taken by one Compact can be
+// consumed by another after a write that neither fold included (PR #230
+// review, second round). Two Compact calls can overlap for one room even
+// inside a plain Server: LoadDoc compacts before materialising, and since
+// v1.39 room loading runs off the global room-map lock, so a load can overlap
+// the previous residency's on-unload compaction for the same room. Direct use
+// of this exported, documented-thread-safe type can overlap them freely.
+type compactLedger struct {
+	// appended counts every update ever appended for this room.
+	appended int64
+	// folded is the appended-count that the most recent successful fold is
+	// known to have included. It advances only forward (max), so a fold that
+	// finishes late can never retract a later fold's progress.
+	folded int64
+	// inflight counts Compact calls currently folding this room. The entry
+	// must not be dropped while any of them still holds a mark to apply —
+	// dropping it would reset appended to 0 under them, and their folded mark
+	// would then read as a huge outstanding debt.
+	inflight int
+}
+
+// outstanding reports the un-folded write count.
+func (l *compactLedger) outstanding() int64 { return l.appended - l.folded }
+
+// ledgerLocked returns room's ledger, creating it if absent. Caller holds m.mu.
+func (m *MemoryPersistence) ledgerLocked(room string) *compactLedger {
+	l := m.rooms[room]
+	if l == nil {
+		l = &compactLedger{}
+		m.rooms[room] = l
+	}
+	return l
+}
+
+// dropIfIdleLocked deletes room's ledger once nothing is outstanding and no
+// compaction is still in flight for it. Rooms come and go (idle eviction), so
+// a map keyed by room name that is only ever zeroed grows with churn.
+// Caller holds m.mu.
+func (m *MemoryPersistence) dropIfIdleLocked(room string, l *compactLedger) {
+	if l.inflight == 0 && l.outstanding() <= 0 {
+		delete(m.rooms, room)
+	}
 }
 
 // errMemoryPersistenceNotConstructed is returned by every MemoryPersistence
@@ -350,7 +402,7 @@ func NewMemoryPersistence() *MemoryPersistence {
 	// folds a room down to a single record, preserving the one-blob-per-room
 	// memory shape this type has always had.
 	ad.KeepVersions = 1
-	return &MemoryPersistence{adapter: ad, pending: make(map[string]int)}
+	return &MemoryPersistence{adapter: ad, rooms: make(map[string]*compactLedger)}
 }
 
 func (m *MemoryPersistence) compactEvery() int {
@@ -407,8 +459,9 @@ func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 	// Decide under the lock, compact outside it: MergeUpdatesV1 on a large
 	// room must never block another room's counter update.
 	m.mu.Lock()
-	m.pending[room]++
-	due := m.pending[room] >= m.compactEvery()
+	l := m.ledgerLocked(room)
+	l.appended++
+	due := l.outstanding() >= int64(m.compactEvery())
 	m.mu.Unlock()
 	if due {
 		_ = m.Compact(context.Background(), room) // best-effort; see this method's doc
@@ -420,48 +473,55 @@ func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
 // CompactableAdapter interface so the server's on-unload and CompactEvery
 // compaction work too (both are additive to this type's own threshold).
 //
-// The pending count folded is SNAPSHOTTED before the fold, and only that
-// snapshot is subtracted afterward — Compact never just deletes the entry.
 // MergeUpdatesV1 (invoked by the wrapped adapter, below) runs OUTSIDE m.mu, by
-// design: a large room's fold must never block another room's counter
-// update. That window is exactly what lets a concurrent StoreUpdate append
-// and increment pending[room] while this call is folding. That update was not
-// (or may not have been) included in the fold; deleting the entry regardless
-// — the pre-fix behaviour — erases its contribution, so the un-folded record
-// count can exceed CompactEvery indefinitely once writes stop (PR #230
-// review, reported against the line that used to read `delete(m.pending,
-// room)` unconditionally). Subtracting only the snapshot can occasionally
-// under-forgive the other way — a write that lands late enough to actually be
-// swept into this same fold still gets counted toward the next one — but that
-// is bounded (compacts at most one write early), never unbounded.
+// design: a large room's fold must never block another room's counter update.
+// That window is what makes the bookkeeping delicate — a concurrent
+// StoreUpdate can append while this call is folding, and a concurrent Compact
+// can fold and report while this one is still in flight.
+//
+// The bookkeeping is therefore MONOTONE rather than snapshot-and-subtract.
+// This call reads the room's appended-count as its mark BEFORE folding, and on
+// success advances the room's folded-count to that mark only if it moves it
+// forward. Two properties follow, and both are needed:
+//
+//   - A write appended after this fold began is never forgiven by it, because
+//     the mark was read before it. Erasing such a write's contribution is what
+//     let the un-folded record count exceed CompactEvery indefinitely once
+//     writes stopped — the first round of this bug (PR #230 review), reported
+//     against a line that deleted the room's entry unconditionally.
+//   - A compaction that finishes late can never retract a later one's
+//     progress, because folded only moves forward. Subtracting a snapshot
+//     instead reintroduced the same erasure between two overlapping Compact
+//     calls — the second round of the same review.
+//
+// It can still under-forgive in the harmless direction: a write that lands
+// late enough to actually be swept into this fold is nonetheless counted
+// toward the next one, so the next compaction fires at most one write early.
+// That is bounded, and bounded-early is the correct way to be wrong here.
+//
+// On failure the ledger is left untouched, so the threshold re-fires rather
+// than letting records grow behind a persistently failing fold.
 func (m *MemoryPersistence) Compact(ctx context.Context, room string) error {
 	if m.adapter == nil {
 		return errMemoryPersistenceNotConstructed
 	}
 
 	m.mu.Lock()
-	snapshot := m.pending[room]
+	l := m.ledgerLocked(room)
+	mark := l.appended
+	l.inflight++
 	m.mu.Unlock()
 
 	err := m.adapter.Compact(ctx, room)
-	if err != nil {
-		// Best-effort per this type's own StoreUpdate doc: leave pending
-		// untouched on failure. Resetting it here would let records grow
-		// while the threshold never re-fires for a persistently failing fold.
-		return err
-	}
 
 	m.mu.Lock()
-	// Delete rather than zero when nothing remains: rooms come and go (idle
-	// eviction), and a map keyed by room name that is only ever zeroed grows
-	// with churn.
-	if remaining := m.pending[room] - snapshot; remaining > 0 {
-		m.pending[room] = remaining
-	} else {
-		delete(m.pending, room)
+	l.inflight--
+	if err == nil && mark > l.folded {
+		l.folded = mark
 	}
+	m.dropIfIdleLocked(room, l)
 	m.mu.Unlock()
-	return nil
+	return err
 }
 
 // room holds the shared document and awareness state for one named room.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/reearth/ygo/encoding"
 	"github.com/reearth/ygo/internal/relaylane"
 	"github.com/reearth/ygo/internal/roomname"
+	"github.com/reearth/ygo/persistence"
 	ygsync "github.com/reearth/ygo/sync"
 )
 
@@ -258,42 +259,124 @@ type VersionableAdapter interface {
 // be told apart from versions a user explicitly named.
 const AutoVersionLabel = "auto"
 
-// MemoryPersistence is a thread-safe in-memory PersistenceAdapter that merges
-// all updates into a single V1 snapshot per room. It is the default adapter
-// used when no external persistence is configured and is primarily useful in
-// tests and single-process deployments.
+// defaultMemoryCompactEvery is how many appended updates a room accumulates
+// before MemoryPersistence folds them back into one blob. It matches
+// provider/client's own compaction default so the two in-memory-ish stores
+// behave alike.
+const defaultMemoryCompactEvery = 500
+
+// MemoryPersistence is a thread-safe in-memory PersistenceAdapter. It APPENDS
+// each incremental update and periodically folds a room's backlog into a
+// single blob, rather than re-merging the whole document on every write.
+//
+// The distinction is the point of #186: merging on every write costs
+// O(document) per flush and O(document²) over a session, which is exactly what
+// PersistenceAdapter's own doc warns adapters not to do. Appending costs
+// O(update); the O(document) fold is paid once per CompactEvery writes, so the
+// amortised per-write cost no longer grows with the document.
+//
+// It compacts ITSELF rather than waiting for Server.CompactEvery, which is off
+// by default (see that field's doc) — an adapter that only appended and waited
+// to be told would grow without bound for anyone who had not opted in.
+//
+// Trade, stated plainly: LoadDoc is no longer O(1). It folds whatever records a
+// room still holds — bounded by CompactEvery — and persists that fold, so
+// subsequent loads are cheap again. Writes are continuous and loads are once
+// per room residency, so this is the right direction, but it is not free.
+//
+// Still primarily for tests and single-process deployments; a multi-process
+// deployment wants persistence/sqlite or another VersionedPersistence.
 type MemoryPersistence struct {
-	mu   sync.RWMutex
-	docs map[string][]byte // room → merged V1 update
+	adapter *persistence.LegacyAdapter
+
+	// CompactEvery bounds how many appended updates a room accumulates before
+	// this adapter folds them into one. 0 or less means the default (500).
+	// Set before serving; read without synchronisation.
+	CompactEvery int
+
+	mu      sync.Mutex
+	pending map[string]int // room → writes since that room last compacted
 }
 
 // NewMemoryPersistence returns an empty MemoryPersistence.
 func NewMemoryPersistence() *MemoryPersistence {
-	return &MemoryPersistence{docs: make(map[string][]byte)}
+	ad := persistence.NewLegacyAdapter(persistence.NewMemoryPersistence())
+	// MUST be explicit: KeepVersions defaults to 0, which means "keep all
+	// history" and makes Compact a silent no-op (persistence/adapter.go). 1
+	// folds a room down to a single record, preserving the one-blob-per-room
+	// memory shape this type has always had.
+	ad.KeepVersions = 1
+	return &MemoryPersistence{adapter: ad, pending: make(map[string]int)}
 }
 
-// LoadDoc returns the merged V1 update for room, or nil if none exists.
-func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.docs[room], nil
-}
-
-// StoreUpdate merges update into the stored snapshot for room.
-func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	existing := m.docs[room]
-	if len(existing) == 0 {
-		m.docs[room] = update
-		return nil
+func (m *MemoryPersistence) compactEvery() int {
+	if m.CompactEvery > 0 {
+		return m.CompactEvery
 	}
-	merged, err := crdt.MergeUpdatesV1(existing, update)
+	return defaultMemoryCompactEvery
+}
+
+// LoadDoc returns the room's state as one V1 update, folding any outstanding
+// appended records first so later loads are cheap again. Compaction failure is
+// not fatal here: the fold is an optimisation, and the adapter can still
+// materialise the room from its records.
+func (m *MemoryPersistence) LoadDoc(room string) ([]byte, error) {
+	_ = m.Compact(context.Background(), room)
+	return m.adapter.LoadDoc(room)
+}
+
+// StoreUpdate appends update, then folds the room once it has accumulated
+// CompactEvery writes.
+//
+// It returns ONLY the append error. A failed fold is swallowed deliberately:
+// the write itself succeeded, the server reports StoreUpdate errors as
+// persistence failures, and returning a compaction error would misreport a
+// successful write. This mirrors CompactableAdapter's own best-effort
+// contract. Callers who need the error can call Compact directly.
+func (m *MemoryPersistence) StoreUpdate(room string, update []byte) error {
+	return m.storeThenMaybeCompact(context.Background(), room, update, false)
+}
+
+// StoreUpdateContext is the context-aware variant (PersistenceAdapterContext),
+// forwarded to the wrapped adapter so Shutdown can abort an in-flight write.
+func (m *MemoryPersistence) StoreUpdateContext(ctx context.Context, room string, update []byte) error {
+	return m.storeThenMaybeCompact(ctx, room, update, true)
+}
+
+func (m *MemoryPersistence) storeThenMaybeCompact(ctx context.Context, room string, update []byte, withCtx bool) error {
+	var err error
+	if withCtx {
+		err = m.adapter.StoreUpdateContext(ctx, room, update)
+	} else {
+		err = m.adapter.StoreUpdate(room, update)
+	}
 	if err != nil {
 		return err
 	}
-	m.docs[room] = merged
+
+	// Decide under the lock, compact outside it: MergeUpdatesV1 on a large
+	// room must never block another room's counter update.
+	m.mu.Lock()
+	m.pending[room]++
+	due := m.pending[room] >= m.compactEvery()
+	m.mu.Unlock()
+	if due {
+		_ = m.Compact(ctx, room) // best-effort; see this method's doc
+	}
 	return nil
+}
+
+// Compact folds the room's appended records into one, satisfying the optional
+// CompactableAdapter interface so the server's on-unload and CompactEvery
+// compaction work too (both are additive to this type's own threshold).
+func (m *MemoryPersistence) Compact(ctx context.Context, room string) error {
+	err := m.adapter.Compact(ctx, room)
+	// Delete rather than zero: rooms come and go (idle eviction), and a map
+	// keyed by room name that is only ever zeroed grows with churn.
+	m.mu.Lock()
+	delete(m.pending, room)
+	m.mu.Unlock()
+	return err
 }
 
 // room holds the shared document and awareness state for one named room.

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -631,30 +631,40 @@ type Server struct {
 	shutdownOnce sync.Once
 	shutdownCh   chan struct{} // closed by Shutdown
 
-	// strandedInFlight counts committing goroutines that are inside — or about
-	// to enter — the retirement branch of loadRoom's doc.OnUpdate observer,
-	// i.e. writes the room's persistence worker can no longer take and the
-	// committer must perform itself (#229). Shutdown waits for it to reach zero
-	// so it does not return while such a write is still on its way to the
-	// adapter; without that wait the fix would only NARROW the loss window,
-	// since the standard `srv.Shutdown(ctx); return` shape would let the process
-	// exit mid-write.
+	// strandedInFlight counts committing goroutines that are anywhere inside
+	// loadRoom's doc.OnUpdate observer — EVERY commit, not only the ones that
+	// end up on the retirement branch and perform the adapter write themselves
+	// (#229). Shutdown waits for it to reach zero so it does not return while
+	// such a write is still on its way to the adapter; without that wait the fix
+	// would only NARROW the loss window, since the standard
+	// `srv.Shutdown(ctx); return` shape would let the process exit mid-write.
 	//
-	// It is incremented BEFORE the observer's outer select, not after the
-	// retirement branch is chosen. That ordering is required: an increment
-	// placed after the branch leaves a gap in which Shutdown could observe zero
-	// and return while a committer has already decided to write. The cost is
-	// two atomic adds on every committed transaction, which is deliberate —
-	// correctness of the shutdown join over a few nanoseconds on a path that
-	// already encodes an update and takes a channel.
+	// Counting every commit is not laziness, it is the requirement: the
+	// increment must happen BEFORE the observer's outer select, because an
+	// increment placed after the retirement branch is chosen leaves a gap in
+	// which Shutdown observes zero and returns while a committer has already
+	// decided to write. The cost is two atomic adds on every committed
+	// transaction, which is deliberate — correctness of the shutdown join over a
+	// few nanoseconds on a path that already encodes an update and takes a
+	// channel.
 	//
-	// strandedWake (buffered, cap 1) wakes the waiter on each decrement. A
-	// dropped send is harmless: a waiter that is genuinely parked on the channel
-	// has by definition left the buffer empty, so the next decrement's send
-	// succeeds. A plain sync.WaitGroup is unusable here — producers appear at
-	// arbitrary times, so Add would race Wait.
+	// The consequence of that breadth is worth stating, because it surfaces as a
+	// confusing error: a SUSTAINED producer — code holding a retained *crdt.Doc
+	// and committing in a loop — can keep this above zero indefinitely, so
+	// Shutdown burns its whole deadline and returns context.DeadlineExceeded
+	// with no wedged adapter anywhere. Callers who need Shutdown to return early
+	// must stop their writers, not only their connections.
+	//
+	// strandedZero is a broadcast latch, replaced-and-closed on each 1→0
+	// transition (see strandedBroadcast). A close rather than a token hand-off
+	// because Shutdown may legitimately be called concurrently — shutdownOnce
+	// implies as much — and a cap-1 wake token would be consumed by one caller,
+	// parking the others until their contexts expired. A plain sync.WaitGroup is
+	// unusable here for a different reason: producers appear at arbitrary times,
+	// so Add would race Wait.
 	strandedInFlight atomic.Int64
-	strandedWake     chan struct{}
+	strandedZeroMu   sync.Mutex
+	strandedZero     chan struct{}
 
 	// AuthFunc, if non-nil, is called before upgrading each incoming WebSocket
 	// connection. Return false to reject the connection; the server responds
@@ -1160,7 +1170,7 @@ func NewServer() *Server {
 		rooms:        make(map[string]*room),
 		shutdownCh:   make(chan struct{}),
 		sweeperDone:  make(chan struct{}),
-		strandedWake: make(chan struct{}, 1),
+		strandedZero: make(chan struct{}),
 	}
 	s.upgrader = gws.Upgrader{CheckOrigin: s.checkOrigin}
 	return s
@@ -1274,10 +1284,25 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// by ctx like every other wait in this function, so a wedged adapter costs
 	// the caller its deadline and shows up as ctx.Err() rather than as a hang.
 	//
-	// This bounds what Shutdown can see; it is not a claim of losslessness. A
-	// commit that begins after the counter reads zero is not covered, and
-	// cannot be: peer read loops and any holder of a *crdt.Doc are producers
-	// the server has no way to join.
+	// This bounds what Shutdown can see; it is not a claim of losslessness.
+	// Three limits, all real:
+	//
+	//   - A commit that begins after the counter reads zero is not covered, and
+	//     cannot be: peer read loops and any holder of a *crdt.Doc are producers
+	//     the server has no way to join.
+	//   - Neither is a room this function never enumerated. The snapshot above
+	//     is taken once and skips rooms still mid-load, and ServeHTTP has no
+	//     shutdownCh gate, so a connection accepted while Shutdown runs can
+	//     create a room — or finish loading one — afterwards. Nothing waits on
+	//     that room's persistDone, so a commit into it can return from Transact
+	//     with the update merely buffered. Callers who need the documented
+	//     guarantee must stop accepting connections BEFORE calling Shutdown
+	//     (see docs/PERSISTENCE.md). Pre-existing; recorded here because the
+	//     join above would otherwise read as covering it.
+	//   - Conversely the counter covers EVERY commit, not only the stranded
+	//     ones (that breadth is required — see Server.strandedInFlight), so a
+	//     sustained writer can hold this wait open until ctx expires even
+	//     though nothing is stuck.
 	s.waitStranded(ctx)
 
 	// Wind down outbound relay delivery (#202), in three ordered steps. The

--- a/provider/websocket/server.go
+++ b/provider/websocket/server.go
@@ -207,7 +207,12 @@ type PersistenceAdapterContext interface {
 // adapter implements it, the server calls Compact to signal a good time to
 // collapse stored updates for a room into a compact form (e.g. merge the update
 // log into a snapshot, prune old versions) — on room unload, and, when
-// Server.CompactEvery > 0, after every N persistence flushes.
+// Server.CompactEvery > 0, after every N persistence flushes on the
+// coalescing path (see Server.CompactEvery's own field doc and
+// startPersistenceWorker's doc for why: onFlushed, the call site that counts
+// those N flushes, is only reachable from there — the strict
+// (coalescing-disabled) path never calls it, so those deployments get
+// on-unload compaction only).
 //
 // Compact is invoked from the room's persistence worker goroutine, serialised
 // with StoreUpdate for that room INSTANCE, so implementations need no extra
@@ -231,9 +236,14 @@ type PersistenceAdapterContext interface {
 //
 // If your adapter's Compact is not safe against a concurrent StoreUpdate for
 // the same room name, serialise inside the adapter. Every store this repo ships
-// behind persistence.LegacyAdapter already does, each with a single mutex
-// covering all of its operations: persistence.MemoryPersistence,
-// persistence.FilePersistence, and persistence/sqlite.
+// behind persistence.LegacyAdapter already does, each serialising its writers
+// under a single mutex: persistence.MemoryPersistence and
+// persistence.FilePersistence do so for every operation, reads included;
+// persistence/sqlite's reads (Load, ListVersions, GetUpdate, MaterializeAt)
+// are deliberately lock-free instead and consistent by other means (see that
+// package's methods.go) — but its Compact and AppendUpdate are both writers
+// serialised under its own mutex, which is the property this section
+// actually depends on.
 //
 // On room unload, Compact runs synchronously in the worker's exit path.
 // Compact is invoked with context.Background() (it is not cancelled by


### PR DESCRIPTION
Closes #186. Closes #229. Closes #228.

## The bug

`provider/websocket.MemoryPersistence.StoreUpdate` called `crdt.MergeUpdatesV1(existing, update)` where `existing` was the **whole accumulated document** — O(document) per flush, ~O(document²) over a session. `PersistenceAdapter`'s own doc tells adapters to be append-only; this one wasn't.

## The fix

The correct implementation already existed in-repo, so this deletes bad code rather than inventing an algorithm: the type now wraps `persistence.MemoryPersistence` + `persistence.LegacyAdapter` (append-only, with `Compact`) and **compacts itself** on a per-room write threshold. Exported type and constructor are unchanged.

Self-compaction rather than relying on `Server.CompactEvery` is load-bearing: that field defaults to 0 (off), so an adapter that only appended and waited to be told would grow without bound for anyone who hadn't opted in — worse than the bug.

`KeepVersions = 1` is set explicitly on the wrapped adapter. It defaults to 0, which means "keep all history" and makes `Compact` a **silent no-op** that still passes every content-level test — so there's a regression gate asserting the record count actually collapses, proven by mutation.

## Measured

| N (updates in room) | before | after | improvement |
|---|---|---|---|
| 100 | 13,975 ns/op | 1,457 ns/op | 9.6× |
| 1,000 | 132,871 ns/op | 1,710 ns/op | 77.7× |
| 10,000 | 1,676,329 ns/op | 4,653 ns/op | **360×** |

**Stated honestly:** per-write cost is now `append + O(document)/CompactEvery` — the growth constant is divided by 500, **not eliminated**. Read literally, the issue's acceptance criterion ("flush cost no longer grows with doc size") is *not* fully met, and flat is not achievable for this storage model: `LoadDoc` must return the room as one V1 blob, so any bounded-record scheme has to periodically fold the whole document. Measured tracks the predicted `append + before/500` model within 2-3% at every rung.

**The trade:** `LoadDoc` is no longer O(1). It folds the room's outstanding records (bounded by `CompactEvery`) and persists that fold, so later loads are cheap again. Writes are continuous, loads happen once per room residency.

## Two corrections to the issue

1. **This is not "the shipped default adapter."** `NewServer()` has *no persistence*, and nothing under `provider/`, `cmd/`, or `examples/` constructs it outside tests. It's opt-in via `NewServerWithPersistence`, so the affected population is callers who explicitly chose it.
2. The benchmark the acceptance criterion cites measures a *different type* (`persistence.MemoryPersistence`) on a *different path* (`LoadDoc`, not `StoreUpdate`). A benchmark for the type actually at issue was added.

## Also here

- `docs/ARCHITECTURE.md`'s package map refreshed — it listed only `provider/{websocket,http}` and omitted five packages shipped between v1.19 and v1.48. Every arrow was verified against real imports with `go list`.
- Three doc sites that described the old merge-on-write behaviour corrected.
- The rest of the `docs/ARCHITECTURE.md` drift the plan had bounded out and flagged for a follow-up issue is **folded in here instead**, rather than opening another issue for work this size:
  - **"Garbage collection" documented an API that does not exist** — `doc.GC = true` / `doc.GC = false`. `Doc` has no exported `GC` field; the flag is set with `crdt.New(crdt.WithGC(false))`. Code copied from that section would not have compiled. It also covered only the automatic per-transaction pass, omitting that auto-GC is **suspended while any `UndoManager` is registered**, and omitting `crdt.RunGC`'s tombstone reclamation (#166) and its destructive effect on `RestoreDocument`.
  - **"Compatibility testing" described only the Yjs fixture layer**, omitting `testutil/fuzz` entirely — including `TestFuzzConvergenceMoves`, the oracle that found the `YArray.Move` divergence fixed in v1.40.0. All four oracles are now listed with what each proves, which need node, and how to replay a seed.
  - **`mobile`'s package doc understated its own bound surface** — it named only `*Doc` and `*Awareness`, omitting `*SyncClient` and `*Subscription`, and claimed the package exposes no callbacks. It exposes three observer *interfaces*, which is the only callback form `gomobile bind` supports in that direction. `ARCHITECTURE.md`'s `mobile/` section said the same and now matches.
  - One diagram note: the `┼` below `sync/` is a **crossing, not a junction** — the line through it is `awareness/` → `encoding/`. On a skim it read as `awareness/` feeding `crdt/`, which it does not.

## Notable review outcome

The whole-branch review caught something no per-task review could: an added `StoreUpdateContext` method made the type newly satisfy `PersistenceAdapterContext`, which flipped the server onto a code path whose shutdown drain runs with an already-cancelled context — **measured at 51-151 committed writes discarded per run**. The method is removed, and a test now asserts the type deliberately does *not* satisfy that interface, with the reason recorded.

That investigation also surfaced a **pre-existing** durability bug in shipped code, [#229](https://github.com/reearth/ygo/issues/229): the persistence worker's shutdown drain is one-shot while the producer never watches `shutdownCh`, so committed updates can land on an unread channel — in the *default* configuration, and contradicting a guarantee `persistence.go` explicitly documents. It's the persistence-side twin of #202. It was filed separately and initially deferred, then **fixed on this branch** at the maintainer's direction, along with the deferred `provider/client` follow-ups in [#228](https://github.com/reearth/ygo/issues/228). See the scope-expansion comment below for both.

## Release

`[1.49.0]` — MINOR: adds `Compact` and `CompactEvery`, removes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
