### PR TITLE
test(crdt): a benchmark that can actually see the observed-transaction cost (#180 follow-up)

### DIFF
--- a/crdt/bench_perf185_test.go
+++ b/crdt/bench_perf185_test.go
@@ -49,14 +49,6 @@ func newFragmentedDoc(n int) (*Doc, *YText) {
 	return doc, txt
 }
 
-func textItemCount(txt *YText) int {
-	n := 0
-	for it := txt.start; it != nil; it = it.Right {
-		n++
-	}
-	return n
-}
-
 // TestNewFragmentedDocIsFragmented guards the fixture. If a future change lets
 // these inserts merge, the benchmarks below would silently start measuring a
 // short item list while still reporting a large n — the exact failure that

--- a/crdt/bench_perf185_test.go
+++ b/crdt/bench_perf185_test.go
@@ -3,6 +3,7 @@ package crdt
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 )
 
@@ -14,11 +15,26 @@ import (
 // O(1) no matter how many characters the document holds.
 //
 // newFragmentedDoc builds a document that genuinely holds one item per
-// character, by inserting at random positions so no two inserts are contiguous
-// and nothing merges. It is O(n): an earlier version interleaved two clients
-// and synced them per character, which cost two encode+apply round trips per
-// character and was O(n^2) — 4k characters took 60ms, making large sizes
-// untestable.
+// character. It is O(n): an earlier version interleaved two clients and synced
+// them per character, which cost two encode+apply round trips per character and
+// was O(n^2) — 4k characters took 60ms, making large sizes untestable.
+//
+// Two independent properties keep it fragmented, and it is worth being precise
+// about which does what, because a future edit could remove one while believing
+// the other is doing the work:
+//
+//   - Each insert is its own transaction, so squashRuns — which only collapses
+//     a same-client run created within ONE transaction — never sees a run to
+//     collapse. Verified: 500 SEQUENTIAL end-inserts, one per transaction, still
+//     produce 500 distinct items.
+//   - Positions are random, so items are not contiguous in the linked list even
+//     when they do share a transaction. Verified: 500 random-position inserts in
+//     a SINGLE transaction also stay distinct.
+//
+// Note that randomness alone does not guarantee non-contiguity — two draws can
+// land adjacent — so the per-transaction property is the load-bearing one; the
+// random positions additionally split the seed item, which is why the item count
+// is n+4 rather than n+1.
 //
 // The RNG is seeded so the shape is identical across runs and machines.
 func newFragmentedDoc(n int) (*Doc, *YText) {
@@ -45,11 +61,35 @@ func textItemCount(txt *YText) int {
 // these inserts merge, the benchmarks below would silently start measuring a
 // short item list while still reporting a large n — the exact failure that
 // makes BenchmarkObservedTxn_Apply blind.
+//
+// It counts the inserted single-character items exactly rather than checking a
+// total against a threshold. A total-count check is too loose to be a guard: the
+// random inserts split the 4-character seed into as many as four items, so a
+// document that had quietly merged a handful of inserts could still clear a
+// "total >= n" bar and report success while measuring the wrong shape.
 func TestNewFragmentedDocIsFragmented(t *testing.T) {
 	const n = 2000
 	_, txt := newFragmentedDoc(n)
-	if got := textItemCount(txt); got < n {
-		t.Fatalf("fixture merged: %d items for %d inserts; the benchmarks would measure the wrong shape", got, n)
+
+	singles := 0
+	for it := txt.start; it != nil; it = it.Right {
+		cs, ok := it.Content.(*ContentString)
+		if !ok {
+			continue
+		}
+		if cs.Str == "x" {
+			singles++
+			continue
+		}
+		// Anything else must be a piece of the seed. An "x" that has merged
+		// with a neighbour shows up here as a longer run containing one.
+		if strings.Contains(cs.Str, "x") {
+			t.Fatalf("fixture merged: found item %q containing an inserted character; "+
+				"the benchmarks would measure a shorter item list than the n they report", cs.Str)
+		}
+	}
+	if singles != n {
+		t.Fatalf("fixture merged: %d distinct single-character items, want exactly %d", singles, n)
 	}
 }
 

--- a/crdt/bench_perf185_test.go
+++ b/crdt/bench_perf185_test.go
@@ -2,48 +2,107 @@ package crdt
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
-// buildFragmented returns a doc whose YText "t" holds n single-character items
-// that CANNOT merge: two clients alternate, so no two adjacent items share a
-// client. This is the shape a real multi-peer document takes, and the shape the
-// existing BenchmarkObservedTxn_Apply fails to produce.
-func buildFragmented(n int) (*Doc, *YText) {
+// ── Fragmented-document fixture ──────────────────────────────────────────────
+//
+// The pre-existing BenchmarkObservedTxn_Apply (bench_test.go) cannot see the
+// cost these benchmarks target: a single client appending merges into a handful
+// of ContentString items, so its observer walk is O(items) and effectively
+// O(1) no matter how many characters the document holds.
+//
+// newFragmentedDoc builds a document that genuinely holds one item per
+// character, by inserting at random positions so no two inserts are contiguous
+// and nothing merges. It is O(n): an earlier version interleaved two clients
+// and synced them per character, which cost two encode+apply round trips per
+// character and was O(n^2) — 4k characters took 60ms, making large sizes
+// untestable.
+//
+// The RNG is seeded so the shape is identical across runs and machines.
+func newFragmentedDoc(n int) (*Doc, *YText) {
 	doc := newTestDoc(1)
 	txt := doc.GetText("t")
-	other := newTestDoc(2)
-	otherTxt := other.GetText("t")
-	for i := 0; i < n/2; i++ {
-		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "a", nil) })
-		other.Transact(func(txn *Transaction) { otherTxt.Insert(txn, otherTxt.Len(), "b", nil) })
-		if err := ApplyUpdateV1(doc, EncodeStateAsUpdateV1(other, doc.StateVector()), nil); err != nil {
-			panic(err)
-		}
-		if err := ApplyUpdateV1(other, EncodeStateAsUpdateV1(doc, other.StateVector()), nil); err != nil {
-			panic(err)
-		}
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "seed", nil) })
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < n; i++ {
+		pos := rng.Intn(txt.Len())
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, pos, "x", nil) })
 	}
 	return doc, txt
 }
 
