### PR TITLE
fix(client): a rejected auth token could reach a second attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.49.3] — 2026-09-01
+
+### Fixed
+
+- **`provider/client`: a rejected auth token could be retried.** `Options.Token`
+  is documented as terminal — a server that refuses the token is reported once,
+  never retried — and `runReconnectLoop` enforces that by returning on
+  `ErrAuthRejected` before its backoff sleep. But both detectors for a rejection
+  live on the READ path: the `PermissionDenied` data frame and the 4401 close
+  code. The client writes the Auth frame and then immediately writes SyncStep1
+  without waiting for a reply, so when the server's rejection and close won that
+  race the SyncStep1 *write* failed, the read loop was never entered, and the
+  failure surfaced as an ordinary retryable I/O error. The reconnect loop then
+  dialled again with a token the server had already refused.
+
+  The rejection was not actually lost when this happened — data the peer sent
+  before closing stays readable even after the local write fails with `EPIPE` —
+  so the client was discarding evidence it already had. A handshake write
+  failure now drains the read side, bounded by 250ms and gated on
+  `Options.Token` being set, and reports `ErrAuthRejected` when it finds the
+  rejection in either form.
+
+  Present since v1.48.0. Observed as intermittent CI failures of
+  `TestClient_Auth_WrongTokenIsTerminal` with `authCalls=2` on v1.49.0's and
+  v1.49.2's `main` runs; that test could not reproduce it on demand, so the new
+  `TestClient_Auth_RejectionSurvivesHandshakeWriteFailure` forces the condition
+  deterministically with a test hook between the two handshake writes.
+
+  Impact is limited: the connection still terminates correctly with
+  `ErrAuthRejected`, so there was never an infinite retry, a hang, or data loss.
+  A rejected client made two authentication attempts instead of one, which
+  matters where a server counts auth failures for rate-limiting or lockout.
+
 ## [1.49.2] — 2026-09-01
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,34 @@
+## v1.49.3
+
+**Who is affected: anyone using `provider/client` with `Options.Token` against a
+server that can reject it.** If you do not set `Token`, nothing here changes for
+you.
+
+A rejected authentication token could be sent to the server twice instead of
+once. The client still gave up correctly after that — `Connect` returned
+`ErrAuthRejected` and stopped — so there was never an infinite retry loop, a
+hang, or any data loss. The practical impact is that a client with a bad
+credential made two failed authentication attempts, which matters if your server
+counts those toward rate-limiting or account lockout.
+
+**Why it happened.** The client announces its token and then immediately sends
+its opening sync message, without waiting for a reply. Both of the ways a
+rejection is recognised arrive on the *receiving* side. When the server rejected
+the token and closed fast enough, the client's second message failed to send, it
+never got as far as reading, and a refused credential looked like an ordinary
+network glitch — so it reconnected and tried the same token again.
+
+The rejection was not lost; it was sitting unread. A failed send does not mean
+the other side has stopped talking. The client now checks for it before deciding
+a failure was retryable.
+
+**Present since v1.48.0**, and in every release since. It surfaced as an
+intermittent CI failure that the existing test could not reproduce on demand;
+the new test forces the exact timing every run.
+
+**Upgrade notes:** none. No API change, no behaviour change for anyone not using
+`Token`.
+
 ## v1.49.2
 
 **Who is affected: nobody's running code.** This release changes no library

