### PR TITLE
docs: release notes for v1.49.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.49.2] — 2026-09-01
+
+### Fixed
+
+- **Benchmarks: the observed-transaction benchmark could not measure what it
+  claimed.** Test-only; no library source changed in this release. Three
+  separate flaws made the #180 suite agree with the performance claims in #189
+  instead of testing them, which let one claim survive review and
+  implementation before measurement showed it was backwards.
+  - The pre-existing `BenchmarkObservedTxn_Apply` is blind by construction: a
+    single client appending merges into a handful of `ContentString` items, so
+    its observer walk is O(items) and effectively O(1) however many characters
+    the document holds.
+  - Its replacement measured a document that grew while being measured. Every
+    iteration inserts, and Go picks `b.N` by timing progressively larger runs,
+    so the reported ns/op tracked `b.N` rather than the size named in the
+    sub-benchmark. `n=1000/observed` reported 114,392 ns/op before the fix and
+    ~7,300 ns/op after: roughly 16x of the original figure was artifact. The
+    document is now rebuilt, with the timer stopped, once it drifts 2% past
+    `n`.
+  - The fixture was O(n^2) — two encode+apply round trips per character, so 4k
+    characters took 60ms and larger sizes were untestable. It is now linear:
+    50k builds in 103ms.
+- **Benchmarks: `BenchmarkDeleteSet_IsDeleted` sampled the wrong range
+  counts.** It covered 1/10/100/1000 and skipped 0, 2, 4, 8 and 16. A
+  transaction's delete set holds one range per distinct deleted region, so
+  ordinary editing produces 0 or 1 and a pure insert produces an empty set —
+  the omitted region is where every real workload sits. `computeDelta` calls
+  `IsDeleted` once per pre-existing item, so sub-nanosecond differences there
+  are multiplied by the document's item count on every observed transaction.
+
+See #189 for the measurements this produced, including one proposed
+optimisation that was implemented, reviewed, measured, and rejected.
+
 ## [1.49.1] — 2026-08-25
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+## v1.49.2
+
+**Who is affected: nobody's running code.** This release changes no library
+source — `crdt`, `provider`, `cluster`, `persistence` and `mobile` are
+byte-identical to v1.49.1. It ships one corrected benchmark file. If you are
+upgrading for a fix, you already have it.
+
+It is tagged so the corrected measurements have a version to cite.
+
+**What changed.** The benchmark suite added in #180 could not see the cost it
+was pointed at, in three separate ways, and that mattered: it agreed with the
+performance claims in #189 rather than testing them, so one proposed
+optimisation was implemented and reviewed clean before measurement showed it
+made the common path slower.
+
+- The suite's original observed-transaction benchmark is blind by construction.
+  A single client appending merges into a handful of items, so its walk is
+  effectively O(1) regardless of document size.
+- Its replacement measured a document that grew while being measured, so the
+  result described `b.N` rather than the document size it named. One figure was
+  16x artifact.
+- Its fixture was quadratic, which put realistic document sizes out of reach.
+- The delete-set benchmark sampled 1/10/100/1000 ranges and skipped 0/2/4/8/16,
+  which is where every real workload sits.
+
+**What it produced.** With a benchmark that measures the right shape, the
+performance epic went from nine asserted findings to one large measured one —
+building an observer's delta costs roughly 1000x the edit itself on a
+100k-item document — plus two rejections and three claims recorded as
+unverified. #189 now carries all of it, and #181, #184, #185 and #188 are
+closed into it.
+
+**Upgrade notes:** none. There is nothing to migrate and no behaviour change.
+
 ## v1.49.1
 
 **Who is affected: anyone whose documents have deletion history and who loads


### PR DESCRIPTION
Release docs for **v1.49.2**, a test-only release.

## What this release contains

One merged PR: #236, which fixed three measurement flaws in the #180 benchmark suite plus a range-sampling gap in the delete-set benchmark.

## What it does not contain

**No library source.** `crdt`, `provider`, `cluster`, `persistence` and `mobile` are byte-identical to v1.49.1 — verified with `git diff --name-only v1.49.1..main` filtered to non-test `.go` files outside `examples/` and `benchmarks/`, which returns nothing.

Both CHANGELOG and RELEASE_NOTES say this in the first line of their entry, so nobody upgrades expecting a fix that is not there.

## Note on precedent

This is the first tag in recent history for a release with no library change. The last ten tags all changed library source, and the directly comparable case — #197, the test/docs/CI-only benchmark suite — rode along in v1.41.0 rather than getting its own tag. CI's "Behaviour changes carry entries" job encodes the same convention: *"Tests, testdata, markdown, CI, tooling and examples ride along with the next release."*

Tagging anyway at the maintainer's direction, so the corrected measurements now cited on #189 have a stable version to reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)