-func benchObservedFragmented(b *testing.B, n int, withObserver bool) {
-	doc, txt := buildFragmented(n)
-	if withObserver {
-		unsub := txt.Observe(func(YTextEvent) {})
-		defer unsub()
+func textItemCount(txt *YText) int {
+	n := 0
+	for it := txt.start; it != nil; it = it.Right {
+		n++
 	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "x", nil) })
+	return n
+}
+
+// TestNewFragmentedDocIsFragmented guards the fixture. If a future change lets
+// these inserts merge, the benchmarks below would silently start measuring a
+// short item list while still reporting a large n — the exact failure that
+// makes BenchmarkObservedTxn_Apply blind.
+func TestNewFragmentedDocIsFragmented(t *testing.T) {
+	const n = 2000
+	_, txt := newFragmentedDoc(n)
+	if got := textItemCount(txt); got < n {
+		t.Fatalf("fixture merged: %d items for %d inserts; the benchmarks would measure the wrong shape", got, n)
 	}
 }
 
-// The C1 gate (spec §7) compares the baseline-subtracted cost at 100k against
-// 1k. Both the observed and baseline variants are required: the difference
-// between them is the delta-computation cost, which is the quantity #185 is
-// about.
+// ── Observed-transaction cost ────────────────────────────────────────────────
+
+// benchObservedFragmented measures one single-character insert on a document of
+// roughly n items, with and without an observer attached. The difference
+// between the two is the cost of building the observer's delta.
+//
+// The rebuild guard is load-bearing. Each iteration inserts, so the document
+// grows as the benchmark runs; Go chooses b.N by timing progressively larger
+// runs, so without the guard the reported ns/op depends on b.N rather than on
+// n, and a size-labelled result would not describe the size it names. The
+// document is rebuilt (with the timer stopped) once it has grown 2% past n.
+func benchObservedFragmented(b *testing.B, n int, withObserver bool) {
+	doc, txt := newFragmentedDoc(n)
+	var unsub func()
+	if withObserver {
+		unsub = txt.Observe(func(YTextEvent) {})
+	}
+	defer func() {
+		if unsub != nil {
+			unsub()
+		}
+	}()
+
+	maxGrowth := n / 50
+	if maxGrowth < 1 {
+		maxGrowth = 1
+	}
+	grown := 0
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if grown >= maxGrowth {
+			b.StopTimer()
+			if unsub != nil {
+				unsub()
+				unsub = nil
+			}
+			doc, txt = newFragmentedDoc(n)
+			if withObserver {
+				unsub = txt.Observe(func(YTextEvent) {})
+			}
+			grown = 0
+			b.StartTimer()
+		}
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "x", nil) })
+		grown++
+	}
+}
+
 func BenchmarkObservedTxn_Fragmented(b *testing.B) {
 	for _, n := range []int{1_000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("n=%d/observed", n), func(b *testing.B) { benchObservedFragmented(b, n, true) })
@@ -51,9 +110,12 @@ func BenchmarkObservedTxn_Fragmented(b *testing.B) {
 	}
 }
 