--- a/provider/client/auth_writefail_test.go
+++ b/provider/client/auth_writefail_test.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/encoding"
+)
+
+// withPostAuthWriteHook installs fn as loop.go's postAuthWriteHook for the
+// duration of the test. fn runs on the loop goroutine, strictly after the Auth
+// token frame has been written and strictly before the SyncStep1 that follows
+// it — the one point where a test can make that second write fail on purpose.
+func withPostAuthWriteHook(t *testing.T, fn func()) {
+	t.Helper()
+	orig := postAuthWriteHook
+	postAuthWriteHook = fn
+	t.Cleanup(func() { postAuthWriteHook = orig })
+}
+
+// rejectingRawServer is a bare y-websocket server that rejects the first frame
+// it reads with a PermissionDenied reply and a 4401 close, then hard-closes the
+// TCP connection (SO_LINGER 0 → RST) so a subsequent client write cannot
+// succeed. It reports each Auth frame it observes on authFrames, and closes
+// rejected once the hard close has happened.
+func rejectingRawServer(t *testing.T, authFrames *atomic.Int32, rejected chan struct{}) *httptest.Server {
+	t.Helper()
+	var once bool
+	up := gws.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			_ = conn.Close()
+			return
+		}
+		// Count only Auth (tag 2) frames — that is what OnTokenAuth counts
+		// on the real server, and what "was the token retried?" means.
+		if mt, body, derr := decodeEnvelope(payload); derr == nil && mt == wireMsgAuth {
+			_ = body
+			authFrames.Add(1)
+		}
+		_ = conn.WriteMessage(gws.BinaryMessage, encoding.EncodeBytes(func(enc *encoding.Encoder) {
+			enc.WriteVarUint(wireMsgAuth)
+			enc.WriteVarUint(authTypePermissionDenied)
+			enc.WriteVarString("bad token")
+		}))
+		_ = conn.WriteControl(gws.CloseMessage,
+			gws.FormatCloseMessage(wsCodeUnauthorized, "unauthorized"),
+			time.Now().Add(time.Second))
+		if nc := conn.UnderlyingConn(); nc != nil {
+			if tc, ok := nc.(*net.TCPConn); ok {
+				_ = tc.SetLinger(0) // force RST, so the client's next write fails
+			}
+		}
+		_ = conn.Close()
+		if !once {
+			once = true
+			close(rejected)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestClient_Auth_RejectionSurvivesHandshakeWriteFailure covers the gap that
+// made TestClient_Auth_WrongTokenIsTerminal fail intermittently on CI with
+// authCalls=2 (seen on v1.49.0's and v1.49.2's main runs).
+//
+// Both auth-rejection detectors live on the READ path: the PermissionDenied
+// data frame and the 4401 close code. But the client writes the Auth token and
+// then IMMEDIATELY writes SyncStep1 without waiting for a reply. If the server's
+// rejection and close win that race, the SyncStep1 WRITE fails, the read loop is
+// never entered, and the failure surfaces as an ordinary retryable I/O error —
+// so runReconnectLoop backs off and dials again with a token already rejected.
+//
+// The rejection is not actually lost when that happens: a probe confirmed that
+// data the peer sent before hard-closing stays readable even after the local
+// write fails with EPIPE. The client was simply discarding it by returning
+// early. This test pins that it no longer does.
+func TestClient_Auth_RejectionSurvivesHandshakeWriteFailure(t *testing.T) {
+	var authFrames atomic.Int32
+	rejected := make(chan struct{})
+	ts := rejectingRawServer(t, &authFrames, rejected)
+
+	// Deterministic, not racy: block the loop goroutine between the Auth write
+	// and the SyncStep1 write until the server has rejected and hard-closed, so
+	// the SyncStep1 write is guaranteed to fail.
+	withPostAuthWriteHook(t, func() {
+		select {
+		case <-rejected:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	c, err := New(Options{
+		URL:   "ws" + strings.TrimPrefix(ts.URL, "http") + "/room",
+		Doc:   crdt.New(),
+		Token: "wrong-token",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Connect(context.Background()) }()
+
+	var connectErr error
+	select {
+	case connectErr = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Connect did not return; the rejection was not recognised as terminal")
+	}
+
+	require.ErrorIs(t, connectErr, ErrAuthRejected,
+		"a rejection already sitting in the receive buffer must be recognised even though "+
+			"the SyncStep1 write failed before the read loop ran")
+
+	// reconnectBackoffBase is 500ms, so 2s covers several would-be retries.
+	time.Sleep(2 * time.Second)
+	require.Equal(t, int32(1), authFrames.Load(),
+		"the token was sent to the server more than once: a handshake write failure let a "+
+			"rejected token reach a second attempt")
+}

--- a/provider/client/loop.go
+++ b/provider/client/loop.go
@@ -107,6 +107,13 @@ var (
 // below simply does nothing) in production.
 var closeDrainHook = func() {}
 
+// postAuthWriteHook runs on the loop goroutine immediately after the Auth token
+// frame has been written and immediately before the SyncStep1 that follows it.
+// That gap is the one point where a test can make the SyncStep1 write fail on
+// purpose, which is the condition that used to let a rejected token reach a
+// second attempt — see auth_writefail_test.go. Always a no-op in production.
+var postAuthWriteHook = func() {}
+
 // dialNetDialContext, when non-nil, replaces gws.Dialer's own network-dial
 // function (see runLoop's dialer construction) for the calling test's
 // duration — the same "package-level indirection purely for test
@@ -138,6 +145,14 @@ var dialNetDialContext func(ctx context.Context, network, addr string) (net.Conn
 // letting only the ceiling be configurable is one fewer number an embedder
 // can get wrong for no real benefit.
 const reconnectBackoffBase = 500 * time.Millisecond
+
+// handshakeRejectionDrainTimeout bounds classifyHandshakeWriteErr's read of
+// whatever the peer managed to send before the handshake write failed. Short on
+// purpose: the data it is looking for was already in the receive buffer before
+// the write failed, so this never waits on the network in the case it exists to
+// serve — the bound only limits how long an unrelated failure can delay a
+// legitimate reconnect.
+const handshakeRejectionDrainTimeout = 250 * time.Millisecond
 
 // readDeadlineMultiplier is how many Options.PingInterval periods of total
 // silence (no pong, no data frame — see runLoop's keepalive section) this
@@ -535,8 +550,9 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	// comment.
 	if c.opts.Token != "" {
 		if err := s.write(encodeAuthToken(c.opts.Token)); err != nil {
-			return fmt.Errorf("client: send auth token: %w", err)
+			return s.classifyHandshakeWriteErr(fmt.Errorf("client: send auth token: %w", err))
 		}
+		postAuthWriteHook()
 	}
 
 	// Open with our state vector, so the server can send back exactly what
@@ -547,7 +563,7 @@ func (c *Client) runLoop(ctx context.Context, onSynced func()) error {
 	// anyway is what makes this client correct against a y-websocket server
 	// that DOES wait — and it costs one state vector.
 	if err := s.write(encodeEnvelope(wireMsgSync, ygsync.EncodeSyncStep1(c.opts.Doc))); err != nil {
-		return fmt.Errorf("client: send sync step 1: %w", err)
+		return s.classifyHandshakeWriteErr(fmt.Errorf("client: send sync step 1: %w", err))
 	}
 
 	for {
@@ -743,6 +759,62 @@ func (c *Client) runReconnectLoop(ctx context.Context) error {
 			c.dropLaneRemainder()
 			return nil
 		case <-timer.C:
+		}
+	}
+}
+
+// classifyHandshakeWriteErr upgrades a handshake write failure to
+// ErrAuthRejected when the server had already rejected this connection's token
+// and the rejection is still sitting unread in the receive buffer.
+//
+// Both auth-rejection detectors live on the READ path — the PermissionDenied
+// data frame (handleFrame's wireMsgAuth case) and the 4401 close code
+// (runLoop's readErr case). But this client writes the Auth token and then
+// SyncStep1 without waiting for a reply, so if the server's rejection and close
+// win that race the SECOND write fails and the read loop is never entered at
+// all. Without this, that surfaces as an ordinary retryable I/O error and
+// runReconnectLoop dials again with a token the server has already refused,
+// breaking the "reported once, never retried" guarantee ErrAuthRejected's doc
+// makes. It is exactly how TestClient_Auth_WrongTokenIsTerminal came to fail on
+// CI with authCalls=2, on v1.49.0's and v1.49.2's main runs.
+//
+// A failed write does not mean the read side has nothing left to say. Data the
+// peer sent before closing stays readable even after the local write fails with
+// EPIPE — verified, not assumed — so this drains what is already buffered and
+// looks for the rejection in either of the two forms it can take.
+//
+// Deliberately narrow, so an ordinary network failure is still retried:
+//   - only when Options.Token is set, matching the same gate runLoop's readErr
+//     case applies for the close code;
+//   - bounded by a short deadline, so a peer that is merely slow rather than
+//     rejecting cannot stall reconnection;
+//   - returns writeErr unchanged unless a rejection is actually found.
+func (s *session) classifyHandshakeWriteErr(writeErr error) error {
+	if s.c.opts.Token == "" {
+		return writeErr
+	}
+	if err := s.conn.SetReadDeadline(time.Now().Add(handshakeRejectionDrainTimeout)); err != nil {
+		return writeErr
+	}
+	for {
+		_, payload, err := s.conn.ReadMessage()
+		if err != nil {
+			// The close frame carries the rejection just as well as the data
+			// frame does, and survives an abrupt reset that truncates the
+			// payload — the same reasoning runLoop's readErr case documents.
+			if gws.IsCloseError(err, wsCodeUnauthorized) {
+				return fmt.Errorf("client: %w (via close code, after handshake write failed): %w",
+					ErrAuthRejected, writeErr)
+			}
+			return writeErr
+		}
+		mt, body, derr := decodeEnvelope(payload)
+		if derr != nil || mt != wireMsgAuth {
+			continue // not the frame we are looking for; keep draining
+		}
+		subType, reason, derr := decodeAuthReply(body)
+		if derr == nil && subType == authTypePermissionDenied {
+			return fmt.Errorf("client: %w: %s", ErrAuthRejected, reason)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the intermittent CI failure of `TestClient_Auth_WrongTokenIsTerminal` (`authCalls=2`) seen on v1.49.0's and v1.49.2's `main` runs. **Present since v1.48.0.**

## The bug

`Options.Token` is documented as terminal — a server that refuses the token is reported once, never retried — and `runReconnectLoop` enforces that by returning on `ErrAuthRejected` before its backoff sleep ([loop.go:722](provider/client/loop.go)).

But both detectors for a rejection live on the **read** path: the `PermissionDenied` data frame and the 4401 close code. The client writes the Auth frame and then **immediately** writes SyncStep1 without waiting for a reply. When the server's rejection and close win that race, the SyncStep1 **write** fails, the read loop is never entered, and the failure surfaces as an ordinary retryable I/O error — so the reconnect loop dials again with a token already refused.

## Why it's fixable

The rejection isn't lost. A probe confirmed that data the peer sent before hard-closing stays readable **even after the local write fails with `EPIPE`**:

```
write-after-close err = write: broken pipe
read-after-write-failure: data="DENIAL" err=<nil>
```

The client was discarding evidence it already had.

## The fix

`classifyHandshakeWriteErr` drains the read side on a handshake write failure and reports `ErrAuthRejected` when it finds the rejection in either form. Deliberately narrow so ordinary network failures still retry:

- gated on `Options.Token` being set — the same gate `runLoop`'s `readErr` case applies to the close code
- bounded by a 250ms deadline, so a merely-slow peer cannot stall reconnection
- returns the original error unchanged when no rejection is found

## Test

`TestClient_Auth_WrongTokenIsTerminal` asserts the right property but **cannot reproduce this on demand** — it passed 12/12 locally under `-race` with 8-way CPU contention. So the new test forces the condition deterministically: a raw server that rejects and hard-closes with `SO_LINGER 0`, plus a `postAuthWriteHook` (following the existing `closeDrainHook` pattern) that parks the loop goroutine between the two handshake writes until the server has closed.

Red/green verified: **3 auth frames before the fix, 1 after.**

## Impact

Limited. The connection still terminated correctly with `ErrAuthRejected`, so there was never an infinite retry, a hang, or data loss. A rejected client made two authentication attempts instead of one, which matters where a server counts auth failures for rate-limiting or lockout.

## Verification

- `go test -race ./...` — full tree green
- `TestClient_Auth_WrongTokenIsTerminal` — 10x under `-race`, green
- `golangci-lint run ./...` — 0 issues

Ships as v1.49.3; CHANGELOG and RELEASE_NOTES included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)