-// BenchmarkItemAlloc_SingleCharInsert is E5's before/after measurement: the
-// allocs/op and B/op attributable to Origin, OriginRight and parentID being
-// *ID. Task 6 quotes the delta on #188.
+// ── Per-insert allocations ───────────────────────────────────────────────────
+
+// BenchmarkItemAlloc_SingleCharInsert reports allocs/op and B/op for one
+// single-character insert. Item.Origin, Item.OriginRight and Item.parentID are
+// *ID, and the allocations behind those pointers are what #188's item-origin
+// bullet is about.
 func BenchmarkItemAlloc_SingleCharInsert(b *testing.B) {
 	doc := newTestDoc(1)
 	txt := doc.GetText("t")
@@ -65,34 +127,35 @@ func BenchmarkItemAlloc_SingleCharInsert(b *testing.B) {
 	}
 }
 
-// BenchmarkDeleteSet_IsDeleted isolates E1's win at range counts that span the
-// crossover from linear-is-fine to binary-search-wins.
+// ── Delete-set lookup ────────────────────────────────────────────────────────
+
+// BenchmarkDeleteSet_IsDeleted measures IsDeleted against the number of delete
+// ranges held by one client.
+//
+// The small counts are the important ones, and an earlier version of this
+// benchmark omitted them. A transaction's delete set holds one range per
+// distinct deleted region, so ordinary editing produces 0 or 1 — a pure insert
+// produces an EMPTY set. Measuring only 1/10/100/1000 hides what happens in the
+// range where real workloads sit, and computeDelta calls IsDeleted once per
+// pre-existing item, so a fraction of a nanosecond here is multiplied by the
+// document's item count on every observed transaction.
 func BenchmarkDeleteSet_IsDeleted(b *testing.B) {
-	for _, ranges := range []int{1, 10, 100, 1_000} {
+	for _, ranges := range []int{0, 1, 2, 4, 8, 16, 100, 1_000} {
 		b.Run(fmt.Sprintf("ranges=%d", ranges), func(b *testing.B) {
 			ds := newDeleteSet()
 			for i := 0; i < ranges; i++ {
 				ds.add(ID{Client: 1, Clock: uint64(i * 4)}, 2)
 			}
-			probe := ID{Client: 1, Clock: uint64(ranges*4 - 3)} // worst case: last range
+			// Probe the LAST range, the worst case for a linear scan. With no
+			// ranges at all, probe a clock that cannot match.
+			probe := ID{Client: 1, Clock: 1}
+			if ranges > 0 {
+				probe = ID{Client: 1, Clock: uint64(ranges*4 - 3)}
+			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = ds.IsDeleted(probe)
 			}
 		})
 	}
-}
-
-func TestBuildFragmentedActuallyFragments(t *testing.T) {
-	doc, txt := buildFragmented(1000)
-	n := 0
-	for item := txt.start; item != nil; item = item.Right {
-		n++
-	}
-	// A merged doc would collapse to a handful of items. Require at least half
-	// the inserted characters to remain as distinct items.
-	if n < 500 {
-		t.Fatalf("expected a fragmented doc (>=500 items), got %d — the benchmark would be measuring the wrong shape", n)
-	}
-	_ = doc
 }

--- a/crdt/bench_perf185_test.go
+++ b/crdt/bench_perf185_test.go
@@ -1,0 +1,98 @@
+package crdt
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildFragmented returns a doc whose YText "t" holds n single-character items
+// that CANNOT merge: two clients alternate, so no two adjacent items share a
+// client. This is the shape a real multi-peer document takes, and the shape the
+// existing BenchmarkObservedTxn_Apply fails to produce.
+func buildFragmented(n int) (*Doc, *YText) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	other := newTestDoc(2)
+	otherTxt := other.GetText("t")
+	for i := 0; i < n/2; i++ {
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "a", nil) })
+		other.Transact(func(txn *Transaction) { otherTxt.Insert(txn, otherTxt.Len(), "b", nil) })
+		if err := ApplyUpdateV1(doc, EncodeStateAsUpdateV1(other, doc.StateVector()), nil); err != nil {
+			panic(err)
+		}
+		if err := ApplyUpdateV1(other, EncodeStateAsUpdateV1(doc, other.StateVector()), nil); err != nil {
+			panic(err)
+		}
+	}
+	return doc, txt
+}
+
+func benchObservedFragmented(b *testing.B, n int, withObserver bool) {
+	doc, txt := buildFragmented(n)
+	if withObserver {
+		unsub := txt.Observe(func(YTextEvent) {})
+		defer unsub()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "x", nil) })
+	}
+}
+
+// The C1 gate (spec §7) compares the baseline-subtracted cost at 100k against
+// 1k. Both the observed and baseline variants are required: the difference
+// between them is the delta-computation cost, which is the quantity #185 is
+// about.
+func BenchmarkObservedTxn_Fragmented(b *testing.B) {
+	for _, n := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("n=%d/observed", n), func(b *testing.B) { benchObservedFragmented(b, n, true) })
+		b.Run(fmt.Sprintf("n=%d/baseline", n), func(b *testing.B) { benchObservedFragmented(b, n, false) })
+	}
+}
+
+// BenchmarkItemAlloc_SingleCharInsert is E5's before/after measurement: the
+// allocs/op and B/op attributable to Origin, OriginRight and parentID being
+// *ID. Task 6 quotes the delta on #188.
+func BenchmarkItemAlloc_SingleCharInsert(b *testing.B) {
+	doc := newTestDoc(1)
+	txt := doc.GetText("t")
+	doc.Transact(func(txn *Transaction) { txt.Insert(txn, 0, "seed", nil) })
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc.Transact(func(txn *Transaction) { txt.Insert(txn, txt.Len(), "x", nil) })
+	}
+}
+
+// BenchmarkDeleteSet_IsDeleted isolates E1's win at range counts that span the
+// crossover from linear-is-fine to binary-search-wins.
+func BenchmarkDeleteSet_IsDeleted(b *testing.B) {
+	for _, ranges := range []int{1, 10, 100, 1_000} {
+		b.Run(fmt.Sprintf("ranges=%d", ranges), func(b *testing.B) {
+			ds := newDeleteSet()
+			for i := 0; i < ranges; i++ {
+				ds.add(ID{Client: 1, Clock: uint64(i * 4)}, 2)
+			}
+			probe := ID{Client: 1, Clock: uint64(ranges*4 - 3)} // worst case: last range
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = ds.IsDeleted(probe)
+			}
+		})
+	}
+}
+
+func TestBuildFragmentedActuallyFragments(t *testing.T) {
+	doc, txt := buildFragmented(1000)
+	n := 0
+	for item := txt.start; item != nil; item = item.Right {
+		n++
+	}
+	// A merged doc would collapse to a handful of items. Require at least half
+	// the inserted characters to remain as distinct items.
+	if n < 500 {
+		t.Fatalf("expected a fragmented doc (>=500 items), got %d — the benchmark would be measuring the wrong shape", n)
+	}
+	_ = doc
+}


### PR DESCRIPTION
Test-only. **No production code, no exported symbols, no wire change, no release needed.**

## Why

#180 added a benchmark suite so the performance claims in epic #189 could stop being argued and start being measured. Working through those claims revealed that the suite could not see the thing it was pointed at, in two separate ways — and that a claim can pass review, get implemented, and still be wrong when the benchmark agrees with it instead of testing it.

This PR makes the measuring device trustworthy. The findings it produced are going onto #189 separately.

## What was wrong

**1. The existing `BenchmarkObservedTxn_Apply` is blind by construction.** A single client appending merges into a handful of `ContentString` items, so its observer walk is O(items) and effectively O(1) no matter how many characters the document holds. It cannot detect a cost that scales with document size, which is exactly what it was meant to detect.

**2. The first version of the replacement measured a document that grew while being measured.** Every iteration inserts, and Go chooses `b.N` by timing progressively larger runs, so the reported ns/op tracked `b.N` rather than the size named in the sub-benchmark. Measured effect on the same fixture:

| | `n=1000/observed` |
|---|---|
| before this fix | 114,392 ns/op |
| after | ~7,300 ns/op |

Roughly 16x of the original figure was artifact. The document is now rebuilt, with the timer stopped, once it drifts 2% past `n`.

**3. The fixture was O(n²).** Interleaving two clients and syncing per character cost two encode+apply round trips per character: 1k took 4.9 ms, 4k took 60.6 ms, and larger sizes were untestable. `newFragmentedDoc` inserts at seeded-random positions instead — same fragmentation, one item per character, guarded by a test — and is linear: 50k builds in 103 ms.

**4. `BenchmarkDeleteSet_IsDeleted` sampled the wrong range counts.** It covered 1/10/100/1000 and skipped 0, 2, 4, 8, 16. A transaction's delete set holds one range per distinct deleted region, so ordinary editing produces 0 or 1 and a pure insert produces an empty set — the omitted region is where every real workload sits. `computeDelta` calls `IsDeleted` once per pre-existing item, so sub-nanosecond differences there are multiplied by the document's item count on every observed transaction.

## What it now measures

Stable across a 16x swing in iteration count, which is how the growth artifact is known to be gone:

| doc size | edit | with observer | observer cost |
|---|---|---|---|
| 1,000 | 0.9 µs | 7.3 µs | 6.4 µs |
| 10,000 | 1.5 µs | 83.9 µs | 82.4 µs |
| 100,000 | 8.6 µs | 1,308 µs | **1,299 µs** |

At 100k items, building the observer's delta costs about **1000x the edit itself**.

## Guards

- `TestNewFragmentedDocIsFragmented` fails if the fixture ever starts merging — the failure mode that makes the pre-existing benchmark blind.
- The rebuild guard's rationale is documented at the call site so the growth artifact is not reintroduced.
- The delete-set benchmark's small-range coverage carries a comment explaining why those counts are the important ones.

## Verification

- `go test -race ./crdt/...` green
- `go vet ./...` clean
- `gofmt` clean
- Exempt from the "Behaviour changes carry entries" job: the only changed file is `_test.go`

Refs #180, #185, #188, #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)