### PR TITLE
feat(cluster): Redis Streams relay tier with at-least-once delivery and bounded replay (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,77 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.0] — 2026-09-08
+
+### Added
+
+- **`cluster/redis`: an at-least-once delivery tier built on Redis Streams
+  (#206).** `Config.Transport` selects it; the zero value is `PubSub`, so every
+  existing deployment is unchanged and no new field has to be set.
+
+  Redis pub/sub is at-most-once by Redis's own definition: a subscriber that
+  cannot keep up loses the message for good, and no amount of client-side
+  buffering changes that. #187 asked for "no silent divergence on
+  backpressure" and PR #200 could only bound the damage. This tier delivers a
+  bounded version of it: each room becomes a Redis stream, and a reader that
+  stalls or restarts resumes from where it left off.
+
+  The guarantee is bounded and stated as such: **at-least-once within
+  `min(StreamRetention, StreamMaxLen / publish-rate)`** — defaults 60s and 4096
+  entries, the two enforced separately (`MAXLEN ~` inline on `XADD`, `XTRIM
+  MINID` on a `TrimInterval` sweeper), so whichever binds first is the real
+  window. 60s matches y-redis's own `REDIS_MIN_MESSAGE_LIFETIME`. It is not a
+  no-loss guarantee: a reader lagging past its room's window loses what was
+  trimmed underneath it, and `StreamStats.Gaps` makes that loss provable rather
+  than silent.
+
+  Sync streams are read from the **oldest retained entry**, not the tail. V1
+  updates are idempotent, so replay is harmless — which eliminates the race
+  between loading a snapshot and starting to read, and makes late-joiner
+  catch-up fall out for free. No cursor is persisted anywhere; a lost cursor
+  costs a replay, not a loss.
+
+  Under lane backpressure the reader declines to advance its cursor rather than
+  merging or dropping the backlog. The entries stay in the stream and are read
+  again next cycle, so backpressure toward Redis is safe here for the first
+  time — what it costs is lag, and lag past the window shows up as `Gaps`.
+
+  Awareness gets its own stream, read from the tail and never replayed. Sharing
+  the sync stream would let heartbeat traffic evict sync entries out of the
+  retention window, and replaying presence would resurrect clients that are
+  long gone. Awareness entries are excluded from gap accounting for the same
+  reason.
+
+  New `Config` fields: `Transport`, `StreamPrefix`, `StreamRetention`,
+  `StreamMaxLen`, `AwarenessMaxLen`, `AwarenessRetention`, `Readers`,
+  `TrimInterval`, `ReadBlock`. `New` **rejects** rather than silently adjusts:
+  an unknown `Transport`; a client `PoolSize` not greater than `Readers`; a
+  `TrimInterval` not less than `StreamRetention`; and a `ReadBlock` outside
+  `[1ms, 250ms]` — 250ms because a blocked `XREAD` cannot be interrupted, so
+  that value is also how long `Close` and a newly activated room may wait, and
+  1ms because go-redis truncates sub-millisecond values to `BLOCK 0`, which
+  Redis reads as "block forever". Nothing is validated in `PubSub` mode.
+
+  New `StreamStats` and `(*Relay).StreamStats()` report `Replayed`, `Gaps`,
+  `Restarts`, `Trimmed`, `Stalled` and `Deferred`. `Gaps` counts provable
+  losses via a sequence number that is monotonic per **(node, stream)** — a
+  per-node counter would report a hole every time a node published to a second
+  room — and should be alerted on by presence, not by rate. `Stalled` and
+  `Deferred` count the two reasons a cursor advance is declined and are kept
+  apart deliberately: one asks for capacity, the other is an activation bug.
+  `StreamStats` is separate from `Stats` because each type's fields are
+  permanently zero under the other tier.
+
+  Pub/sub remains **supported, not deprecated**: `PUBLISH` costs nothing, while
+  `XADD` is a write with replication, AOF/RDB, and memory proportional to
+  `retention × rate × update size`. At-most-once is a legitimate choice.
+  Migration is `Both` mode, which publishes to and reads from both tiers and
+  needs no deduplication — roll every node to `Both`, then roll every node to
+  `Streams`. Redis Cluster is deliberately unsupported: a multi-key `XREAD`
+  needs one hash slot, and forcing one would bake `Readers` into key names, so
+  a config typo would have two nodes addressing different streams for the same
+  room. See [docs/CLUSTERING.md](docs/CLUSTERING.md).
+
 ## [1.49.5] — 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a config typo would have two nodes addressing different streams for the same
   room. See [docs/CLUSTERING.md](docs/CLUSTERING.md).
 
+  Review fixes folded into the tier before release: a sync payload pushed onto
+  a lane whose worker was retired between the reader resolving it and the push
+  no longer advances that stream's cursor, so the entries are re-read for the
+  successor residency instead of being skipped; a **negative** `ReadBlock` is
+  rejected as documented rather than defaulted to 250ms (only the unset value
+  defaults); the `XTRIM MINID` cutoff is derived from the **Redis server's**
+  clock via `TIME` rather than the application host's, so a skewed app node can
+  no longer trim entries that are still inside the window (a failed `TIME`
+  skips the sweep), and the sweep pipelines its `XTRIM`s in chunks instead of
+  one round trip per key, which the 10,000-room target needs to finish inside
+  `TrimInterval`. Three documentation overclaims were corrected with them:
+  `StreamStats.Gaps` detects jumps only after this process has observed a
+  baseline for a source (loss during a reader's own downtime is bounded by the
+  retention window, not reported), and the idle `XREAD` rate is room-dependent
+  — `Readers × ceil(2 × rooms ÷ Readers ÷ 512) ÷ ReadBlock`, i.e. ~160/s at
+  10,000 rooms, not the 16/s that holds only for a single batch per reader.
+
 ## [1.49.5] — 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.50.0] — 2026-09-08
+## [1.50.0] — 2026-09-10
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ func main() {
 - **The y-protocols layer** — the `SyncStep1`/`SyncStep2`/incremental-update handshake, and awareness for presence and cursors.
 - **Transport-agnostic core** — the CRDT has no transport dependency; the WebSocket and HTTP bindings are addons.
 - **A production WebSocket server** — [Hocuspocus](https://tiptap.dev/docs/hocuspocus)-compatible, scaling horizontally across instances through a Redis-backed [cluster relay](docs/CLUSTERING.md), with versioned [persistence](docs/PERSISTENCE.md) (including a CGo-free SQLite store), snapshots, and a turnkey [`ygo-server`](cmd/ygo-server/) binary.
+- **Two cluster delivery tiers** — the Redis [cluster relay](docs/CLUSTERING.md) runs on pub/sub (the default, at-most-once, free to publish) or on Redis Streams, which is at-least-once within `min(StreamRetention, StreamMaxLen/rate)` and makes anything trimmed past that window a visible, counted `Gaps` rather than silent divergence. `Both` mode migrates a live cluster between them without deduplication.
 - **An embeddable offline-first client** — [`provider/client`](docs/CLIENT.md) is a `*crdt.Doc` that is readable and editable whether or not it has ever connected, hydrated from a local store before any dial. There is no separate offline-op queue: the sync handshake itself carries edits made while disconnected.
 - **Native mobile bindings** — [`mobile/`](mobile/) embeds in iOS and Android apps via `gomobile bind`, with on-device editing, sync, presence, change observers, and a self-syncing `mobile.SyncClient`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,14 +31,26 @@ single `Gaps` means the window was too small for how far behind that node
 actually got. Size the window for the worst delay you intend to survive: a
 deploy rollover, a long garbage-collection pause, a node restart.
 
+One limit on that visibility, stated plainly: `Gaps` detects a jump only after
+the process has seen a baseline for the publishing node, and those baselines
+live in memory. A relay that has just restarted takes whatever sequence number
+it reads first as its baseline, so anything trimmed away **while it was down**
+leaves `Gaps` at zero. Loss over a reader's own downtime is bounded by the
+retention window rather than reported — which is the other reason to size the
+window for your restart and deploy times.
+
 **What it costs, and why pub/sub is still here.** Publishing to pub/sub costs
 Redis nothing: it hands the message to whoever is listening and forgets it.
 Writing to a stream is a real write — it replicates, it goes into your AOF/RDB
 if you have persistence on, and it holds memory proportional to
 `retention × update rate × update size` for every room on the node (roughly
 800KB per busy room at the defaults). Reading costs a small steady stream of
-commands even when nothing is happening — 16 per second per node at the
-defaults.
+commands even when nothing is happening, and that cost **grows with how many
+rooms a node holds**: each reader issues one `XREAD` per 512 stream keys, and
+each room has two, so an idle node costs `Readers × ceil(2 × rooms ÷ Readers ÷
+512) ÷ ReadBlock` commands per second — 16 per second at the defaults for a
+node under about a thousand rooms, and roughly 160 per second at ten thousand.
+Size Redis from the formula rather than from the small-cluster figure.
 
 **Size Redis for every room you have ever used, not for the rooms in use at
 once.** The retention window bounds how big each room's stream gets; it does

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,18 +40,37 @@ if you have persistence on, and it holds memory proportional to
 commands even when nothing is happening — 16 per second per node at the
 defaults.
 
+**Size Redis for every room you have ever used, not for the rooms in use at
+once.** The retention window bounds how big each room's stream gets; it does
+not bound how many streams exist. This release sets no expiry on stream keys,
+and the trimmer only visits rooms a node currently holds, so once a room has
+gone quiet everywhere its two keys stay where they are, holding their last
+window, for as long as that Redis instance lives. If your room names are a
+bounded set of documents, that is a one-off ceiling you can multiply out. If
+they are per-session or per-tenant and unbounded, budget for the whole history
+or delete the keys from an operations job in the meantime. Expiring idle keys
+automatically is the intended fix and is tracked as a follow-up issue.
+
 So pub/sub is **not deprecated and is not going away**. At-most-once is a
 legitimate choice when your rooms are hot, your Redis is sized for fan-out
 rather than for writes, and catching up from storage on reload is good enough
 for you. Choose Streams when a missed update between reloads is not acceptable
 to you, and pay for it in Redis memory and write throughput.
 
-**Migrating a live cluster without splitting it.** The two mechanisms do not
-talk to each other: a Streams node does not publish to pub/sub, so a pub/sub
-node never sees its edits. Switching a running cluster straight over would
-therefore split it for the length of the rollout. There is a third setting for
-this, `Transport: Both`, which publishes to and reads from both mechanisms at
-once:
+**Migrating a live cluster without splitting it.** A mixed cluster delivers in
+one direction only. A Streams node does not publish to pub/sub, so a pub/sub
+node never sees its edits — that half is what matters, and it is why switching
+a running cluster straight over would leave half of it deaf for the length of
+the rollout. The other half crosses: this release does not gate the *receiving*
+side on the setting, so a Streams node still subscribes to its rooms' pub/sub
+channels and does apply what a pub/sub node publishes. Do not rely on that —
+it means a half-migrated cluster is one-way rather than symmetric, and it also
+means choosing Streams does not by itself remove the pub/sub connection from
+the node's Redis footprint. Gating the receiving side too is tracked as a
+follow-up issue.
+
+The way through is the third setting, `Transport: Both`, which publishes to and
+reads from both mechanisms at once:
 
 1. Roll every node from the default to `Both`.
 2. Once no pub/sub-only node is left, roll every node from `Both` to `Streams`.
@@ -78,10 +97,15 @@ state rather than somewhere to stay.
 
 **What to watch.** `Relay.StreamStats()` is new and separate from the existing
 `Relay.Stats()`. Alert on `Gaps` **appearing at all**; alert on a sustained
-*rate* of `Replayed` (cursors being lost repeatedly), `Stalled` (a room's local
-consumer cannot keep up) or `Deferred` (rooms being read before they are
-ready). `Trimmed` and `Restarts` are informational — the second one exists so
-that a node restarting is never miscounted as data loss.
+*rate* of `Stalled` (a room's local consumer cannot keep up) or `Deferred`
+(rooms being read before they are ready). `Trimmed` and `Restarts` are
+informational — the second one exists so that a node restarting is never
+miscounted as data loss. `Replayed` is a **batching gauge, not an alarm**: it
+counts the entries a reader merged into one update instead of pushing them one
+by one, so any room taking more than about four remote updates a second shows a
+permanent rate at the default read interval, and that is the tier working
+normally. Use it to watch inbound volume and to see catch-up bursts stand out
+against a room's own baseline; do not put a threshold on it.
 [docs/CLUSTERING.md](docs/CLUSTERING.md) has the full posture.
 
 **One note for anyone who ran this from the branch before release.** The stream

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,7 +49,7 @@ window, for as long as that Redis instance lives. If your room names are a
 bounded set of documents, that is a one-off ceiling you can multiply out. If
 they are per-session or per-tenant and unbounded, budget for the whole history
 or delete the keys from an operations job in the meantime. Expiring idle keys
-automatically is the intended fix and is tracked as a follow-up issue.
+automatically is the intended fix and is tracked in #248.
 
 So pub/sub is **not deprecated and is not going away**. At-most-once is a
 legitimate choice when your rooms are hot, your Redis is sized for fan-out
@@ -66,8 +66,8 @@ side on the setting, so a Streams node still subscribes to its rooms' pub/sub
 channels and does apply what a pub/sub node publishes. Do not rely on that —
 it means a half-migrated cluster is one-way rather than symmetric, and it also
 means choosing Streams does not by itself remove the pub/sub connection from
-the node's Redis footprint. Gating the receiving side too is tracked as a
-follow-up issue.
+the node's Redis footprint. Gating the receiving side too is tracked
+in #249.
 
 The way through is the third setting, `Transport: Both`, which publishes to and
 reads from both mechanisms at once:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,97 @@
+## v1.50.0
+
+**Who is affected: nobody, unless you choose to be.** This release adds a
+second way for `cluster/redis` to move updates between nodes. The existing way
+is the default and is unchanged — if you do not set the new
+`Config.Transport` field, your cluster behaves exactly as it did in v1.49.x,
+down to the Redis commands it issues.
+
+**What you may want to opt into.** Until now, a multi-node deployment relayed
+updates over Redis pub/sub, which is *at-most-once*: if a node cannot keep up
+with the stream of messages — a slow moment, a network blip, Redis
+disconnecting a client whose buffer overflowed — the messages it missed are
+gone. Nothing reports it. Because collaborative updates depend on each other,
+one missed update quietly parks every later edit from that same client on that
+node, and the node only catches up when the room is next loaded from storage.
+On a busy room that is never loaded again, so it never catches up.
+
+`Transport: Streams` replaces that mechanism with Redis Streams, which keep
+recent messages instead of forgetting them. A node that falls behind, restarts,
+or joins late reads what it missed instead of losing it.
+
+**What it guarantees, precisely.** Delivery is at-least-once **within the
+window Redis is asked to retain** — `min(StreamRetention, StreamMaxLen ÷ your
+publish rate)`, 60 seconds and 4096 messages per room by default. This is not a
+no-loss guarantee and we will not describe it as one: the retained history is
+trimmed at both ends, so a node that falls further behind than the window loses
+whatever was trimmed underneath it. The difference from pub/sub is not that
+loss became impossible. It is that loss became **bounded and visible** — a new
+`Relay.StreamStats()` counter, `Gaps`, goes non-zero when it happens, and a
+single `Gaps` means the window was too small for how far behind that node
+actually got. Size the window for the worst delay you intend to survive: a
+deploy rollover, a long garbage-collection pause, a node restart.
+
+**What it costs, and why pub/sub is still here.** Publishing to pub/sub costs
+Redis nothing: it hands the message to whoever is listening and forgets it.
+Writing to a stream is a real write — it replicates, it goes into your AOF/RDB
+if you have persistence on, and it holds memory proportional to
+`retention × update rate × update size` for every room on the node (roughly
+800KB per busy room at the defaults). Reading costs a small steady stream of
+commands even when nothing is happening — 16 per second per node at the
+defaults.
+
+So pub/sub is **not deprecated and is not going away**. At-most-once is a
+legitimate choice when your rooms are hot, your Redis is sized for fan-out
+rather than for writes, and catching up from storage on reload is good enough
+for you. Choose Streams when a missed update between reloads is not acceptable
+to you, and pay for it in Redis memory and write throughput.
+
+**Migrating a live cluster without splitting it.** The two mechanisms do not
+talk to each other: a Streams node does not publish to pub/sub, so a pub/sub
+node never sees its edits. Switching a running cluster straight over would
+therefore split it for the length of the rollout. There is a third setting for
+this, `Transport: Both`, which publishes to and reads from both mechanisms at
+once:
+
+1. Roll every node from the default to `Both`.
+2. Once no pub/sub-only node is left, roll every node from `Both` to `Streams`.
+
+Reverse the two steps to go back. `Both` needs no deduplication — receiving an
+update twice is harmless, because applying the same update again does nothing —
+so there is no window during the rollout where correctness depends on the order
+you restart your nodes. It does double the publish work, so it is a transition
+state rather than somewhere to stay.
+
+**Two things to know before you turn it on.**
+
+- **Redis Cluster is not supported**, and for the Streams tier that is
+  deliberate rather than unfinished. Reading many rooms in one command requires
+  every one of them to live on the same Cluster shard, and pinning them there
+  would put each node's reader count into the key names — so two nodes
+  configured slightly differently would read and write *different* streams for
+  the same room and never notice. Single-node Redis or Sentinel, as before.
+- **Leave `Config.NodeID` unset unless you have a reason not to.** By default
+  each process gets a fresh random identity, which means a restarted node
+  reads back its own last window of writes from Redis and recovers them. A
+  fixed `NodeID` makes the node recognise and skip its own messages, so its
+  own pre-restart writes have to come from storage instead.
+
+**What to watch.** `Relay.StreamStats()` is new and separate from the existing
+`Relay.Stats()`. Alert on `Gaps` **appearing at all**; alert on a sustained
+*rate* of `Replayed` (cursors being lost repeatedly), `Stalled` (a room's local
+consumer cannot keep up) or `Deferred` (rooms being read before they are
+ready). `Trimmed` and `Restarts` are informational — the second one exists so
+that a node restarting is never miscounted as data loss.
+[docs/CLUSTERING.md](docs/CLUSTERING.md) has the full posture.
+
+**One note for anyone who ran this from the branch before release.** The stream
+key layout changed late in development — the sync/awareness marker now comes
+before the room name, so that a room whose name begins with `a:` cannot collide
+with another room's presence stream. A pre-release build's streams will not
+line up with a v1.50.0 build's. Nothing released was ever affected.
+
+**Nothing else changed.** No existing signature, default, or Redis command
+moved. Closes #206.
 ## v1.49.5
 
 **Who is affected: anyone using `provider/client` with `Options.Token` against

--- a/cluster/redis/internal_test.go
+++ b/cluster/redis/internal_test.go
@@ -337,7 +337,7 @@ func newTestRelayNoStart() *Relay {
 // message arriving after RoomDeactivated already unsubscribed would
 // re-create a worker that nothing could ever reap (a later RoomDeactivated
 // for the same room just no-ops, since activeRooms is already back at
-// zero) — the exact unbounded per-room growth this task exists to stop.
+// zero) — the exact unbounded per-room growth this drop prevents.
 func TestUnit_WorkerForInbound_MissOnInactiveRoom_DropsStray(t *testing.T) {
 	r := newTestRelayNoStart()
 	t.Cleanup(func() { close(r.done) })
@@ -506,8 +506,7 @@ func TestInteg_StopWorker_ReapedRoom_DropsUntilReactivated(t *testing.T) {
 
 	// The Redis subscription and activeRooms refcount are both untouched by
 	// stopWorker: publishing now must be DROPPED, not lazily recreate the
-	// worker (that behaviour was removed by this task's carried-forward
-	// router simplification).
+	// worker.
 	require.NoError(t, pub.Publish(context.Background(), cluster.Outbound{
 		Room: "room", Kind: cluster.KindSync, Data: []byte{0x09},
 	}))

--- a/cluster/redis/internal_test.go
+++ b/cluster/redis/internal_test.go
@@ -28,6 +28,29 @@ import (
 	"github.com/reearth/ygo/crdt"
 )
 
+// newMiniRedis and newClient duplicate the identically-named helpers in
+// redis_test.go on purpose: those live in package redis_test (a separate
+// package from this file's package redis), so they are no more reachable
+// from here than any other unexported symbol in a different package — the
+// same reason countingSink below duplicates redis_test's fakeSink instead of
+// reusing it. streams_test.go needs resolveStreamCfg and streamCfg's
+// unexported fields directly, which requires package redis, so it gets its
+// own copy of the miniredis boilerplate rather than none at all.
+
+// newMiniRedis returns a miniredis instance scoped to t.
+func newMiniRedis(t *testing.T) *miniredis.Miniredis {
+	t.Helper()
+	return miniredis.RunT(t)
+}
+
+// newClient returns a *goredis.Client pointed at mr, registered for cleanup.
+func newClient(t *testing.T, mr *miniredis.Miniredis) *goredis.Client {
+	t.Helper()
+	c := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
 // countingSink is a minimal cluster.Sink test double for internal-package
 // tests. It is deliberately not the redis_test package's fakeSink: that type
 // lives in package redis_test and is not visible from these package-redis

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -103,6 +103,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	goredis "github.com/redis/go-redis/v9"
 
@@ -191,6 +192,85 @@ type Config struct {
 	// uses relaylane.DefaultCap. Coalescing never loses an edit — it trades
 	// per-update delivery granularity for bounded memory on a wedged room.
 	RoomQueueSize int
+
+	// Transport selects the delivery mechanism. The zero value is PubSub,
+	// which is the behaviour every existing deployment already has.
+	//
+	// Streams trades Redis memory for an at-least-once guarantee: each room
+	// becomes a Redis stream, and a reader that stalls or restarts resumes
+	// from where it left off instead of losing whatever it missed. The
+	// guarantee is bounded — at-least-once within
+	// min(StreamRetention, StreamMaxLen/rate) — because a stream is trimmed.
+	//
+	// PubSub remains supported, not deprecated: PUBLISH costs nothing, while
+	// XADD is a write with replication, AOF/RDB and memory proportional to
+	// retention x rate x update size. At-most-once is a legitimate choice.
+	//
+	// Both publishes to and reads from both, for migration. It needs no
+	// deduplication because V1 updates are idempotent, so double-applying is
+	// a no-op. Pub/sub and Streams nodes do NOT interoperate, so the
+	// zero-downtime path is: roll every node to Both, then roll every node to
+	// Streams. See docs/CLUSTERING.md.
+	Transport Transport
+
+	// StreamPrefix namespaces stream keys. Default "ygo:stream:".
+	//
+	// Deliberately distinct from ChannelPrefix's "ygo:cluster:": streams live
+	// in the keyspace where SCAN, MEMORY USAGE and eviction policy can see
+	// them, and channels do not, so sharing one prefix would make a
+	// keyspace listing mix two unrelated kinds of thing.
+	StreamPrefix string
+
+	// StreamRetention is the age bound on a room's sync stream. Default 60s,
+	// matching y-redis's own REDIS_MIN_MESSAGE_LIFETIME, which is long enough
+	// to cover a node restart, a deploy rollover, or a GC pause.
+	//
+	// This is one half of the delivery guarantee; StreamMaxLen is the other.
+	StreamRetention time.Duration
+
+	// StreamMaxLen is the entry-count ceiling on a room's sync stream.
+	// Default 4096, which is roughly 800KB per hot room at 200-byte updates.
+	//
+	// Enforced inline on XADD with MAXLEN ~, so trimming is approximate and a
+	// stream may briefly hold more. That overshoot costs memory; it never
+	// costs delivery, because approximate trimming keeps MORE than asked,
+	// never fewer.
+	StreamMaxLen int64
+
+	// AwarenessMaxLen and AwarenessRetention bound the SEPARATE awareness
+	// stream. Defaults 64 entries and 10s.
+	//
+	// Awareness gets its own stream deliberately. It is high-frequency
+	// heartbeat traffic, so sharing the sync stream's MAXLEN would let
+	// presence evict sync entries out of the retention window — silently
+	// shrinking the very guarantee this tier exists to provide. It is also
+	// never replayed: awareness is read from the stream's tail, because
+	// replaying it would resurrect presence for clients that are long gone.
+	AwarenessMaxLen    int64
+	AwarenessRetention time.Duration
+
+	// Readers is how many goroutines multiplex the node's assigned rooms.
+	// Default 4.
+	//
+	// Not one per room: each blocking XREAD holds a connection, so a reader
+	// per room would exhaust Redis's default maxclients (10000) well before
+	// this server's 10k-room target. Rooms are hash-assigned to readers.
+	//
+	// New fails if the client's PoolSize is not greater than Readers, because
+	// every reader holds a pool connection for its whole ReadBlock and an
+	// undersized pool starves publishes.
+	Readers int
+
+	// TrimInterval is how often the MINID sweeper enforces StreamRetention.
+	// Default 30s. New fails if it is not less than StreamRetention.
+	TrimInterval time.Duration
+
+	// ReadBlock bounds each XREAD BLOCK. Default 5s.
+	//
+	// Bounded rather than infinite so a reader notices room-membership
+	// changes. Activation does not wait for it: a newly activated room gets a
+	// fresh short read folded in immediately.
+	ReadBlock time.Duration
 }
 
 // Stats is a point-in-time snapshot of the relay's inbound degraded-path
@@ -250,6 +330,7 @@ type Relay struct {
 	log      *slog.Logger
 	nodeID   []byte
 	chanSize int
+	scfg     streamCfg
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
@@ -356,6 +437,11 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		cfg.Logger = slog.Default()
 	}
 
+	scfg, err := resolveStreamCfg(client, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	nodeID := cfg.NodeID
 	if len(nodeID) == 0 {
 		nodeID = make([]byte, nodeIDLen)
@@ -373,6 +459,7 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		log:         cfg.Logger,
 		nodeID:      nodeID,
 		chanSize:    cfg.ChannelSize,
+		scfg:        scfg,
 		outbound:    make(chan cluster.Outbound, cfg.OutboundBuffer),
 		done:        make(chan struct{}),
 		activeRooms: make(map[string]int),

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -262,19 +262,31 @@ type Config struct {
 	// this server's 10k-room target. Rooms are hash-assigned to readers.
 	//
 	// New fails if the client's PoolSize is not greater than Readers, because
-	// every reader holds a pool connection for its whole ReadBlock and an
-	// undersized pool starves publishes.
+	// a reader holds a pool connection for as long as its XREAD blocks, so a
+	// pool no larger than Readers leaves publishes and the trim sweeper
+	// waiting on a connection every cycle.
 	Readers int
 
 	// TrimInterval is how often the MINID sweeper enforces StreamRetention.
 	// Default 30s. New fails if it is not less than StreamRetention.
 	TrimInterval time.Duration
 
-	// ReadBlock bounds each XREAD BLOCK. Default 5s.
+	// ReadBlock is how long one reader's XREAD blocks when it has nothing to
+	// deliver. Default 250ms, which is also the maximum: New fails if it is
+	// larger.
 	//
-	// Bounded rather than infinite so a reader notices room-membership
-	// changes. Activation does not wait for it: a newly activated room gets a
-	// fresh short read folded in immediately.
+	// It is not just a Redis-efficiency knob, because a blocked XREAD cannot
+	// be interrupted (go-redis honours a context deadline, not a
+	// cancellation) and a reader's key set is fixed when its XREAD is issued.
+	// So this value is simultaneously the upper bound on how long Close waits
+	// for a reader to notice shutdown, and on how long a newly activated room
+	// waits before its stream is read at all. Lower it to shorten both at the
+	// cost of more commands per second; it cannot be raised, because the
+	// latencies it would extend are not negotiable. See maxReadBlock
+	// (streams.go) for the full reasoning.
+	//
+	// Delivery latency for a room already being read is NOT bounded by this:
+	// XREAD returns as soon as any of its keys gets an entry.
 	ReadBlock time.Duration
 }
 
@@ -651,11 +663,10 @@ func (r *Relay) Start(ctx context.Context, sink cluster.Sink) error {
 	// zero value, and every existing caller — launches nothing new and
 	// XREADs nothing.
 	//
-	// The readers get a DERIVED context (streamReadCtx), not ctx: a reader
-	// blocks inside XREAD for up to ReadBlock, and Close closes r.done and
-	// then joins r.wg, so a reader watching only ctx would make Close wait
-	// out a ReadBlock — or hang forever when ctx outlives the relay, which
-	// is the ordinary case. See streamReadCtx.
+	// The readers get a DERIVED context (streamReadCtx), not ctx: ctx
+	// ordinarily outlives the relay (Server cancels relayCtx after Close), so
+	// readers bound to it would go on issuing XREADs against a closed relay.
+	// See streamReadCtx for what that context does and does not buy.
 	if r.scfg.transport.usesStreams() {
 		readCtx := r.streamReadCtx(ctx)
 		for i := 0; i < r.scfg.readers; i++ {
@@ -944,6 +955,23 @@ func (r *Relay) RoomDeactivated(room string) {
 			r.streamRooms[room] = n
 		} else {
 			delete(r.streamRooms, room)
+			// The room is really gone from this node, so forget where its
+			// AWARENESS stream had got to — and only its awareness stream.
+			// Presence is read from the tail precisely because replaying it
+			// resurrects clients that are long gone, and a retained cursor
+			// resurrects them the moment the room comes back: the websocket
+			// provider evicts and reloads idle rooms continuously (#183), so
+			// a reactivation inside one process is routine, and it would
+			// otherwise resume mid-stream and replay up to AwarenessMaxLen
+			// presence blobs for the previous occupants. The room's SYNC
+			// cursor is deliberately kept — see cursorLimit.
+			//
+			// Not synchronised against a read already in flight: that read's
+			// id vector was built before this delete, so it can still write
+			// the cursor back once. The residue is bounded by one read cycle
+			// (ReadBlock) and by AwarenessRetention, not by the whole
+			// retention window, and evictStaleCursorsLocked reclaims it.
+			delete(r.cursors, r.scfg.awKey(room))
 		}
 		r.streamMu.Unlock()
 	}

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -386,14 +386,17 @@ type Relay struct {
 	// incremented/decremented in Streams/Both mode. roomsForReader is what
 	// consumes it, to build each reader's XREAD key set.
 	streamRooms map[string]int
-	// cursors is the last stream ID this node has delivered per stream KEY
-	// (not per room: a room has a sync stream and an awareness stream, and
-	// they advance independently). Purely in-memory and never persisted — a
-	// lost cursor costs a replay, not a loss, because a sync stream is read
-	// from its oldest retained entry when no cursor is known. Entries are
-	// kept past a room's deactivation so ordinary churn does not re-replay
-	// the whole retention window, and bounded by cursorLimit. Guarded by
-	// streamMu; see setCursor / evictStaleCursorsLocked.
+	// cursors is the last SYNC stream ID this node has delivered, per stream
+	// key. Purely in-memory and never persisted — a lost cursor costs a
+	// replay, not a loss, because a sync stream is read from its oldest
+	// retained entry when no cursor is known. Entries are kept past a room's
+	// deactivation so ordinary churn does not re-replay the whole retention
+	// window, and bounded by cursorLimit. Guarded by streamMu; see setCursor
+	// / evictStaleCursorsLocked.
+	//
+	// Awareness cursors are deliberately NOT here. They must not survive a
+	// room's deactivation, and a residency-scoped home makes that structural:
+	// see roomWorker.awCursor, which also states why the two kinds differ.
 	cursors map[string]string
 	// lastSeq is the highest sequence number seen from each source node ON
 	// EACH STREAM, used to tell a trimmed-away gap from a node restart. Keyed
@@ -958,23 +961,24 @@ func (r *Relay) RoomDeactivated(room string) {
 			r.streamRooms[room] = n
 		} else {
 			delete(r.streamRooms, room)
-			// The room is really gone from this node, so forget where its
-			// AWARENESS stream had got to — and only its awareness stream.
-			// Presence is read from the tail precisely because replaying it
-			// resurrects clients that are long gone, and a retained cursor
-			// resurrects them the moment the room comes back: the websocket
-			// provider evicts and reloads idle rooms continuously (#183), so
-			// a reactivation inside one process is routine, and it would
-			// otherwise resume mid-stream and replay up to AwarenessMaxLen
-			// presence blobs for the previous occupants. The room's SYNC
-			// cursor is deliberately kept — see cursorLimit.
+			// The room is really gone from this node — and no cursor is
+			// deleted here, deliberately. Its SYNC cursor is KEPT: dropping
+			// it would make ordinary room churn replay the room's whole
+			// retention window on every reactivation, the condition
+			// StreamStats.Replayed exists to alarm on (see cursorLimit). Its
+			// AWARENESS cursor must NOT survive — presence is read from the
+			// tail precisely because replaying it resurrects clients that are
+			// long gone, and the websocket provider evicts and reloads idle
+			// rooms continuously (#183), so a reactivation inside one process
+			// is routine — but it is not stored here to delete. It lives on
+			// the room's delivery worker, which stopWorker retires below, so
+			// it dies with the residency it belongs to.
 			//
-			// Not synchronised against a read already in flight: that read's
-			// id vector was built before this delete, so it can still write
-			// the cursor back once. The residue is bounded by one read cycle
-			// (ReadBlock) and by AwarenessRetention, not by the whole
-			// retention window, and evictStaleCursorsLocked reclaims it.
-			delete(r.cursors, r.scfg.awKey(room))
+			// That placement is what makes the rule hold rather than nearly
+			// hold: deleting an awareness cursor from this map could only
+			// NARROW the replay window, because a read whose id vector was
+			// built before the delete applies afterwards and writes the old
+			// position straight back. See roomWorker.awCursor.
 		}
 		r.streamMu.Unlock()
 	}

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -197,46 +197,37 @@ type Config struct {
 	// which is the behaviour every existing deployment already has.
 	//
 	// Streams trades Redis memory for an at-least-once guarantee: each room
-	// becomes a Redis stream, and a reader that stalls or restarts resumes
-	// from where it left off instead of losing whatever it missed. The
-	// guarantee is bounded — at-least-once within
+	// becomes a Redis stream, and a reader that stalls or restarts resumes from
+	// where it left off. The guarantee is bounded — at-least-once within
 	// min(StreamRetention, StreamMaxLen/rate) — because a stream is trimmed.
 	//
 	// PubSub remains supported, not deprecated: PUBLISH costs nothing, while
 	// XADD is a write with replication, AOF/RDB and memory proportional to
 	// retention x rate x update size. At-most-once is a legitimate choice.
 	//
-	// Both publishes to and reads from both, for migration. It needs no
-	// deduplication because V1 updates are idempotent, so double-applying is
-	// a no-op.
+	// Both publishes to and reads from both, for migration; no deduplication is
+	// needed, because V1 updates are idempotent.
 	//
-	// A mixed cluster delivers ONE WAY ONLY, and the asymmetry is worth
-	// stating precisely. Outbound is gated on the setting: a Streams node
-	// does not PUBLISH, so a PubSub-only node never sees its edits. Inbound
-	// is NOT gated in this release — Start still opens the pub/sub connection
-	// and RoomActivated still SUBSCRIBEs each room's channel whatever the
-	// Transport — so a Streams node does still RECEIVE pub/sub traffic and
-	// apply it. Two consequences: choosing Streams does not remove the
-	// pub/sub connection or the per-room SUBSCRIBE from this node's Redis
-	// footprint, and a half-migrated cluster is one-way rather than cleanly
-	// split. Gating the inbound side too is tracked in #249.
+	// A MIXED CLUSTER DELIVERS ONE WAY ONLY. Outbound is gated on the setting,
+	// so a Streams node does not PUBLISH and a PubSub-only node never sees its
+	// edits. Inbound is NOT gated in this release — Start still opens the
+	// pub/sub connection and RoomActivated still SUBSCRIBEs each room's channel
+	// whatever the Transport — so a Streams node still receives and applies
+	// pub/sub traffic, keeping that connection and every per-room SUBSCRIBE in
+	// its Redis footprint. Gating inbound too is tracked in #249.
 	//
-	// The migration advice is the same either way, because it only depends on
-	// the outbound gate: the zero-downtime path is to roll every node to
-	// Both, then roll every node to Streams. See docs/CLUSTERING.md.
+	// Migration depends only on the outbound gate: roll every node to Both,
+	// then roll every node to Streams. See docs/CLUSTERING.md.
 	Transport Transport
 
 	// StreamPrefix namespaces stream keys. Default "ygo:stream:".
 	//
 	// A room's two streams are StreamPrefix+"s:"+room (sync) and
 	// StreamPrefix+"a:"+room (awareness). The kind discriminator precedes the
-	// room name so that no room name — and every printable character is a
-	// legal room name, ":" included — can produce another room's key.
-	//
-	// Deliberately distinct from ChannelPrefix's "ygo:cluster:": streams live
-	// in the keyspace where SCAN, MEMORY USAGE and eviction policy can see
-	// them, and channels do not, so sharing one prefix would make a
-	// keyspace listing mix two unrelated kinds of thing.
+	// room name so that no room name — and every printable character is legal
+	// in one, ":" included — can produce another room's key. Deliberately
+	// distinct from ChannelPrefix's "ygo:cluster:", because streams live in the
+	// keyspace where SCAN, MEMORY USAGE and eviction policy see them.
 	StreamPrefix string
 
 	// StreamRetention is the age bound on a room's sync stream. Default 60s,
@@ -258,26 +249,22 @@ type Config struct {
 	// AwarenessMaxLen and AwarenessRetention bound the SEPARATE awareness
 	// stream. Defaults 64 entries and 10s.
 	//
-	// Awareness gets its own stream deliberately. It is high-frequency
-	// heartbeat traffic, so sharing the sync stream's MAXLEN would let
-	// presence evict sync entries out of the retention window — silently
-	// shrinking the very guarantee this tier exists to provide. It is also
-	// never replayed: awareness is read from the stream's tail, because
-	// replaying it would resurrect presence for clients that are long gone.
+	// Its own stream deliberately: presence is high-frequency, so sharing the
+	// sync stream's MAXLEN would let it evict sync entries out of the retention
+	// window, silently shrinking the guarantee this tier provides. It is also
+	// never replayed — read from the tail, because replay resurrects clients
+	// long gone.
 	AwarenessMaxLen    int64
 	AwarenessRetention time.Duration
 
-	// Readers is how many goroutines multiplex the node's assigned rooms.
-	// Default 4.
+	// Readers is how many goroutines multiplex the node's assigned rooms
+	// (hash-assigned). Default 4.
 	//
-	// Not one per room: each blocking XREAD holds a connection, so a reader
-	// per room would exhaust Redis's default maxclients (10000) well before
-	// this server's 10k-room target. Rooms are hash-assigned to readers.
-	//
-	// New fails if the client's PoolSize is not greater than Readers, because
-	// a reader holds a pool connection for as long as its XREAD blocks, so a
-	// pool no larger than Readers leaves publishes and the trim sweeper
-	// waiting on a connection every cycle.
+	// Not one per room: each blocking XREAD holds a connection, so a reader per
+	// room would exhaust Redis's default maxclients (10000) well before this
+	// server's 10k-room target. New fails if PoolSize is not greater than
+	// Readers, since a pool no larger than Readers leaves publishes and the
+	// trim sweeper waiting on a connection every cycle.
 	Readers int
 
 	// TrimInterval is how often the MINID sweeper enforces StreamRetention.
@@ -288,15 +275,13 @@ type Config struct {
 	// deliver. Default 250ms, which is also the maximum: New fails if it is
 	// larger, and the minimum: New fails if it is smaller than 1ms.
 	//
-	// It is not just a Redis-efficiency knob, because a blocked XREAD cannot
-	// be interrupted (go-redis honours a context deadline, not a
-	// cancellation) and a reader's key set is fixed when its XREAD is issued.
-	// So this value is simultaneously the upper bound on how long Close waits
-	// for a reader to notice shutdown, and on how long a newly activated room
-	// waits before its stream is read at all. Lower it to shorten both at the
-	// cost of more commands per second; it cannot be raised, because the
-	// latencies it would extend are not negotiable. See maxReadBlock and
-	// minReadBlock (streams.go) for the full reasoning.
+	// Not just a Redis-efficiency knob: a blocked XREAD cannot be interrupted
+	// (go-redis honours a context deadline, not a cancellation) and a reader's
+	// key set is fixed when its XREAD is issued, so this is simultaneously the
+	// upper bound on how long Close waits for a reader to notice shutdown and
+	// on how long a newly activated room waits to be read at all. Lower it to
+	// shorten both at the cost of more commands per second; it cannot be
+	// raised. See maxReadBlock and minReadBlock (streams.go).
 	//
 	// Delivery latency for a room already being read is NOT bounded by this:
 	// XREAD returns as soon as any of its keys gets an entry.
@@ -364,12 +349,10 @@ type Relay struct {
 
 	// seqs holds this node's sequence counter for each stream KEY it has
 	// published to, so readers can detect trimmed or dropped entries. Per
-	// stream, not per node: a reader of one stream sees only the entries that
-	// landed in that stream, so one shared counter would look full of holes on
-	// any node publishing to more than one room, and gap detection would fire
-	// on healthy clusters. Counters restart at 0 on process restart; a
-	// decrease is read as a restart rather than a gap. Guarded by streamMu and
-	// bounded by seqLimit; see nextSeq / evictStaleSeqsLocked.
+	// stream, not per node — see nextSeq for why one shared counter would make
+	// gap detection fire on healthy clusters. Counters restart at 0 with the
+	// process, and a decrease is read as a restart rather than a gap. Guarded
+	// by streamMu and bounded by seqLimit; see evictStaleSeqsLocked.
 	seqs map[string]uint64
 
 	// Stream tier counters. Only incremented in Streams mode; always zero
@@ -383,44 +366,34 @@ type Relay struct {
 	stalled  atomic.Uint64 // incremented by stream reader: lane at capacity
 	deferred atomic.Uint64 // incremented by stream reader: room has no worker yet
 
-	// streamMu guards streamRooms. Separate from mu: mu is held across the
-	// pub/sub SUBSCRIBE/UNSUBSCRIBE RPC (see mu's doc below), and streamRooms
-	// bookkeeping must not be blocked behind a stalled Redis call it has
-	// nothing to do with. It is also separate from workersMu — streamRooms
-	// tracks READER-side (XREAD) assignment, an entirely different axis from
-	// the pub/sub delivery workers workersMu guards.
+	// streamMu guards streamRooms. Separate from mu, which is held across the
+	// pub/sub SUBSCRIBE/UNSUBSCRIBE RPC, so this bookkeeping never blocks
+	// behind a stalled Redis call it has nothing to do with; separate from
+	// workersMu because reader assignment is a different axis from delivery.
 	streamMu sync.Mutex
-	// streamRooms is a reference count per room name, mirroring activeRooms
-	// but for the stream reader's assignment instead of pub/sub subscription:
-	// RoomActivated/RoomDeactivated for the same room can arrive out of order
-	// across a room's eviction/reload handoff (see the Relay contract's
-	// RoomActivated doc), and a plain set would let the predecessor's
-	// deactivation evict a room the successor still needs read. Only
-	// incremented/decremented in Streams/Both mode. roomsForReader is what
-	// consumes it, to build each reader's XREAD key set.
+	// streamRooms is a reference count per room name, mirroring activeRooms but
+	// for reader assignment: RoomActivated/RoomDeactivated for one room can
+	// arrive out of order across an eviction/reload handoff (see the Relay
+	// contract's RoomActivated doc), and a plain set would let the
+	// predecessor's deactivation evict a room the successor still needs read.
+	// Maintained in Streams/Both mode only; consumed by roomsForReader.
 	streamRooms map[string]int
 	// cursors is the last SYNC stream ID this node has delivered, per stream
-	// key. Purely in-memory and never persisted — a lost cursor costs a
-	// replay, not a loss, because a sync stream is read from its oldest
-	// retained entry when no cursor is known. Entries are kept past a room's
-	// deactivation so ordinary churn does not re-replay the whole retention
-	// window, and bounded by cursorLimit. Guarded by streamMu; see setCursor
-	// / evictStaleCursorsLocked.
-	//
-	// Awareness cursors are deliberately NOT here. They must not survive a
-	// room's deactivation, and a residency-scoped home makes that structural:
-	// see roomWorker.awCursor, which also states why the two kinds differ.
+	// key. Purely in-memory and never persisted: a lost cursor costs a replay,
+	// not a loss, because a sync stream is read from its oldest retained entry
+	// when no cursor is known. Kept past a room's deactivation and bounded by
+	// cursorLimit; guarded by streamMu (see setCursor,
+	// evictStaleCursorsLocked). Awareness cursors are deliberately NOT here —
+	// roomWorker.awCursor states the retention rule for both kinds.
 	cursors map[string]string
 	// lastSeq is the last sequence number seen from each source node ON EACH
 	// STREAM, used to tell a trimmed-away gap from a node restart. Keyed by
-	// both because the publisher's counter is per stream (see seqs): keying
-	// by nodeID alone would interleave two streams' sequences from one node
-	// into a single series and report the interleaving itself as gaps. The
-	// value also carries whether the PREVIOUS observation went backwards, so
-	// that the comparison immediately after a decrease re-baselines rather
-	// than reporting a gap — see noteSeq for why that case is routine.
-	// Guarded by streamMu and bounded by seqLimit; see noteSeq /
-	// evictStaleLastSeqLocked.
+	// both because the publisher's counter is per stream: keying by nodeID
+	// alone would fold two streams' sequences into one series and report the
+	// interleaving itself as gaps. The value also carries whether the PREVIOUS
+	// observation went backwards, so the comparison after a decrease
+	// re-baselines instead of accusing — see noteSeq. Guarded by streamMu and
+	// bounded by seqLimit; see evictStaleLastSeqLocked.
 	lastSeq map[seqSource]seqState
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
@@ -681,14 +654,10 @@ func (r *Relay) Start(ctx context.Context, sink cluster.Sink) error {
 	go r.runSubscriber(ctx)
 	go r.runPublisher(ctx)
 
-	// Streams-tier readers. Gated on the transport, so PubSub mode — the
-	// zero value, and every existing caller — launches nothing new and
-	// XREADs nothing.
-	//
-	// The readers get a DERIVED context (streamReadCtx), not ctx: ctx
-	// ordinarily outlives the relay (Server cancels relayCtx after Close), so
-	// readers bound to it would go on issuing XREADs against a closed relay.
-	// See streamReadCtx for what that context does and does not buy.
+	// Streams-tier readers, gated on the transport so PubSub mode — the zero
+	// value, and every existing caller — launches nothing new. They get a
+	// DERIVED context, not ctx, which ordinarily outlives the relay; see
+	// streamReadCtx for what that buys and what it does not.
 	if r.scfg.transport.usesStreams() {
 		readCtx := r.streamReadCtx(ctx)
 		for i := 0; i < r.scfg.readers; i++ {
@@ -696,12 +665,9 @@ func (r *Relay) Start(ctx context.Context, sink cluster.Sink) error {
 			go r.runStreamReader(readCtx, i)
 		}
 
-		// The MINID trim sweeper: the age half of the delivery guarantee
-		// (see runTrimSweeper's doc). It gets the plain Start ctx, not the
-		// derived readCtx above — its own select watches r.done directly,
-		// which is enough for a ticker loop and does not need
-		// streamReadCtx's r.done→cancel forwarding (that forwarding exists
-		// only because a blocked XREAD can't otherwise be interrupted).
+		// The MINID trim sweeper: the age half of the delivery guarantee. It
+		// gets the plain Start ctx, because its own select watches r.done
+		// directly — enough for a ticker loop. See runTrimSweeper.
 		r.wg.Add(1)
 		go r.runTrimSweeper(ctx)
 	}
@@ -826,15 +792,12 @@ func (r *Relay) runSubscriber(ctx context.Context) {
 // the done/startCtx channels give it all the ordering it needs, and the
 // hot path must not be serialised against lifecycle/room-membership ops.
 //
-// Config.Transport routes what happens next. When the transport uses
-// streams (Streams or Both), Publish XADDs synchronously, inline on the
-// caller's goroutine, before anything is queued for pub/sub — a failed XADD
-// must fail the call rather than be swallowed by the async pub/sub hand-off,
-// since Streams mode is the durable tier callers opted into for exactly that
-// error visibility. When the transport does not also use pub/sub (Streams
-// only), Publish returns immediately after the XADD and never touches the
-// outbound queue or PUBLISH at all — a Streams deployment must not still pay
-// for, or depend on, the at-most-once channel it exists to replace.
+// Config.Transport routes what happens next. Under Streams or Both, Publish
+// XADDs synchronously before anything is queued for pub/sub, so a failed XADD
+// fails the call rather than being swallowed by the async hand-off — error
+// visibility is what callers opt into the durable tier for. Under Streams alone
+// it returns straight after the XADD, never touching the outbound queue or
+// PUBLISH.
 func (r *Relay) Publish(ctx context.Context, out cluster.Outbound) error {
 	if r.closed.Load() {
 		return ErrRelayClosed
@@ -909,15 +872,11 @@ func (r *Relay) RoomActivated(room string) {
 	default:
 	}
 
-	// Reader-side assignment refcount. This runs BEFORE the pub/sub
-	// count>1 short-circuit below, not after it: that short-circuit exists
-	// to skip a redundant SUBSCRIBE RPC, but a second RoomActivated call is
-	// still a real activation this relay must keep counted for the stream
-	// reader, exactly the successor-before-predecessor overlap the Relay
-	// contract requires tolerating. Placing this after the short-circuit
-	// (mirroring where the pub/sub work "ends") would silently skip the
-	// increment on every call past the first, undercounting activations and
-	// making a later RoomDeactivated evict a still-live room.
+	// Reader-side assignment refcount, BEFORE the pub/sub count>1
+	// short-circuit below: that only skips a redundant SUBSCRIBE RPC, whereas a
+	// second RoomActivated is still a real activation the reader must count —
+	// the successor-before-predecessor overlap the Relay contract requires
+	// tolerating. After it, a later RoomDeactivated would evict a live room.
 	if r.scfg.transport.usesStreams() {
 		r.streamMu.Lock()
 		r.streamRooms[room]++
@@ -965,45 +924,28 @@ func (r *Relay) RoomDeactivated(room string) {
 		return
 	}
 
-	// Reader-side assignment ONLY — never publish-side state. RoomDeactivated's
-	// own contract (cluster/relay.go) warns that a relay releasing per-room
-	// PUBLISH-side state here — it names "a stream key" — would drop a
+	// Reader-side assignment ONLY — never publish-side state.
+	// RoomDeactivated's own contract (cluster/relay.go) warns that releasing
+	// per-room PUBLISH-side state here — it names "a stream key" — would drop a
 	// trailing update, because the provider's lane worker can still call
 	// Publish for this room after RoomDeactivated returns. publishStream
-	// therefore never consults streamRooms; this map is consulted only by
-	// the (later) stream reader to decide which rooms it still owns.
+	// therefore never consults streamRooms; only the reader does.
 	//
-	// Decremented here, guarded by the same "was this room actually active"
-	// check as activeRooms above (r.activeRooms[room] <= 0 already
-	// returned), so an extra/no-op RoomDeactivated call can't underflow this
-	// counter either — mirroring activeRooms's own refcount rather than the
-	// pub/sub count>0 short-circuit below, which exists to skip a redundant
-	// UNSUBSCRIBE RPC and would otherwise leave a still-referenced room's
-	// count untouched on every call past the last one that reaches zero.
+	// Guarded by the same "was this room actually active" check as activeRooms
+	// above (r.activeRooms[room] <= 0 already returned), so a no-op
+	// RoomDeactivated cannot underflow this counter — mirroring activeRooms's
+	// own refcount rather than the pub/sub count>0 short-circuit below.
 	if r.scfg.transport.usesStreams() {
 		r.streamMu.Lock()
 		if n := r.streamRooms[room] - 1; n > 0 {
 			r.streamRooms[room] = n
 		} else {
 			delete(r.streamRooms, room)
-			// The room is really gone from this node — and no cursor is
-			// deleted here, deliberately. Its SYNC cursor is KEPT: dropping
-			// it would make ordinary room churn replay the room's whole
-			// retention window on every reactivation, the condition
-			// StreamStats.Replayed exists to alarm on (see cursorLimit). Its
-			// AWARENESS cursor must NOT survive — presence is read from the
-			// tail precisely because replaying it resurrects clients that are
-			// long gone, and the websocket provider evicts and reloads idle
-			// rooms continuously (#183), so a reactivation inside one process
-			// is routine — but it is not stored here to delete. It lives on
-			// the room's delivery worker, which stopWorker retires below, so
-			// it dies with the residency it belongs to.
-			//
-			// That placement is what makes the rule hold rather than nearly
-			// hold: deleting an awareness cursor from this map could only
-			// NARROW the replay window, because a read whose id vector was
-			// built before the delete applies afterwards and writes the old
-			// position straight back. See roomWorker.awCursor.
+			// No cursor is deleted here, deliberately: the sync cursor is kept
+			// and the awareness cursor is not stored here to delete — it dies
+			// with the worker stopWorker retires below. See
+			// roomWorker.awCursor for the rule and why placement, not deletion,
+			// is what enforces it.
 		}
 		r.streamMu.Unlock()
 	}

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -359,13 +359,16 @@ type Relay struct {
 	// bounded by seqLimit; see nextSeq / evictStaleSeqsLocked.
 	seqs map[string]uint64
 
-	// Stream tier counters: replayed, gaps, restarts, trimmed, stalled. Only
-	// incremented in Streams mode; always zero under pub/sub. See StreamStats.
+	// Stream tier counters. Only incremented in Streams mode; always zero
+	// under pub/sub. See StreamStats for what each one means and how an
+	// operator should read it — in particular why the two declined-advance
+	// causes (stalled, deferred) are counted apart.
 	replayed atomic.Uint64 // incremented by stream reader
 	gaps     atomic.Uint64 // incremented by stream reader
 	restarts atomic.Uint64 // incremented by stream reader
 	trimmed  atomic.Uint64 // incremented by MINID sweeper
-	stalled  atomic.Uint64 // incremented by stream reader
+	stalled  atomic.Uint64 // incremented by stream reader: lane at capacity
+	deferred atomic.Uint64 // incremented by stream reader: room has no worker yet
 
 	// streamMu guards streamRooms. Separate from mu: mu is held across the
 	// pub/sub SUBSCRIBE/UNSUBSCRIBE RPC (see mu's doc below), and streamRooms
@@ -380,8 +383,8 @@ type Relay struct {
 	// across a room's eviction/reload handoff (see the Relay contract's
 	// RoomActivated doc), and a plain set would let the predecessor's
 	// deactivation evict a room the successor still needs read. Only
-	// incremented/decremented in Streams/Both mode. The reader task that
-	// consumes this to build its XREAD key set lands later.
+	// incremented/decremented in Streams/Both mode. roomsForReader is what
+	// consumes it, to build each reader's XREAD key set.
 	streamRooms map[string]int
 	// cursors is the last stream ID this node has delivered per stream KEY
 	// (not per room: a room has a sync stream and an awareness stream, and

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -215,6 +215,11 @@ type Config struct {
 
 	// StreamPrefix namespaces stream keys. Default "ygo:stream:".
 	//
+	// A room's two streams are StreamPrefix+"s:"+room (sync) and
+	// StreamPrefix+"a:"+room (awareness). The kind discriminator precedes the
+	// room name so that no room name — and every printable character is a
+	// legal room name, ":" included — can produce another room's key.
+	//
 	// Deliberately distinct from ChannelPrefix's "ygo:cluster:": streams live
 	// in the keyspace where SCAN, MEMORY USAGE and eviction policy can see
 	// them, and channels do not, so sharing one prefix would make a
@@ -332,11 +337,15 @@ type Relay struct {
 	chanSize int
 	scfg     streamCfg
 
-	// seq is incremented by nextSeq for each stream entry published by this
-	// node, allowing readers to detect trimmed or dropped entries. It restarts
-	// at 0 on process restart; a decrease is treated as a restart rather than a
-	// gap. See nextSeq.
-	seq atomic.Uint64
+	// seqs holds this node's sequence counter for each stream KEY it has
+	// published to, so readers can detect trimmed or dropped entries. Per
+	// stream, not per node: a reader of one stream sees only the entries that
+	// landed in that stream, so one shared counter would look full of holes on
+	// any node publishing to more than one room, and gap detection would fire
+	// on healthy clusters. Counters restart at 0 on process restart; a
+	// decrease is read as a restart rather than a gap. Guarded by streamMu and
+	// bounded by seqLimit; see nextSeq / evictStaleSeqsLocked.
+	seqs map[string]uint64
 
 	// Stream tier counters: replayed, gaps, restarts, trimmed, stalled. Only
 	// incremented in Streams mode; always zero under pub/sub. See StreamStats.
@@ -371,10 +380,14 @@ type Relay struct {
 	// the whole retention window, and bounded by cursorLimit. Guarded by
 	// streamMu; see setCursor / evictStaleCursorsLocked.
 	cursors map[string]string
-	// lastSeq is the highest sequence number seen from each source node,
-	// keyed by nodeID, used to tell a trimmed-away gap from a node restart.
-	// Guarded by streamMu; see noteSeq.
-	lastSeq map[string]uint64
+	// lastSeq is the highest sequence number seen from each source node ON
+	// EACH STREAM, used to tell a trimmed-away gap from a node restart. Keyed
+	// by both because the publisher's counter is per stream (see seqs): keying
+	// by nodeID alone would interleave two streams' sequences from one node
+	// into a single series and report the interleaving itself as gaps.
+	// Guarded by streamMu and bounded by seqLimit; see noteSeq /
+	// evictStaleLastSeqLocked.
+	lastSeq map[seqSource]uint64
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
@@ -511,7 +524,8 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		workers:     make(map[string]*roomWorker),
 		streamRooms: make(map[string]int),
 		cursors:     make(map[string]string),
-		lastSeq:     make(map[string]uint64),
+		seqs:        make(map[string]uint64),
+		lastSeq:     make(map[seqSource]uint64),
 	}, nil
 }
 

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -332,6 +332,12 @@ type Relay struct {
 	chanSize int
 	scfg     streamCfg
 
+	// seq is incremented by nextSeq for each stream entry published by this
+	// node, allowing readers to detect trimmed or dropped entries. It restarts
+	// at 0 on process restart; a decrease is treated as a restart rather than a
+	// gap. See nextSeq.
+	seq atomic.Uint64
+
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
 	outbound chan cluster.Outbound

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -719,6 +719,16 @@ func (r *Relay) runSubscriber(ctx context.Context) {
 // Publish does NOT acquire r.mu: the started/closed atomics combined with
 // the done/startCtx channels give it all the ordering it needs, and the
 // hot path must not be serialised against lifecycle/room-membership ops.
+//
+// Config.Transport routes what happens next. When the transport uses
+// streams (Streams or Both), Publish XADDs synchronously, inline on the
+// caller's goroutine, before anything is queued for pub/sub — a failed XADD
+// must fail the call rather than be swallowed by the async pub/sub hand-off,
+// since Streams mode is the durable tier callers opted into for exactly that
+// error visibility. When the transport does not also use pub/sub (Streams
+// only), Publish returns immediately after the XADD and never touches the
+// outbound queue or PUBLISH at all — a Streams deployment must not still pay
+// for, or depend on, the at-most-once channel it exists to replace.
 func (r *Relay) Publish(ctx context.Context, out cluster.Outbound) error {
 	if r.closed.Load() {
 		return ErrRelayClosed
@@ -729,6 +739,16 @@ func (r *Relay) Publish(ctx context.Context, out cluster.Outbound) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	if r.scfg.transport.usesStreams() {
+		if err := r.publishStream(ctx, out); err != nil {
+			return err
+		}
+	}
+	if !r.scfg.transport.usesPubSub() {
+		return nil
+	}
+
 	// Safe to read r.startCtx unlocked: started.Store(true) happens-after
 	// the startCtx write in Start, so the started.Load()==true above acts
 	// as the matching acquire.

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -679,6 +679,15 @@ func (r *Relay) Start(ctx context.Context, sink cluster.Sink) error {
 			r.wg.Add(1)
 			go r.runStreamReader(readCtx, i)
 		}
+
+		// The MINID trim sweeper: the age half of the delivery guarantee
+		// (see runTrimSweeper's doc). It gets the plain Start ctx, not the
+		// derived readCtx above — its own select watches r.done directly,
+		// which is enough for a ticker loop and does not need
+		// streamReadCtx's r.done→cancel forwarding (that forwarding exists
+		// only because a blocked XREAD can't otherwise be interrupted).
+		r.wg.Add(1)
+		go r.runTrimSweeper(ctx)
 	}
 
 	// started is set LAST: the atomic Store acts as a release barrier so

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -338,6 +338,14 @@ type Relay struct {
 	// gap. See nextSeq.
 	seq atomic.Uint64
 
+	// Stream tier counters: replayed, gaps, restarts, trimmed, stalled. Only
+	// incremented in Streams mode; always zero under pub/sub. See StreamStats.
+	replayed atomic.Uint64 //nolint:unused // incremented by stream reader
+	gaps     atomic.Uint64 //nolint:unused // incremented by stream reader
+	restarts atomic.Uint64 //nolint:unused // incremented by stream reader
+	trimmed  atomic.Uint64 //nolint:unused // incremented by MINID sweeper
+	stalled  atomic.Uint64 //nolint:unused // incremented by stream reader
+
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
 	outbound chan cluster.Outbound

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -362,6 +362,19 @@ type Relay struct {
 	// incremented/decremented in Streams/Both mode. The reader task that
 	// consumes this to build its XREAD key set lands later.
 	streamRooms map[string]int
+	// cursors is the last stream ID this node has delivered per stream KEY
+	// (not per room: a room has a sync stream and an awareness stream, and
+	// they advance independently). Purely in-memory and never persisted — a
+	// lost cursor costs a replay, not a loss, because a sync stream is read
+	// from its oldest retained entry when no cursor is known. Entries are
+	// kept past a room's deactivation so ordinary churn does not re-replay
+	// the whole retention window, and bounded by cursorLimit. Guarded by
+	// streamMu; see setCursor / evictStaleCursorsLocked.
+	cursors map[string]string
+	// lastSeq is the highest sequence number seen from each source node,
+	// keyed by nodeID, used to tell a trimmed-away gap from a node restart.
+	// Guarded by streamMu; see noteSeq.
+	lastSeq map[string]uint64
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
@@ -497,6 +510,8 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		laneCap:     cfg.RoomQueueSize,
 		workers:     make(map[string]*roomWorker),
 		streamRooms: make(map[string]int),
+		cursors:     make(map[string]string),
+		lastSeq:     make(map[string]uint64),
 	}, nil
 }
 
@@ -617,6 +632,23 @@ func (r *Relay) Start(ctx context.Context, sink cluster.Sink) error {
 	r.wg.Add(2)
 	go r.runSubscriber(ctx)
 	go r.runPublisher(ctx)
+
+	// Streams-tier readers. Gated on the transport, so PubSub mode — the
+	// zero value, and every existing caller — launches nothing new and
+	// XREADs nothing.
+	//
+	// The readers get a DERIVED context (streamReadCtx), not ctx: a reader
+	// blocks inside XREAD for up to ReadBlock, and Close closes r.done and
+	// then joins r.wg, so a reader watching only ctx would make Close wait
+	// out a ReadBlock — or hang forever when ctx outlives the relay, which
+	// is the ordinary case. See streamReadCtx.
+	if r.scfg.transport.usesStreams() {
+		readCtx := r.streamReadCtx(ctx)
+		for i := 0; i < r.scfg.readers; i++ {
+			r.wg.Add(1)
+			go r.runStreamReader(readCtx, i)
+		}
+	}
 
 	// started is set LAST: the atomic Store acts as a release barrier so
 	// any goroutine that observes started=true via Load() sees the writes

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -340,11 +340,11 @@ type Relay struct {
 
 	// Stream tier counters: replayed, gaps, restarts, trimmed, stalled. Only
 	// incremented in Streams mode; always zero under pub/sub. See StreamStats.
-	replayed atomic.Uint64 //nolint:unused // incremented by stream reader
-	gaps     atomic.Uint64 //nolint:unused // incremented by stream reader
-	restarts atomic.Uint64 //nolint:unused // incremented by stream reader
-	trimmed  atomic.Uint64 //nolint:unused // incremented by MINID sweeper
-	stalled  atomic.Uint64 //nolint:unused // incremented by stream reader
+	replayed atomic.Uint64 // incremented by stream reader
+	gaps     atomic.Uint64 // incremented by stream reader
+	restarts atomic.Uint64 // incremented by stream reader
+	trimmed  atomic.Uint64 // incremented by MINID sweeper
+	stalled  atomic.Uint64 // incremented by stream reader
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -219,7 +219,7 @@ type Config struct {
 	// apply it. Two consequences: choosing Streams does not remove the
 	// pub/sub connection or the per-room SUBSCRIBE from this node's Redis
 	// footprint, and a half-migrated cluster is one-way rather than cleanly
-	// split. Gating the inbound side too is tracked as a follow-up issue.
+	// split. Gating the inbound side too is tracked in #249.
 	//
 	// The migration advice is the same either way, because it only depends on
 	// the outbound gate: the zero-downtime path is to roll every node to

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -208,9 +208,22 @@ type Config struct {
 	//
 	// Both publishes to and reads from both, for migration. It needs no
 	// deduplication because V1 updates are idempotent, so double-applying is
-	// a no-op. Pub/sub and Streams nodes do NOT interoperate, so the
-	// zero-downtime path is: roll every node to Both, then roll every node to
-	// Streams. See docs/CLUSTERING.md.
+	// a no-op.
+	//
+	// A mixed cluster delivers ONE WAY ONLY, and the asymmetry is worth
+	// stating precisely. Outbound is gated on the setting: a Streams node
+	// does not PUBLISH, so a PubSub-only node never sees its edits. Inbound
+	// is NOT gated in this release — Start still opens the pub/sub connection
+	// and RoomActivated still SUBSCRIBEs each room's channel whatever the
+	// Transport — so a Streams node does still RECEIVE pub/sub traffic and
+	// apply it. Two consequences: choosing Streams does not remove the
+	// pub/sub connection or the per-room SUBSCRIBE from this node's Redis
+	// footprint, and a half-migrated cluster is one-way rather than cleanly
+	// split. Gating the inbound side too is tracked as a follow-up issue.
+	//
+	// The migration advice is the same either way, because it only depends on
+	// the outbound gate: the zero-downtime path is to roll every node to
+	// Both, then roll every node to Streams. See docs/CLUSTERING.md.
 	Transport Transport
 
 	// StreamPrefix namespaces stream keys. Default "ygo:stream:".
@@ -398,14 +411,17 @@ type Relay struct {
 	// room's deactivation, and a residency-scoped home makes that structural:
 	// see roomWorker.awCursor, which also states why the two kinds differ.
 	cursors map[string]string
-	// lastSeq is the highest sequence number seen from each source node ON
-	// EACH STREAM, used to tell a trimmed-away gap from a node restart. Keyed
-	// by both because the publisher's counter is per stream (see seqs): keying
+	// lastSeq is the last sequence number seen from each source node ON EACH
+	// STREAM, used to tell a trimmed-away gap from a node restart. Keyed by
+	// both because the publisher's counter is per stream (see seqs): keying
 	// by nodeID alone would interleave two streams' sequences from one node
-	// into a single series and report the interleaving itself as gaps.
+	// into a single series and report the interleaving itself as gaps. The
+	// value also carries whether the PREVIOUS observation went backwards, so
+	// that the comparison immediately after a decrease re-baselines rather
+	// than reporting a gap — see noteSeq for why that case is routine.
 	// Guarded by streamMu and bounded by seqLimit; see noteSeq /
 	// evictStaleLastSeqLocked.
-	lastSeq map[seqSource]uint64
+	lastSeq map[seqSource]seqState
 
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
@@ -543,7 +559,7 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		streamRooms: make(map[string]int),
 		cursors:     make(map[string]string),
 		seqs:        make(map[string]uint64),
-		lastSeq:     make(map[seqSource]uint64),
+		lastSeq:     make(map[seqSource]seqState),
 	}, nil
 }
 

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -273,7 +273,7 @@ type Config struct {
 
 	// ReadBlock is how long one reader's XREAD blocks when it has nothing to
 	// deliver. Default 250ms, which is also the maximum: New fails if it is
-	// larger.
+	// larger, and the minimum: New fails if it is smaller than 1ms.
 	//
 	// It is not just a Redis-efficiency knob, because a blocked XREAD cannot
 	// be interrupted (go-redis honours a context deadline, not a
@@ -282,8 +282,8 @@ type Config struct {
 	// for a reader to notice shutdown, and on how long a newly activated room
 	// waits before its stream is read at all. Lower it to shorten both at the
 	// cost of more commands per second; it cannot be raised, because the
-	// latencies it would extend are not negotiable. See maxReadBlock
-	// (streams.go) for the full reasoning.
+	// latencies it would extend are not negotiable. See maxReadBlock and
+	// minReadBlock (streams.go) for the full reasoning.
 	//
 	// Delivery latency for a room already being read is NOT bounded by this:
 	// XREAD returns as soon as any of its keys gets an entry.

--- a/cluster/redis/redis.go
+++ b/cluster/redis/redis.go
@@ -346,6 +346,23 @@ type Relay struct {
 	trimmed  atomic.Uint64 // incremented by MINID sweeper
 	stalled  atomic.Uint64 // incremented by stream reader
 
+	// streamMu guards streamRooms. Separate from mu: mu is held across the
+	// pub/sub SUBSCRIBE/UNSUBSCRIBE RPC (see mu's doc below), and streamRooms
+	// bookkeeping must not be blocked behind a stalled Redis call it has
+	// nothing to do with. It is also separate from workersMu — streamRooms
+	// tracks READER-side (XREAD) assignment, an entirely different axis from
+	// the pub/sub delivery workers workersMu guards.
+	streamMu sync.Mutex
+	// streamRooms is a reference count per room name, mirroring activeRooms
+	// but for the stream reader's assignment instead of pub/sub subscription:
+	// RoomActivated/RoomDeactivated for the same room can arrive out of order
+	// across a room's eviction/reload handoff (see the Relay contract's
+	// RoomActivated doc), and a plain set would let the predecessor's
+	// deactivation evict a room the successor still needs read. Only
+	// incremented/decremented in Streams/Both mode. The reader task that
+	// consumes this to build its XREAD key set lands later.
+	streamRooms map[string]int
+
 	// outbound carries Publish calls to the publisher goroutine. A bounded
 	// channel back-pressures the caller, matching MemRelay.
 	outbound chan cluster.Outbound
@@ -479,6 +496,7 @@ func New(client *goredis.Client, cfg Config) (*Relay, error) {
 		activeRooms: make(map[string]int),
 		laneCap:     cfg.RoomQueueSize,
 		workers:     make(map[string]*roomWorker),
+		streamRooms: make(map[string]int),
 	}, nil
 }
 
@@ -803,6 +821,21 @@ func (r *Relay) RoomActivated(room string) {
 	default:
 	}
 
+	// Reader-side assignment refcount. This runs BEFORE the pub/sub
+	// count>1 short-circuit below, not after it: that short-circuit exists
+	// to skip a redundant SUBSCRIBE RPC, but a second RoomActivated call is
+	// still a real activation this relay must keep counted for the stream
+	// reader, exactly the successor-before-predecessor overlap the Relay
+	// contract requires tolerating. Placing this after the short-circuit
+	// (mirroring where the pub/sub work "ends") would silently skip the
+	// increment on every call past the first, undercounting activations and
+	// making a later RoomDeactivated evict a still-live room.
+	if r.scfg.transport.usesStreams() {
+		r.streamMu.Lock()
+		r.streamRooms[room]++
+		r.streamMu.Unlock()
+	}
+
 	r.activeRooms[room]++
 	if r.activeRooms[room] > 1 {
 		return // already subscribed
@@ -842,6 +875,31 @@ func (r *Relay) RoomDeactivated(room string) {
 	}
 	if r.activeRooms[room] <= 0 {
 		return
+	}
+
+	// Reader-side assignment ONLY — never publish-side state. RoomDeactivated's
+	// own contract (cluster/relay.go) warns that a relay releasing per-room
+	// PUBLISH-side state here — it names "a stream key" — would drop a
+	// trailing update, because the provider's lane worker can still call
+	// Publish for this room after RoomDeactivated returns. publishStream
+	// therefore never consults streamRooms; this map is consulted only by
+	// the (later) stream reader to decide which rooms it still owns.
+	//
+	// Decremented here, guarded by the same "was this room actually active"
+	// check as activeRooms above (r.activeRooms[room] <= 0 already
+	// returned), so an extra/no-op RoomDeactivated call can't underflow this
+	// counter either — mirroring activeRooms's own refcount rather than the
+	// pub/sub count>0 short-circuit below, which exists to skip a redundant
+	// UNSUBSCRIBE RPC and would otherwise leave a still-referenced room's
+	// count untouched on every call past the last one that reaches zero.
+	if r.scfg.transport.usesStreams() {
+		r.streamMu.Lock()
+		if n := r.streamRooms[room] - 1; n > 0 {
+			r.streamRooms[room] = n
+		} else {
+			delete(r.streamRooms, room)
+		}
+		r.streamMu.Unlock()
 	}
 
 	r.activeRooms[room]--

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -45,11 +45,10 @@ func (t Transport) String() string {
 // usesStreams reports whether this transport reads from and writes to streams.
 func (t Transport) usesStreams() bool { return t == Streams || t == Both }
 
-// usesPubSub reports whether this transport reads from and writes to
-// channels. Publish consults this to decide whether the pub/sub hand-off
-// runs at all: Streams-only mode must skip PUBLISH entirely, not merely
-// ignore its result, or a Streams deployment would still pay for and depend
-// on the at-most-once channel it exists to replace.
+// usesPubSub reports whether this transport reads from and writes to channels.
+// Publish consults it to skip the pub/sub hand-off entirely in Streams-only
+// mode, rather than merely ignoring its result: a Streams deployment must not
+// still depend on the at-most-once channel it exists to replace.
 func (t Transport) usesPubSub() bool { return t == PubSub || t == Both }
 
 // Stream tier defaults. See the corresponding Config fields for rationale.
@@ -67,59 +66,42 @@ const (
 // maxKeysPerRead bounds how many stream keys go into one XREAD. Not
 // configurable: an operator has no basis for choosing it, and Readers already
 // controls concurrency. Without it, 10k rooms across 4 readers would build a
-// ~5000-argument command every cycle. keyBatches (streams_reader.go) enforces
-// this; the reader task that issues XREAD lands later and consumes both.
+// ~5000-argument command every cycle. keyBatches enforces it.
 const maxKeysPerRead = 512
 
-// maxReadBlock is the largest Config.ReadBlock this package accepts, and also
-// its default. resolveStreamCfg REJECTS a larger value rather than capping it
-// silently, so the knob can never be set to a number that does not happen.
+// maxReadBlock is the largest Config.ReadBlock this package accepts, and its
+// default. resolveStreamCfg REJECTS a larger value rather than capping it, so
+// the knob can never be set to a number that does not happen.
 //
-// The ceiling exists because a blocked XREAD cannot be interrupted. go-redis
+// The ceiling exists because A BLOCKED XREAD CANNOT BE INTERRUPTED: go-redis
 // arms the socket read deadline from ctx.Deadline() only
 // (internal/pool.(*Conn).deadline, v9.18.0; withConn has no cancellation
-// watcher), so cancelling a reader's context mid-read does nothing. The
-// interval between one reader's reads is therefore BOTH of these latencies at
-// once, and each has a hard requirement:
+// watcher). One reader's read interval is therefore two latencies at once: how
+// long Close waits for a reader parked in an XREAD (measured 4.80s at a 5s
+// ReadBlock, in a path already fixed twice, #202/#229), and how long a room
+// activated after a reader's key set was fixed waits to be read at all.
 //
-//   - Shutdown. Close closes r.done and joins r.wg, so a reader parked in an
-//     XREAD holds Close open for the rest of that block. At a 5s ReadBlock
-//     this was measured at 4.80s — a five-second stall on every
-//     Server.Shutdown, in a path already fixed twice (#202, #229).
-//   - Activation. A reader's key set is fixed when its XREAD is issued, so a
-//     room activated after that cannot be read until the block expires. A
-//     room joining and then seeing no remote edits for seconds is the
-//     pub/sub tier's instant delivery visibly regressed.
-//
-// Neither is satisfiable at a multi-second block without waking a reader out
-// of its read, and the only mechanism for that is closing its connection —
-// connection churn proportional to room churn, which at this tier's 10k-room
-// target is a worse trade than a few extra idle XREADs per second. So the
-// block stays short and ReadBlock's range is honest about it: the idle cost is
-// Readers x ceil(keys-per-reader / maxKeysPerRead) XREADs per ReadBlock — 16/s
-// for a node with one batch per reader, ~160/s at 10k rooms across 4 readers —
-// and an XREAD that finds nothing is cheap.
-//
-// Lowering ReadBlock below this is a real and supported choice (faster
-// shutdown and activation, more commands); raising it is not offered, because
-// it could not be delivered.
+// Waking a reader out of its read would mean closing its connection — churn
+// proportional to room churn, a worse trade at this tier's 10k-room target
+// than a few extra idle XREADs per second. The idle cost is Readers x
+// ceil(keys-per-reader / maxKeysPerRead) XREADs per ReadBlock: 16/s with one
+// batch per reader, ~160/s at 10k rooms across 4 readers. So lowering ReadBlock
+// is supported; raising it is not offered, because it could not be delivered.
 const maxReadBlock = 250 * time.Millisecond
 
 // minReadBlock is the smallest Config.ReadBlock this package accepts.
 // resolveStreamCfg REJECTS a smaller value rather than degrading it silently.
 //
 // The floor exists because go-redis builds the BLOCK argument as
-// int64(block / time.Millisecond), so a sub-millisecond value truncates to 0.
-// In Redis, BLOCK 0 means block forever, so a reader in that XREAD would never
-// return, and Close's wg.Wait would hang. The reader also arms its socket read
-// deadline from ctx.Deadline(), not from cancellation, so there is no other
-// mechanism to wake it.
+// int64(block / time.Millisecond), so a sub-millisecond value truncates to 0,
+// and Redis reads BLOCK 0 as block forever: the reader would never return and
+// Close's wg.Wait would hang, with nothing able to wake it (see maxReadBlock).
 const minReadBlock = 1 * time.Millisecond
 
 // stalledBackoffBase is the first wait after a room's cursor advance is
 // declined for lane backpressure. It doubles per consecutive stalled cycle and
-// is capped at ReadBlock; see stallBackoff, which applies it. Not configurable,
-// for the same reason as maxKeysPerRead.
+// is capped at ReadBlock; see stallBackoff. Not configurable, for the same
+// reason as maxKeysPerRead.
 const stalledBackoffBase = 50 * time.Millisecond
 
 // streamCfg is Config's stream half with defaults resolved, so no code past
@@ -181,8 +163,7 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 		sc.trimInterval = defaultTrimInterval
 	}
 	// Only the UNSET value is defaulted: a negative ReadBlock must reach the
-	// minReadBlock rejection below, as its doc promises, not be adjusted into
-	// the default.
+	// minReadBlock rejection below, as its doc promises.
 	if sc.readBlock == 0 {
 		sc.readBlock = defaultReadBlock
 	}
@@ -197,8 +178,7 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 			pool, sc.readers, sc.readBlock)
 	}
 	// Rejected, not capped: a knob whose value is silently ignored above some
-	// threshold is worse than one with a documented range. See maxReadBlock
-	// for why the ceiling is where it is.
+	// threshold is worse than one with a documented range. See maxReadBlock.
 	if sc.readBlock > maxReadBlock {
 		return streamCfg{}, fmt.Errorf(
 			"cluster/redis: ReadBlock (%s) must not exceed %s: the interval between a reader's XREADs is also how long Close and a newly activated room wait, and a blocked XREAD cannot be interrupted",
@@ -217,57 +197,38 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 	return sc, nil
 }
 
-// Stream-kind discriminators. The room name is APPENDED to one of these, so
-// the discriminator sits immediately after the prefix, ahead of every
-// caller-supplied byte.
+// Stream-kind discriminators. The room name is APPENDED to one of these, so the
+// discriminator sits ahead of every caller-supplied byte.
 //
-// That placement is the whole point of the layout. internal/roomname.Valid
-// deliberately accepts every printable character, ":" included, to match the
-// y-websocket JS server, so a room name may contain anything a key may. Under
-// the earlier layout — syncKey = prefix+room, awKey = prefix+"aw:"+room — a
-// room named "aw:foo" produced byte-for-byte room "foo"'s awareness key, so
-// that room's SYNC traffic and room "foo"'s PRESENCE traffic shared one Redis
-// stream, each reader interpreting the other room's entries under its own
-// kind.
-//
-// With the discriminator first, a collision would require "s:"+x == "a:"+y
-// for some room names x and y. Those two strings differ in their first byte,
-// so no pair of room names can satisfy it: the room name can no longer forge
-// a discriminator, because it is never in a position to be read as one.
+// internal/roomname.Valid accepts every printable character, ":" included, to
+// match the y-websocket JS server, so a room name may contain anything a key
+// may. Under a suffix layout — awKey = prefix+"aw:"+room — a room named
+// "aw:foo" produced byte-for-byte room "foo"'s awareness key, sharing one
+// stream between that room's SYNC traffic and "foo"'s PRESENCE traffic. With
+// the discriminator first, a collision needs "s:"+x == "a:"+y, which differ in
+// their first byte.
 const (
 	kindDiscrimSync      = "s:"
 	kindDiscrimAwareness = "a:"
 )
 
-// syncKey is the room's sync stream key: prefix + "s:" + room. publishStream
-// XADDs to it and readBatch XREADs it.
-//
-// See the discriminator constants above for why "s:" precedes the room name
-// instead of the two key shapes differing by a suffix on one of them.
+// syncKey is the room's sync stream key: prefix + "s:" + room. See the
+// discriminator constants for why "s:" precedes the room name.
 func (s streamCfg) syncKey(room string) string { return s.prefix + kindDiscrimSync + room }
 
 // awKey is the room's awareness stream key: prefix + "a:" + room. A separate
-// stream from syncKey — see Config.AwarenessMaxLen — and provably a separate
-// KEY for every possible pair of room names, per the discriminator constants.
+// stream from syncKey (see Config.AwarenessMaxLen) and provably a separate KEY
+// for every possible pair of room names, per the discriminator constants.
 func (s streamCfg) awKey(room string) string { return s.prefix + kindDiscrimAwareness + room }
 
 // parseStreamKey recovers the room and the stream kind from a stream key,
-// exactly or not at all.
+// exactly or not at all — after the prefix the next two bytes are the
+// discriminator and every remaining byte is the room name verbatim.
 //
-// Exact because of the layout above: after the prefix the next two bytes are
-// the discriminator, and every remaining byte is the room name verbatim.
-// There is no second reading to weigh, because one key cannot be both a sync
-// key and an awareness key, and the room name never occupies the
-// discriminator's position. Under the earlier suffix layout this operation was
-// genuinely ambiguous, which is why the reader carries a streamTarget forward
-// rather than parsing (see streamTarget); this function serves the diagnostic
-// path, where a key the reader did not ask for turns up and the useful thing
-// to log is what that key claims to be.
-//
-// A key matching neither discriminator returns ok=false and must be IGNORED,
-// never guessed at. Guessing is what would attribute a foreign key's entries
-// to a real room, and this file already records what filing a payload under
-// the wrong interpretation costs (see decodeStreamEntry).
+// For the DIAGNOSTIC path only: the reader carries a streamTarget forward
+// rather than parsing. A key matching neither discriminator returns ok=false
+// and must be IGNORED, never guessed at — guessing would attribute a foreign
+// key's entries to a real room.
 func (s streamCfg) parseStreamKey(key string) (room string, isAwareness, ok bool) {
 	rest, found := strings.CutPrefix(key, s.prefix)
 	if !found {
@@ -283,11 +244,9 @@ func (s streamCfg) parseStreamKey(key string) (room string, isAwareness, ok bool
 }
 
 // liveStreamKeysLocked is the set of stream keys this node still has a room
-// for: both streams of every room in streamRooms.
-//
-// Built in the forward direction — room names through syncKey/awKey — rather
-// than by parsing keys back into rooms, so it holds for any room name without
-// depending on the key layout being reversible at all.
+// for: both streams of every room in streamRooms. Built forward — room names
+// through syncKey/awKey — rather than by parsing keys back into rooms, so it
+// holds for any room name without depending on the layout being reversible.
 //
 // Caller must hold streamMu (which guards streamRooms).
 func (r *Relay) liveStreamKeysLocked() map[string]struct{} {
@@ -299,11 +258,10 @@ func (r *Relay) liveStreamKeysLocked() map[string]struct{} {
 	return live
 }
 
-// Stream entry field names. Single letters on purpose: every byte is
-// multiplied by retention x rate x rooms.
-//
-// room is absent because the stream KEY is authoritative — XRANGE shows it,
-// and there is no route by which an entry could reach the wrong room's key.
+// Stream entry field names. Single letters on purpose: every byte is multiplied
+// by retention x rate x rooms. room is absent because the stream KEY is
+// authoritative, and there is no route by which an entry could reach the wrong
+// room's key.
 const (
 	fieldNode = "n" // publisher nodeID, for the self-delivery filter
 	fieldSeq  = "s" // per-node, per-stream monotonic sequence, for gap detection
@@ -317,35 +275,22 @@ const seqLimit = 4096
 
 // nextSeq issues this node's next sequence number FOR ONE STREAM.
 //
-// The counter must exist from the first release: it cannot be retrofitted,
-// and without it gap detection is impossible. XREAD from a trimmed ID returns
-// the next surviving entry with NO error, and stream IDs are ms-seq rather
-// than contiguous, so trimming is indistinguishable from ordinary
-// advancement by ID arithmetic alone.
+// It cannot be retrofitted, and without it gap detection is impossible: XREAD
+// from a trimmed ID returns the next surviving entry with NO error, and stream
+// IDs are ms-seq rather than contiguous, so trimming is indistinguishable from
+// ordinary advancement by ID arithmetic alone.
 //
-// It is per node PER STREAM, keyed by the stream key this entry is about to be
-// written to. A single per-node counter — the earlier design — is not merely
-// coarser, it is wrong, and it breaks the counter's only consumer. A reader
-// watching one stream sees only the subset of a publisher's entries that
-// landed in THAT stream, so a node publishing to rooms A and B writes seqs
-// [1 3 5] into A's stream and [2 4 6] into B's, and both readers see a
-// sequence full of holes. noteSeq classifies seq > prev+1 as a gap, and
-// StreamStats.Gaps is documented "ALERT ON PRESENCE… a single gap means data
-// was lost" — so a per-node counter makes the tier's headline signal fire
-// constantly on every healthy multi-room node, which is the same as having no
-// signal at all. Per stream, one node's entries in one stream are contiguous,
-// and a jump can only mean entries were trimmed before the reader reached
-// them.
+// Per node PER STREAM. A single per-node counter is not merely coarser, it is
+// wrong: a reader of one stream sees only the publisher's entries that landed
+// in THAT stream, so a node publishing to rooms A and B writes [1 3 5] into A's
+// stream and [2 4 6] into B's, and both readers see holes — and noteSeq
+// classifies seq > prev+1 as a gap, so per-node would fire StreamStats.Gaps
+// ("ALERT ON PRESENCE") constantly on every healthy multi-room node. Counters
+// restart at 0 with the process; a reader reads a DECREASE as a restart.
 //
-// Counters live in memory, so they restart at 0 when the process does, and a
-// reader treats a DECREASE as a restart rather than a gap — see noteSeq.
-//
-// streamMu rather than an atomic per counter: the map lookup has to be
-// serialised anyway, and once it is, incrementing a plain uint64 under that
-// same lock costs one arithmetic op and saves a per-stream heap allocation.
-// The lock is cheap here in absolute terms and cheaper still in context —
-// streamMu is never held across I/O anywhere (that is why it exists separately
-// from mu), and the caller is about to make a network round trip.
+// streamMu rather than an atomic per counter: the map lookup is serialised
+// anyway, so incrementing under it costs one arithmetic op and saves a
+// per-stream allocation. streamMu is never held across I/O.
 func (r *Relay) nextSeq(streamKey string) uint64 {
 	r.streamMu.Lock()
 	defer r.streamMu.Unlock()
@@ -358,24 +303,15 @@ func (r *Relay) nextSeq(streamKey string) uint64 {
 }
 
 // evictStaleSeqsLocked drops the counters of streams whose room this node no
-// longer holds, in one pass, and keeps every counter whose room is still live.
+// longer holds: the map grows with every stream ever published to, and room
+// churn over a long-lived process is unbounded even though the live set is not.
+// Same policy as evictStaleCursorsLocked, including leaving the map above
+// seqLimit when every counter is live.
 //
-// Bounding is needed because the map grows with the streams this node has
-// ever published to, and room churn over a long-lived process is unbounded
-// even though the live set is not. It mirrors evictStaleCursorsLocked's policy
-// exactly, for the same reason: if every counter is live the map is left above
-// seqLimit, which is correct, because the residual is then bounded by real
-// load (streamsPerRoom x resident rooms) rather than by history.
-//
-// Dropping a stale counter is safe in the direction that matters. A room this
-// node has released is a room it has stopped publishing to — the Relay
-// contract has the server activate every room it hosts — so if it is ever
-// reactivated here the counter restarts at 1, and a reader classifies a
-// DECREASE as a restart, never as a gap. The eviction therefore cannot
-// manufacture the alarm this counter exists to raise — at worst it adds one
-// Restarts increment, a counter documented as informational. A caller that
-// published without ever activating (nothing does in production; some tests
-// do) would trade the same way: extra Restarts, never a Gap.
+// Safe in the direction that matters: a room this node released is one it
+// stopped publishing to — the Relay contract has the server activate every room
+// it hosts — so a reactivation restarts the counter at 1, and a reader reads a
+// DECREASE as a restart, never a gap. At worst it adds one Restarts increment.
 //
 // Caller must hold streamMu.
 func (r *Relay) evictStaleSeqsLocked() {
@@ -397,12 +333,10 @@ func streamFields(nodeID []byte, seq uint64, kind cluster.Kind, data []byte) []a
 	}
 }
 
-// decodeStreamEntry reads one XREAD entry's fields.
-//
-// Every field is required. A malformed entry is rejected rather than
-// defaulted: the pub/sub router already learned (see its unrecognised-kind
-// handling) that guessing at a payload can cost a room its legitimate
-// updates, because a non-V1 blob makes the lane's MergeUpdatesV1 fail.
+// decodeStreamEntry reads one XREAD entry's fields. Every field is required: a
+// malformed entry is rejected rather than defaulted, because guessing at a
+// payload can cost a room its legitimate updates — a non-V1 blob makes the
+// lane's MergeUpdatesV1 fail.
 func decodeStreamEntry(vals map[string]any) (nodeID []byte, seq uint64, kind cluster.Kind, data []byte, err error) {
 	str := func(k string) (string, error) {
 		v, ok := vals[k]
@@ -445,19 +379,16 @@ func decodeStreamEntry(vals map[string]any) (nodeID []byte, seq uint64, kind clu
 
 // publishStream appends one payload to its room's stream.
 //
-// Trimming is inline MAXLEN ~ rather than a separate XTRIM call: it costs
-// nothing extra on a write that is already happening, and it is the memory
-// half of the guarantee. The time half is the MINID sweeper, because MAXLEN
-// alone gives no age bound — a hot room's 4096 entries might be two seconds.
+// Trimming is inline MAXLEN ~ rather than a separate XTRIM: free on a write
+// already happening, and the memory half of the guarantee. The time half is the
+// MINID sweeper, because MAXLEN alone gives no age bound — a hot room's 4096
+// entries might be two seconds. The approximate form (~) avoids O(n) per XADD
+// on a hot stream, and keeps MORE entries than asked, never fewer, so it can
+// overshoot on memory but can never shrink the delivery window.
 //
-// The approximate form (~) is deliberate. Exact trimming is O(n) per XADD on
-// a hot stream, and Redis recommends ~ for exactly this reason. Approximate
-// trimming keeps MORE entries than asked, never fewer, so it can overshoot on
-// memory but can never shrink the delivery window.
-//
-// ctx is the caller's: Server.Shutdown cancels the relay context and then
-// joins the lane workers, so a publish that ignored cancellation would stall
-// that join and leave a worker running past Shutdown (#202).
+// ctx is the caller's: Server.Shutdown cancels the relay context and then joins
+// the lane workers, so a publish that ignored cancellation would stall that
+// join and leave a worker running past Shutdown (#202).
 func (r *Relay) publishStream(ctx context.Context, out cluster.Outbound) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -472,9 +403,8 @@ func (r *Relay) publishStream(ctx context.Context, out cluster.Outbound) error {
 		Stream: key,
 		MaxLen: maxLen,
 		Approx: true,
-		// nextSeq is passed the key this entry is about to be written to:
-		// the counter is per stream, because a reader of one stream sees only
-		// that stream's entries. See nextSeq.
+		// nextSeq is passed the key this entry is about to be written to: the
+		// counter is per stream. See nextSeq.
 		Values: streamFields(r.nodeID, r.nextSeq(key), out.Kind, out.Data),
 	}).Err()
 }

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -157,14 +158,87 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 	return sc, nil
 }
 
-// syncKey is the room's sync stream key. publishStream XADDs to it; the
-// reader task that XREADs it lands later.
-func (s streamCfg) syncKey(room string) string { return s.prefix + room }
+// Stream-kind discriminators. The room name is APPENDED to one of these, so
+// the discriminator sits immediately after the prefix, ahead of every
+// caller-supplied byte.
+//
+// That placement is the whole point of the layout. internal/roomname.Valid
+// deliberately accepts every printable character, ":" included, to match the
+// y-websocket JS server, so a room name may contain anything a key may. Under
+// the earlier layout — syncKey = prefix+room, awKey = prefix+"aw:"+room — a
+// room named "aw:foo" produced byte-for-byte room "foo"'s awareness key, so
+// that room's SYNC traffic and room "foo"'s PRESENCE traffic shared one Redis
+// stream, each reader interpreting the other room's entries under its own
+// kind.
+//
+// With the discriminator first, a collision would require "s:"+x == "a:"+y
+// for some room names x and y. Those two strings differ in their first byte,
+// so no pair of room names can satisfy it: the room name can no longer forge
+// a discriminator, because it is never in a position to be read as one.
+const (
+	kindDiscrimSync      = "s:"
+	kindDiscrimAwareness = "a:"
+)
 
-// awKey is the room's awareness stream key. Separate from syncKey — see
-// Config.AwarenessMaxLen. publishStream XADDs to it; the reader task that
-// XREADs it lands later.
-func (s streamCfg) awKey(room string) string { return s.prefix + "aw:" + room }
+// syncKey is the room's sync stream key: prefix + "s:" + room. publishStream
+// XADDs to it and readBatch XREADs it.
+//
+// See the discriminator constants above for why "s:" precedes the room name
+// instead of the two key shapes differing by a suffix on one of them.
+func (s streamCfg) syncKey(room string) string { return s.prefix + kindDiscrimSync + room }
+
+// awKey is the room's awareness stream key: prefix + "a:" + room. A separate
+// stream from syncKey — see Config.AwarenessMaxLen — and provably a separate
+// KEY for every possible pair of room names, per the discriminator constants.
+func (s streamCfg) awKey(room string) string { return s.prefix + kindDiscrimAwareness + room }
+
+// parseStreamKey recovers the room and the stream kind from a stream key,
+// exactly or not at all.
+//
+// Exact because of the layout above: after the prefix the next two bytes are
+// the discriminator, and every remaining byte is the room name verbatim.
+// There is no second reading to weigh, because one key cannot be both a sync
+// key and an awareness key, and the room name never occupies the
+// discriminator's position. Under the earlier suffix layout this operation was
+// genuinely ambiguous, which is why the reader carries a streamTarget forward
+// rather than parsing (see streamTarget); this function serves the diagnostic
+// path, where a key the reader did not ask for turns up and the useful thing
+// to log is what that key claims to be.
+//
+// A key matching neither discriminator returns ok=false and must be IGNORED,
+// never guessed at. Guessing is what would attribute a foreign key's entries
+// to a real room, and this file already records what filing a payload under
+// the wrong interpretation costs (see decodeStreamEntry).
+func (s streamCfg) parseStreamKey(key string) (room string, isAwareness, ok bool) {
+	rest, found := strings.CutPrefix(key, s.prefix)
+	if !found {
+		return "", false, false
+	}
+	if room, found := strings.CutPrefix(rest, kindDiscrimSync); found {
+		return room, false, true
+	}
+	if room, found := strings.CutPrefix(rest, kindDiscrimAwareness); found {
+		return room, true, true
+	}
+	return "", false, false
+}
+
+// liveStreamKeysLocked is the set of stream keys this node still has a room
+// for: both streams of every room in streamRooms.
+//
+// Built in the forward direction — room names through syncKey/awKey — rather
+// than by parsing keys back into rooms, so it holds for any room name without
+// depending on the key layout being reversible at all.
+//
+// Caller must hold streamMu (which guards streamRooms).
+func (r *Relay) liveStreamKeysLocked() map[string]struct{} {
+	live := make(map[string]struct{}, len(r.streamRooms)*streamsPerRoom)
+	for room := range r.streamRooms {
+		live[r.scfg.syncKey(room)] = struct{}{}
+		live[r.scfg.awKey(room)] = struct{}{}
+	}
+	return live
+}
 
 // Stream entry field names. Single letters on purpose: every byte is
 // multiplied by retention x rate x rooms.
@@ -173,23 +247,86 @@ func (s streamCfg) awKey(room string) string { return s.prefix + "aw:" + room }
 // and there is no route by which an entry could reach the wrong room's key.
 const (
 	fieldNode = "n" // publisher nodeID, for the self-delivery filter
-	fieldSeq  = "s" // per-node monotonic sequence, for gap detection
+	fieldSeq  = "s" // per-node, per-stream monotonic sequence, for gap detection
 	fieldKind = "k" // cluster.Kind
 	fieldData = "d" // payload
 )
 
-// nextSeq issues this relay's next sequence number.
+// seqLimit bounds how many per-stream sequence counters this node keeps. See
+// evictStaleSeqsLocked for which entries go, and why losing one is safe.
+const seqLimit = 4096
+
+// nextSeq issues this node's next sequence number FOR ONE STREAM.
 //
-// The counter is per-node and monotonic, and it must exist from the first
-// release: it cannot be retrofitted, and without it gap detection is
-// impossible. XREAD from a trimmed ID returns the next surviving entry with
-// NO error, and stream IDs are ms-seq rather than contiguous, so trimming is
-// indistinguishable from ordinary advancement by ID arithmetic alone.
+// The counter must exist from the first release: it cannot be retrofitted,
+// and without it gap detection is impossible. XREAD from a trimmed ID returns
+// the next surviving entry with NO error, and stream IDs are ms-seq rather
+// than contiguous, so trimming is indistinguishable from ordinary
+// advancement by ID arithmetic alone.
 //
-// It lives in memory, so it restarts at 0 when the process does. A reader
-// treats a DECREASE as a restart rather than a gap — see the reader's
-// gap-detection notes.
-func (r *Relay) nextSeq() uint64 { return r.seq.Add(1) }
+// It is per node PER STREAM, keyed by the stream key this entry is about to be
+// written to. A single per-node counter — the earlier design — is not merely
+// coarser, it is wrong, and it breaks the counter's only consumer. A reader
+// watching one stream sees only the subset of a publisher's entries that
+// landed in THAT stream, so a node publishing to rooms A and B writes seqs
+// [1 3 5] into A's stream and [2 4 6] into B's, and both readers see a
+// sequence full of holes. noteSeq classifies seq > prev+1 as a gap, and
+// StreamStats.Gaps is documented "ALERT ON PRESENCE… a single gap means data
+// was lost" — so a per-node counter makes the tier's headline signal fire
+// constantly on every healthy multi-room node, which is the same as having no
+// signal at all. Per stream, one node's entries in one stream are contiguous,
+// and a jump can only mean entries were trimmed before the reader reached
+// them.
+//
+// Counters live in memory, so they restart at 0 when the process does, and a
+// reader treats a DECREASE as a restart rather than a gap — see noteSeq.
+//
+// streamMu rather than an atomic per counter: the map lookup has to be
+// serialised anyway, and once it is, incrementing a plain uint64 under that
+// same lock costs one arithmetic op and saves a per-stream heap allocation.
+// The lock is cheap here in absolute terms and cheaper still in context —
+// streamMu is never held across I/O anywhere (that is why it exists separately
+// from mu), and the caller is about to make a network round trip.
+func (r *Relay) nextSeq(streamKey string) uint64 {
+	r.streamMu.Lock()
+	defer r.streamMu.Unlock()
+
+	if _, known := r.seqs[streamKey]; !known && len(r.seqs) >= seqLimit {
+		r.evictStaleSeqsLocked()
+	}
+	r.seqs[streamKey]++
+	return r.seqs[streamKey]
+}
+
+// evictStaleSeqsLocked drops the counters of streams whose room this node no
+// longer holds, in one pass, and keeps every counter whose room is still live.
+//
+// Bounding is needed because the map grows with the streams this node has
+// ever published to, and room churn over a long-lived process is unbounded
+// even though the live set is not. It mirrors evictStaleCursorsLocked's policy
+// exactly, for the same reason: if every counter is live the map is left above
+// seqLimit, which is correct, because the residual is then bounded by real
+// load (streamsPerRoom x resident rooms) rather than by history.
+//
+// Dropping a stale counter is safe in the direction that matters. A room this
+// node has released is a room it has stopped publishing to — the Relay
+// contract has the server activate every room it hosts — so if it is ever
+// reactivated here the counter restarts at 1, and a reader classifies a
+// DECREASE as a restart, never as a gap. The eviction therefore cannot
+// manufacture the alarm this counter exists to raise — at worst it adds one
+// Restarts increment, a counter documented as informational. A caller that
+// published without ever activating (nothing does in production; some tests
+// do) would trade the same way: extra Restarts, never a Gap.
+//
+// Caller must hold streamMu.
+func (r *Relay) evictStaleSeqsLocked() {
+	live := r.liveStreamKeysLocked()
+	for key := range r.seqs {
+		if _, ok := live[key]; !ok {
+			delete(r.seqs, key)
+		}
+	}
+}
 
 // streamFields builds the XADD field list for one entry.
 func streamFields(nodeID []byte, seq uint64, kind cluster.Kind, data []byte) []any {
@@ -276,6 +413,9 @@ func (r *Relay) publishStream(ctx context.Context, out cluster.Outbound) error {
 		Stream: key,
 		MaxLen: maxLen,
 		Approx: true,
-		Values: streamFields(r.nodeID, r.nextSeq(), out.Kind, out.Data),
+		// nextSeq is passed the key this entry is about to be written to:
+		// the counter is per stream, because a reader of one stream sees only
+		// that stream's entries. See nextSeq.
+		Values: streamFields(r.nodeID, r.nextSeq(key), out.Kind, out.Data),
 	}).Err()
 }

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -1,0 +1,169 @@
+// Package-internal: the Redis Streams delivery tier. See Config.Transport.
+package redis
+
+import (
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// Transport selects how a Relay moves payloads between nodes.
+type Transport int
+
+const (
+	// PubSub is the zero value: Redis pub/sub, at-most-once. Redis drops slow
+	// subscribers server-side, so a payload missed is a payload gone.
+	PubSub Transport = iota
+	// Streams is the at-least-once tier: one Redis stream per room, replayed
+	// from the oldest retained entry, bounded by retention and length.
+	Streams
+	// Both publishes to and reads from both tiers, for zero-downtime
+	// migration. Needs no deduplication: V1 updates are idempotent.
+	Both
+)
+
+// String makes Transport readable in logs and test failures.
+func (t Transport) String() string {
+	switch t {
+	case PubSub:
+		return "pubsub"
+	case Streams:
+		return "streams"
+	case Both:
+		return "both"
+	default:
+		return fmt.Sprintf("Transport(%d)", int(t))
+	}
+}
+
+// usesStreams reports whether this transport reads from and writes to streams.
+func (t Transport) usesStreams() bool { return t == Streams || t == Both }
+
+// usesPubSub reports whether this transport reads from and writes to channels.
+// This task adds Transport's full API; the reader/writer tasks that dispatch
+// on it land later.
+//
+//nolint:unused // consumed by a later task, see the sentence above
+func (t Transport) usesPubSub() bool { return t == PubSub || t == Both }
+
+// Stream tier defaults. See the corresponding Config fields for rationale.
+const (
+	defaultStreamPrefix       = "ygo:stream:"
+	defaultStreamRetention    = 60 * time.Second
+	defaultStreamMaxLen       = int64(4096)
+	defaultAwarenessMaxLen    = int64(64)
+	defaultAwarenessRetention = 10 * time.Second
+	defaultReaders            = 4
+	defaultTrimInterval       = 30 * time.Second
+	defaultReadBlock          = 5 * time.Second
+)
+
+// maxKeysPerRead bounds how many stream keys go into one XREAD. Not
+// configurable: an operator has no basis for choosing it, and Readers already
+// controls concurrency. Without it, 10k rooms across 4 readers would build a
+// ~5000-argument command every cycle. The reader task that issues XREAD
+// lands later and consumes it.
+//
+//nolint:unused // consumed by a later task, see the sentence above
+const maxKeysPerRead = 512
+
+// stalledBackoffBase is the first wait after a room's cursor advance is
+// declined for lane backpressure. It doubles per consecutive stall, capped at
+// ReadBlock. Not configurable, for the same reason as maxKeysPerRead. The
+// reader task that applies backpressure backoff lands later and consumes it.
+//
+//nolint:unused // consumed by a later task, see the sentence above
+const stalledBackoffBase = 50 * time.Millisecond
+
+// streamCfg is Config's stream half with defaults resolved, so no code past
+// construction has to reason about zero values.
+type streamCfg struct {
+	transport    Transport
+	prefix       string
+	retention    time.Duration
+	maxLen       int64
+	awMaxLen     int64
+	awRetention  time.Duration
+	readers      int
+	trimInterval time.Duration
+	readBlock    time.Duration
+}
+
+// resolveStreamCfg fills defaults and rejects configurations that would fail
+// confusingly later rather than obviously now.
+//
+// It validates NOTHING in PubSub mode: an existing caller has never set these
+// fields, and must not start failing construction because a new field exists.
+func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
+	switch cfg.Transport {
+	case PubSub, Streams, Both:
+	default:
+		return streamCfg{}, fmt.Errorf("cluster/redis: unknown Config.Transport %d", int(cfg.Transport))
+	}
+
+	sc := streamCfg{
+		transport:    cfg.Transport,
+		prefix:       cfg.StreamPrefix,
+		retention:    cfg.StreamRetention,
+		maxLen:       cfg.StreamMaxLen,
+		awMaxLen:     cfg.AwarenessMaxLen,
+		awRetention:  cfg.AwarenessRetention,
+		readers:      cfg.Readers,
+		trimInterval: cfg.TrimInterval,
+		readBlock:    cfg.ReadBlock,
+	}
+	if sc.prefix == "" {
+		sc.prefix = defaultStreamPrefix
+	}
+	if sc.retention <= 0 {
+		sc.retention = defaultStreamRetention
+	}
+	if sc.maxLen <= 0 {
+		sc.maxLen = defaultStreamMaxLen
+	}
+	if sc.awMaxLen <= 0 {
+		sc.awMaxLen = defaultAwarenessMaxLen
+	}
+	if sc.awRetention <= 0 {
+		sc.awRetention = defaultAwarenessRetention
+	}
+	if sc.readers <= 0 {
+		sc.readers = defaultReaders
+	}
+	if sc.trimInterval <= 0 {
+		sc.trimInterval = defaultTrimInterval
+	}
+	if sc.readBlock <= 0 {
+		sc.readBlock = defaultReadBlock
+	}
+
+	if !sc.transport.usesStreams() {
+		return sc, nil
+	}
+
+	if pool := client.Options().PoolSize; pool <= sc.readers {
+		return streamCfg{}, fmt.Errorf(
+			"cluster/redis: PoolSize (%d) must exceed Readers (%d): every blocking XREAD holds a pool connection for its whole ReadBlock, so an equal or smaller pool starves publishes",
+			pool, sc.readers)
+	}
+	if sc.trimInterval >= sc.retention {
+		return streamCfg{}, fmt.Errorf(
+			"cluster/redis: TrimInterval (%s) must be less than StreamRetention (%s): a sweeper slower than the window it enforces cannot enforce it",
+			sc.trimInterval, sc.retention)
+	}
+	return sc, nil
+}
+
+// syncKey is the room's sync stream key. The reader/writer tasks that
+// XADD/XREAD by key land later and consume it.
+//
+//nolint:unused // consumed by a later task, see the sentence above
+func (s streamCfg) syncKey(room string) string { return s.prefix + room }
+
+// awKey is the room's awareness stream key. Separate from syncKey — see
+// Config.AwarenessMaxLen. The reader/writer tasks that XADD/XREAD by key
+// land later and consume it.
+//
+//nolint:unused // consumed by a later task, see the sentence above
+func (s streamCfg) awKey(room string) string { return s.prefix + "aw:" + room }

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -66,10 +66,8 @@ const (
 // maxKeysPerRead bounds how many stream keys go into one XREAD. Not
 // configurable: an operator has no basis for choosing it, and Readers already
 // controls concurrency. Without it, 10k rooms across 4 readers would build a
-// ~5000-argument command every cycle. The reader task that issues XREAD
-// lands later and consumes it.
-//
-//nolint:unused // consumed by a later task, see the sentence above
+// ~5000-argument command every cycle. keyBatches (streams_reader.go) enforces
+// this; the reader task that issues XREAD lands later and consumes both.
 const maxKeysPerRead = 512
 
 // stalledBackoffBase is the first wait after a room's cursor advance is

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -61,7 +61,7 @@ const (
 	defaultAwarenessRetention = 10 * time.Second
 	defaultReaders            = 4
 	defaultTrimInterval       = 30 * time.Second
-	defaultReadBlock          = 5 * time.Second
+	defaultReadBlock          = maxReadBlock
 )
 
 // maxKeysPerRead bounds how many stream keys go into one XREAD. Not
@@ -70,6 +70,39 @@ const (
 // ~5000-argument command every cycle. keyBatches (streams_reader.go) enforces
 // this; the reader task that issues XREAD lands later and consumes both.
 const maxKeysPerRead = 512
+
+// maxReadBlock is the largest Config.ReadBlock this package accepts, and also
+// its default. resolveStreamCfg REJECTS a larger value rather than capping it
+// silently, so the knob can never be set to a number that does not happen.
+//
+// The ceiling exists because a blocked XREAD cannot be interrupted. go-redis
+// arms the socket read deadline from ctx.Deadline() only
+// (internal/pool.(*Conn).deadline, v9.18.0; withConn has no cancellation
+// watcher), so cancelling a reader's context mid-read does nothing. The
+// interval between one reader's reads is therefore BOTH of these latencies at
+// once, and each has a hard requirement:
+//
+//   - Shutdown. Close closes r.done and joins r.wg, so a reader parked in an
+//     XREAD holds Close open for the rest of that block. At a 5s ReadBlock
+//     this was measured at 4.80s — a five-second stall on every
+//     Server.Shutdown, in a path already fixed twice (#202, #229).
+//   - Activation. A reader's key set is fixed when its XREAD is issued, so a
+//     room activated after that cannot be read until the block expires. A
+//     room joining and then seeing no remote edits for seconds is the
+//     pub/sub tier's instant delivery visibly regressed.
+//
+// Neither is satisfiable at a multi-second block without waking a reader out
+// of its read, and the only mechanism for that is closing its connection —
+// connection churn proportional to room churn, which at this tier's 10k-room
+// target is a worse trade than a few extra idle XREADs per second. So the
+// block stays short and ReadBlock's range is honest about it: 250ms x 4
+// readers is 16 XREADs a second on an idle node, and an XREAD that finds
+// nothing is cheap.
+//
+// Lowering ReadBlock below this is a real and supported choice (faster
+// shutdown and activation, more commands); raising it is not offered, because
+// it could not be delivered.
+const maxReadBlock = 250 * time.Millisecond
 
 // stalledBackoffBase is the first wait after a room's cursor advance is
 // declined for lane backpressure. It doubles per consecutive stall, capped at
@@ -147,8 +180,16 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 
 	if pool := client.Options().PoolSize; pool <= sc.readers {
 		return streamCfg{}, fmt.Errorf(
-			"cluster/redis: PoolSize (%d) must exceed Readers (%d): every blocking XREAD holds a pool connection for its whole ReadBlock, so an equal or smaller pool starves publishes",
-			pool, sc.readers)
+			"cluster/redis: PoolSize (%d) must exceed Readers (%d): a reader holds a pool connection for as long as its XREAD blocks (up to ReadBlock, %s), so a pool no larger than Readers leaves publishes and the trim sweeper waiting on a connection every cycle",
+			pool, sc.readers, sc.readBlock)
+	}
+	// Rejected, not capped: a knob whose value is silently ignored above some
+	// threshold is worse than one with a documented range. See maxReadBlock
+	// for why the ceiling is where it is.
+	if sc.readBlock > maxReadBlock {
+		return streamCfg{}, fmt.Errorf(
+			"cluster/redis: ReadBlock (%s) must not exceed %s: the interval between a reader's XREADs is also how long Close and a newly activated room wait, and a blocked XREAD cannot be interrupted",
+			sc.readBlock, maxReadBlock)
 	}
 	if sc.trimInterval >= sc.retention {
 		return streamCfg{}, fmt.Errorf(

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -104,6 +104,17 @@ const maxKeysPerRead = 512
 // it could not be delivered.
 const maxReadBlock = 250 * time.Millisecond
 
+// minReadBlock is the smallest Config.ReadBlock this package accepts.
+// resolveStreamCfg REJECTS a smaller value rather than degrading it silently.
+//
+// The floor exists because go-redis builds the BLOCK argument as
+// int64(block / time.Millisecond), so a sub-millisecond value truncates to 0.
+// In Redis, BLOCK 0 means block forever, so a reader in that XREAD would never
+// return, and Close's wg.Wait would hang. The reader also arms its socket read
+// deadline from ctx.Deadline(), not from cancellation, so there is no other
+// mechanism to wake it.
+const minReadBlock = 1 * time.Millisecond
+
 // stalledBackoffBase is the first wait after a room's cursor advance is
 // declined for lane backpressure. It doubles per consecutive stall, capped at
 // ReadBlock. Not configurable, for the same reason as maxKeysPerRead. The
@@ -190,6 +201,11 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 		return streamCfg{}, fmt.Errorf(
 			"cluster/redis: ReadBlock (%s) must not exceed %s: the interval between a reader's XREADs is also how long Close and a newly activated room wait, and a blocked XREAD cannot be interrupted",
 			sc.readBlock, maxReadBlock)
+	}
+	if sc.readBlock < minReadBlock {
+		return streamCfg{}, fmt.Errorf(
+			"cluster/redis: ReadBlock (%s) must not be less than %s: go-redis truncates sub-millisecond values to 0, which Redis reads as BLOCK 0 (block forever), so the reader would hang and Close would deadlock waiting for it",
+			sc.readBlock, minReadBlock)
 	}
 	if sc.trimInterval >= sc.retention {
 		return streamCfg{}, fmt.Errorf(

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -116,11 +116,9 @@ const maxReadBlock = 250 * time.Millisecond
 const minReadBlock = 1 * time.Millisecond
 
 // stalledBackoffBase is the first wait after a room's cursor advance is
-// declined for lane backpressure. It doubles per consecutive stall, capped at
-// ReadBlock. Not configurable, for the same reason as maxKeysPerRead. The
-// reader task that applies backpressure backoff lands later and consumes it.
-//
-//nolint:unused // consumed by a later task, see the sentence above
+// declined for lane backpressure. It doubles per consecutive stalled cycle and
+// is capped at ReadBlock; see stallBackoff, which applies it. Not configurable,
+// for the same reason as maxKeysPerRead.
 const stalledBackoffBase = 50 * time.Millisecond
 
 // streamCfg is Config's stream half with defaults resolved, so no code past

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -2,6 +2,7 @@
 package redis
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -43,11 +44,11 @@ func (t Transport) String() string {
 // usesStreams reports whether this transport reads from and writes to streams.
 func (t Transport) usesStreams() bool { return t == Streams || t == Both }
 
-// usesPubSub reports whether this transport reads from and writes to channels.
-// This task adds Transport's full API; the reader/writer tasks that dispatch
-// on it land later.
-//
-//nolint:unused // consumed by a later task, see the sentence above
+// usesPubSub reports whether this transport reads from and writes to
+// channels. Publish consults this to decide whether the pub/sub hand-off
+// runs at all: Streams-only mode must skip PUBLISH entirely, not merely
+// ignore its result, or a Streams deployment would still pay for and depend
+// on the at-most-once channel it exists to replace.
 func (t Transport) usesPubSub() bool { return t == PubSub || t == Both }
 
 // Stream tier defaults. See the corresponding Config fields for rationale.
@@ -158,17 +159,13 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 	return sc, nil
 }
 
-// syncKey is the room's sync stream key. The reader/writer tasks that
-// XADD/XREAD by key land later and consume it.
-//
-//nolint:unused // consumed by a later task, see the sentence above
+// syncKey is the room's sync stream key. publishStream XADDs to it; the
+// reader task that XREADs it lands later.
 func (s streamCfg) syncKey(room string) string { return s.prefix + room }
 
 // awKey is the room's awareness stream key. Separate from syncKey — see
-// Config.AwarenessMaxLen. The reader/writer tasks that XADD/XREAD by key
-// land later and consume it.
-//
-//nolint:unused // consumed by a later task, see the sentence above
+// Config.AwarenessMaxLen. publishStream XADDs to it; the reader task that
+// XREADs it lands later.
 func (s streamCfg) awKey(room string) string { return s.prefix + "aw:" + room }
 
 // Stream entry field names. Single letters on purpose: every byte is
@@ -250,4 +247,37 @@ func decodeStreamEntry(vals map[string]any) (nodeID []byte, seq uint64, kind clu
 		return nil, 0, 0, nil, err
 	}
 	return []byte(n), s, cluster.Kind(k), []byte(d), nil
+}
+
+// publishStream appends one payload to its room's stream.
+//
+// Trimming is inline MAXLEN ~ rather than a separate XTRIM call: it costs
+// nothing extra on a write that is already happening, and it is the memory
+// half of the guarantee. The time half is the MINID sweeper, because MAXLEN
+// alone gives no age bound — a hot room's 4096 entries might be two seconds.
+//
+// The approximate form (~) is deliberate. Exact trimming is O(n) per XADD on
+// a hot stream, and Redis recommends ~ for exactly this reason. Approximate
+// trimming keeps MORE entries than asked, never fewer, so it can overshoot on
+// memory but can never shrink the delivery window.
+//
+// ctx is the caller's: Server.Shutdown cancels the relay context and then
+// joins the lane workers, so a publish that ignored cancellation would stall
+// that join and leave a worker running past Shutdown (#202).
+func (r *Relay) publishStream(ctx context.Context, out cluster.Outbound) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	key, maxLen := r.scfg.syncKey(out.Room), r.scfg.maxLen
+	if out.Kind == cluster.KindAwareness {
+		key, maxLen = r.scfg.awKey(out.Room), r.scfg.awMaxLen
+	}
+
+	return r.client.XAdd(ctx, &goredis.XAddArgs{
+		Stream: key,
+		MaxLen: maxLen,
+		Approx: true,
+		Values: streamFields(r.nodeID, r.nextSeq(), out.Kind, out.Data),
+	}).Err()
 }

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -95,9 +95,10 @@ const maxKeysPerRead = 512
 // of its read, and the only mechanism for that is closing its connection —
 // connection churn proportional to room churn, which at this tier's 10k-room
 // target is a worse trade than a few extra idle XREADs per second. So the
-// block stays short and ReadBlock's range is honest about it: 250ms x 4
-// readers is 16 XREADs a second on an idle node, and an XREAD that finds
-// nothing is cheap.
+// block stays short and ReadBlock's range is honest about it: the idle cost is
+// Readers x ceil(keys-per-reader / maxKeysPerRead) XREADs per ReadBlock — 16/s
+// for a node with one batch per reader, ~160/s at 10k rooms across 4 readers —
+// and an XREAD that finds nothing is cheap.
 //
 // Lowering ReadBlock below this is a real and supported choice (faster
 // shutdown and activation, more commands); raising it is not offered, because
@@ -179,7 +180,10 @@ func resolveStreamCfg(client *goredis.Client, cfg Config) (streamCfg, error) {
 	if sc.trimInterval <= 0 {
 		sc.trimInterval = defaultTrimInterval
 	}
-	if sc.readBlock <= 0 {
+	// Only the UNSET value is defaulted: a negative ReadBlock must reach the
+	// minReadBlock rejection below, as its doc promises, not be adjusted into
+	// the default.
+	if sc.readBlock == 0 {
 		sc.readBlock = defaultReadBlock
 	}
 

--- a/cluster/redis/streams.go
+++ b/cluster/redis/streams.go
@@ -3,9 +3,12 @@ package redis
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/reearth/ygo/cluster"
 )
 
 // Transport selects how a Relay moves payloads between nodes.
@@ -167,3 +170,84 @@ func (s streamCfg) syncKey(room string) string { return s.prefix + room }
 //
 //nolint:unused // consumed by a later task, see the sentence above
 func (s streamCfg) awKey(room string) string { return s.prefix + "aw:" + room }
+
+// Stream entry field names. Single letters on purpose: every byte is
+// multiplied by retention x rate x rooms.
+//
+// room is absent because the stream KEY is authoritative — XRANGE shows it,
+// and there is no route by which an entry could reach the wrong room's key.
+const (
+	fieldNode = "n" // publisher nodeID, for the self-delivery filter
+	fieldSeq  = "s" // per-node monotonic sequence, for gap detection
+	fieldKind = "k" // cluster.Kind
+	fieldData = "d" // payload
+)
+
+// nextSeq issues this relay's next sequence number.
+//
+// The counter is per-node and monotonic, and it must exist from the first
+// release: it cannot be retrofitted, and without it gap detection is
+// impossible. XREAD from a trimmed ID returns the next surviving entry with
+// NO error, and stream IDs are ms-seq rather than contiguous, so trimming is
+// indistinguishable from ordinary advancement by ID arithmetic alone.
+//
+// It lives in memory, so it restarts at 0 when the process does. A reader
+// treats a DECREASE as a restart rather than a gap — see the reader's
+// gap-detection notes.
+func (r *Relay) nextSeq() uint64 { return r.seq.Add(1) }
+
+// streamFields builds the XADD field list for one entry.
+func streamFields(nodeID []byte, seq uint64, kind cluster.Kind, data []byte) []any {
+	return []any{
+		fieldNode, nodeID,
+		fieldSeq, strconv.FormatUint(seq, 10),
+		fieldKind, strconv.Itoa(int(kind)),
+		fieldData, data,
+	}
+}
+
+// decodeStreamEntry reads one XREAD entry's fields.
+//
+// Every field is required. A malformed entry is rejected rather than
+// defaulted: the pub/sub router already learned (see its unrecognised-kind
+// handling) that guessing at a payload can cost a room its legitimate
+// updates, because a non-V1 blob makes the lane's MergeUpdatesV1 fail.
+func decodeStreamEntry(vals map[string]any) (nodeID []byte, seq uint64, kind cluster.Kind, data []byte, err error) {
+	str := func(k string) (string, error) {
+		v, ok := vals[k]
+		if !ok {
+			return "", fmt.Errorf("missing field %q", k)
+		}
+		s, ok := v.(string)
+		if !ok {
+			return "", fmt.Errorf("field %q is %T, want string", k, v)
+		}
+		return s, nil
+	}
+
+	n, err := str(fieldNode)
+	if err != nil {
+		return nil, 0, 0, nil, err
+	}
+	sRaw, err := str(fieldSeq)
+	if err != nil {
+		return nil, 0, 0, nil, err
+	}
+	s, err := strconv.ParseUint(sRaw, 10, 64)
+	if err != nil {
+		return nil, 0, 0, nil, fmt.Errorf("parse seq %q: %w", sRaw, err)
+	}
+	kRaw, err := str(fieldKind)
+	if err != nil {
+		return nil, 0, 0, nil, err
+	}
+	k, err := strconv.Atoi(kRaw)
+	if err != nil {
+		return nil, 0, 0, nil, fmt.Errorf("parse kind %q: %w", kRaw, err)
+	}
+	d, err := str(fieldData)
+	if err != nil {
+		return nil, 0, 0, nil, err
+	}
+	return []byte(n), s, cluster.Kind(k), []byte(d), nil
+}

--- a/cluster/redis/streams_lifecycle_test.go
+++ b/cluster/redis/streams_lifecycle_test.go
@@ -124,16 +124,44 @@ func (s *serialGuardSink) count() int32                                     { re
 // pub/sub, one by streams — would let this room be Injected concurrently
 // from both, violating Sink.Inject's same-room serialisation requirement.
 //
-// Verified non-vacuous two ways:
+// Payloads are genuine V1 update blobs (v1Update, streams_reader_test.go),
+// not arbitrary bytes: a non-update payload takes the stream reader's
+// catch-up merge-failure fallback (crdt.MergeUpdatesV1 fails, so entries are
+// injected individually with a WARN each) instead of the normal merge path,
+// which is both avoidable CI log noise and not the path this test means to
+// exercise — see streams_reader_test.go:247's v1Update doc for the same
+// reasoning applied earlier in this package.
+//
+// The property that actually matters — the pub/sub subscriber and the
+// stream reader resolve to the SAME *roomWorker for room1, not merely to
+// "however many the map happens to hold" — is asserted directly below via
+// require.Same on the *roomWorker pointer, rather than only through
+// len(a.workers). workerForInbound is the one resolution point both
+// runSubscriber (redis.go) and handleStream (streams_reader.go) call, so
+// capturing its return value at two points spanning the whole delivery
+// window (once right after RoomActivated creates the worker, once after
+// both tiers have had a full chance to deliver the burst) and requiring
+// pointer identity pins that no second lane-tracking structure ever swaps
+// room1's worker out from under either tier.
+//
+// Verified non-vacuous three ways:
 //
 //  1. serialGuardSink's detector logic was exercised directly (in a scratch
 //     test, not committed) by calling Inject from two goroutines at once: it
 //     reported the injected error both times, confirming the guard fires
 //     rather than being a silent no-op.
-//  2. The `require.Equal(t, 1, lanes)` assertion below was flipped to expect
-//     2 and re-run against the real relay: it failed
-//     ("expected: 2, actual: 1"), confirming the assertion pins a genuine
-//     value rather than trivially passing for any lane count. Reverted to 1.
+//  2. STRONG: the require.Same check below was verified to actually fire by
+//     temporarily inserting `a.stopWorker("room1"); a.workerFor("room1")`
+//     between the two capture points (a test-local mutation, not a
+//     production change) to force room1 onto a fresh *roomWorker mid-test.
+//     Result: failed with testify's "Not same:" (two distinct *roomWorker
+//     pointers printed). Reverted.
+//  3. WEAK: the `require.Equal(t, 1, lanes)` assertion below was flipped to
+//     expect 2 and re-run against the real relay: it failed ("expected: 2,
+//     actual: 1"). This only shows the count assertion is not trivially
+//     true today — it does NOT show the test would catch a regression like
+//     a second lane-tracking structure introduced elsewhere, which is what
+//     (2)'s require.Same is for. Reverted to 1.
 func TestIntegration_StreamLifecycle_BothModeOneLanePerRoom(t *testing.T) {
 	mr := newMiniRedis(t)
 
@@ -161,13 +189,20 @@ func TestIntegration_StreamLifecycle_BothModeOneLanePerRoom(t *testing.T) {
 	a.RoomActivated("room1")
 	require.NoError(t, b.Start(ctx, &countingSink{}))
 
+	// The worker RoomActivated just created for room1 — captured here so it
+	// can be compared, by pointer identity, against whatever workerForInbound
+	// resolves room1 to once both tiers have had a chance to deliver. See the
+	// require.Same call below.
+	w0, ok := a.workerForInbound("room1")
+	require.True(t, ok, "RoomActivated must create room1's worker before either tier can deliver to it")
+
 	// A burst, not a single publish: this widens the window in which a
 	// pub/sub-delivered and a stream-delivered copy of these entries could
 	// race each other into Inject if they used separate lanes.
 	const n = 30
 	for i := 0; i < n; i++ {
 		require.NoError(t, b.Publish(ctx, cluster.Outbound{
-			Room: "room1", Kind: cluster.KindSync, Data: []byte(fmt.Sprintf("msg-%d", i)),
+			Room: "room1", Kind: cluster.KindSync, Data: v1Update(t, fmt.Sprintf("msg-%d", i)),
 		}))
 	}
 
@@ -188,4 +223,8 @@ func TestIntegration_StreamLifecycle_BothModeOneLanePerRoom(t *testing.T) {
 	lanes := len(a.workers)
 	a.workersMu.Unlock()
 	require.Equal(t, 1, lanes, "one room must have exactly one lane, whichever tier delivered it")
+
+	wLate, ok := a.workerForInbound("room1")
+	require.True(t, ok, "room1 must still resolve to a worker after both tiers have delivered")
+	require.Same(t, w0, wLate, "the pub/sub subscriber and the stream reader must resolve room1 to the SAME *roomWorker")
 }

--- a/cluster/redis/streams_lifecycle_test.go
+++ b/cluster/redis/streams_lifecycle_test.go
@@ -1,0 +1,191 @@
+// Package-internal: pins two cluster.Relay/cluster.Sink contract obligations
+// (cluster/relay.go) for the streams tier that are easy to satisfy by
+// accident and easy to break silently later.
+//
+// Most of the obligations this task set out to cover already have a pinning
+// test from Tasks 5-9 — see the task-10 report for the full inventory of
+// what was checked and found already covered:
+//
+//   - RoomActivated/RoomDeactivated refcounting across a successor-before-
+//     predecessor overlap: TestUnit_StreamReader_ActivationRefcounts
+//     (streams_reader_test.go) for the stream-side refcount,
+//     TestInteg_RoomActivated_RefCounted (redis_test.go) for the pub/sub
+//     side.
+//   - Close must not hang with a reader mid-XREAD or the sweeper ticking:
+//     TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock
+//     (streams_reader_test.go) and TestUnit_StreamTrim_CloseDoesNotHang
+//     (streams_trim_test.go). Combined with the tier-agnostic
+//     TestInteg_Close_NothingFiresAfterReturn (isolation_test.go), which
+//     pins the drainLane closed-check that governs every roomWorker
+//     regardless of which tier fed it, nothing further to add: Close joins
+//     every goroutine on r.wg (publisher, subscriber, every room worker,
+//     every stream reader, the streamReadCtx watcher, the trim sweeper) by
+//     construction of sync.WaitGroup, so "Close returns promptly" and "wg.Wait
+//     already joined everyone" are the same fact from two angles.
+//   - Publish after Close returning ErrRelayClosed: TestUnit_Publish_AfterClose_ReturnsClosed
+//     (redis_test.go) already exercises this on the exact code path (the
+//     closed.Load() check at the top of Publish, before Transport is ever
+//     read) that a Streams-transport config would take too.
+//
+// Two obligations were genuinely uncovered and are pinned below.
+package redis
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/awareness"
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
+)
+
+// RoomDeactivated's own contract (cluster/relay.go) warns that a relay
+// releasing per-room PUBLISH-side state there — it names "a stream key" —
+// would drop a trailing update, because the provider's lane worker can still
+// call Publish for a room after RoomDeactivated has returned (the teardown
+// path stops the outbound lane asynchronously and does not wait for its
+// final drain).
+//
+// publishStream never consults streamRooms (see RoomDeactivated's doc), so
+// this holds today by construction — but nothing before this test pinned it:
+// grep confirms no existing test calls Publish/publishStream for a room
+// after RoomDeactivated has run for it.
+//
+// Verified by mutation: temporarily added `if r.streamRooms[out.Room] == 0 {
+// return ErrRelayClosed }` at the top of publishStream (guarded under
+// streamMu) to simulate a relay that treats RoomDeactivated as releasing
+// publish-side state. This test failed with exactly that error; the
+// existing suite was otherwise unaffected. Reverted.
+func TestUnit_StreamLifecycle_PublishWorksAfterRoomDeactivated(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1")
+	r.RoomDeactivated("room1")
+
+	require.NoError(t, r.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("trailing"),
+	}), "a trailing publish after deactivation must still land")
+
+	require.Len(t, streamEntries(t, mr, r.scfg.syncKey("room1")), 1)
+}
+
+// serialGuardSink wraps countingSink's bookkeeping with a same-room
+// concurrent-Inject detector, standing in for the "no two Inject calls for
+// the same room overlap" half of Sink.Inject's contract
+// (cluster/relay.go). Package-redis doubles available were countingSink and
+// recordingSink (streams_reader_test.go); neither tracks in-flight Inject
+// calls, so this is a purpose-built addition rather than a fourth
+// near-duplicate of an existing sink — it is a thin wrapper, not a fresh
+// fakeSink.
+type serialGuardSink struct {
+	t        *testing.T
+	inFlight int32 // 0 or 1 in the absence of a bug; guarded via CAS below
+	seen     int32
+}
+
+func (s *serialGuardSink) Inject(_ context.Context, in cluster.Inbound) error {
+	if !atomic.CompareAndSwapInt32(&s.inFlight, 0, 1) {
+		s.t.Errorf("concurrent Inject for room %q: Sink.Inject requires same-room calls to be serialised", in.Room)
+	}
+	// A short, deliberate hold so a real overlap (two independent lanes for
+	// the same room) has a window to be observed rather than resolving
+	// between the CAS above and the CAS below.
+	time.Sleep(time.Millisecond)
+	atomic.AddInt32(&s.seen, 1)
+	if !atomic.CompareAndSwapInt32(&s.inFlight, 1, 0) {
+		s.t.Errorf("Inject exited for room %q without holding the guard — instrumentation bug", in.Room)
+	}
+	return nil
+}
+
+func (s *serialGuardSink) Rooms() []string                                  { return nil }
+func (s *serialGuardSink) GetAwareness(string) (*awareness.Awareness, bool) { return nil, false }
+func (s *serialGuardSink) GetDoc(string) *crdt.Doc                          { return nil }
+func (s *serialGuardSink) count() int32                                     { return atomic.LoadInt32(&s.seen) }
+
+// Under Transport: Both, one room must be fed by exactly ONE inbound lane.
+//
+// This is the reason Transport lives on the existing Config rather than in a
+// second relay type: the pub/sub subscriber (runSubscriber) and the stream
+// reader (runStreamReader/handleStream) both resolve a room's worker through
+// the SAME r.workers map (workerForInbound / workerFor), so both routes feed
+// one lane with one consumer goroutine (runRoomWorker) — which is what makes
+// same-room Inject calls provably serialised regardless of which tier
+// delivered which payload. Two independent lane sets — one populated by
+// pub/sub, one by streams — would let this room be Injected concurrently
+// from both, violating Sink.Inject's same-room serialisation requirement.
+//
+// Verified non-vacuous two ways:
+//
+//  1. serialGuardSink's detector logic was exercised directly (in a scratch
+//     test, not committed) by calling Inject from two goroutines at once: it
+//     reported the injected error both times, confirming the guard fires
+//     rather than being a silent no-op.
+//  2. The `require.Equal(t, 1, lanes)` assertion below was flipped to expect
+//     2 and re-run against the real relay: it failed
+//     ("expected: 2, actual: 1"), confirming the assertion pins a genuine
+//     value rather than trivially passing for any lane count. Reverted to 1.
+func TestIntegration_StreamLifecycle_BothModeOneLanePerRoom(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	cfg := func(node string) Config {
+		return Config{
+			Transport: Both,
+			NodeID:    []byte(node),
+			Readers:   1,
+			ReadBlock: readerTestBlock,
+		}
+	}
+
+	sink := &serialGuardSink{t: t}
+	a, err := New(newClient(t, mr), cfg(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	b, err := New(newClient(t, mr), cfg(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	a.RoomActivated("room1")
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+
+	// A burst, not a single publish: this widens the window in which a
+	// pub/sub-delivered and a stream-delivered copy of these entries could
+	// race each other into Inject if they used separate lanes.
+	const n = 30
+	for i := 0; i < n; i++ {
+		require.NoError(t, b.Publish(ctx, cluster.Outbound{
+			Room: "room1", Kind: cluster.KindSync, Data: []byte(fmt.Sprintf("msg-%d", i)),
+		}))
+	}
+
+	require.Eventually(t, func() bool { return sink.count() > 0 },
+		5*time.Second, 10*time.Millisecond, "Both mode must deliver at least one entry")
+	// Give the stream reader at least one full cycle to also pick up the
+	// backlog (it may already have, via pub/sub racing ahead — either way
+	// the invariants below must hold once both tiers have had a chance to
+	// run).
+	time.Sleep(3 * readerTestBlock)
+
+	idx := a.readerFor("room1")
+	rooms := a.roomsForReader(idx)
+	require.Len(t, rooms, 1, "room1 must be assigned to exactly one reader slot")
+	require.Contains(t, rooms, "room1")
+
+	a.workersMu.Lock()
+	lanes := len(a.workers)
+	a.workersMu.Unlock()
+	require.Equal(t, 1, lanes, "one room must have exactly one lane, whichever tier delivered it")
+}

--- a/cluster/redis/streams_lifecycle_test.go
+++ b/cluster/redis/streams_lifecycle_test.go
@@ -1,33 +1,15 @@
 // Package-internal: pins two cluster.Relay/cluster.Sink contract obligations
-// (cluster/relay.go) for the streams tier that are easy to satisfy by
-// accident and easy to break silently later.
+// (cluster/relay.go) for the streams tier that are easy to satisfy by accident
+// and easy to break silently later.
 //
-// Most of the obligations this task set out to cover already have a pinning
-// test from Tasks 5-9 — see the task-10 report for the full inventory of
-// what was checked and found already covered:
-//
-//   - RoomActivated/RoomDeactivated refcounting across a successor-before-
-//     predecessor overlap: TestUnit_StreamReader_ActivationRefcounts
-//     (streams_reader_test.go) for the stream-side refcount,
-//     TestInteg_RoomActivated_RefCounted (redis_test.go) for the pub/sub
-//     side.
-//   - Close must not hang with a reader mid-XREAD or the sweeper ticking:
-//     TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock
-//     (streams_reader_test.go) and TestUnit_StreamTrim_CloseDoesNotHang
-//     (streams_trim_test.go). Combined with the tier-agnostic
-//     TestInteg_Close_NothingFiresAfterReturn (isolation_test.go), which
-//     pins the drainLane closed-check that governs every roomWorker
-//     regardless of which tier fed it, nothing further to add: Close joins
-//     every goroutine on r.wg (publisher, subscriber, every room worker,
-//     every stream reader, the streamReadCtx watcher, the trim sweeper) by
-//     construction of sync.WaitGroup, so "Close returns promptly" and "wg.Wait
-//     already joined everyone" are the same fact from two angles.
-//   - Publish after Close returning ErrRelayClosed: TestUnit_Publish_AfterClose_ReturnsClosed
-//     (redis_test.go) already exercises this on the exact code path (the
-//     closed.Load() check at the top of Publish, before Transport is ever
-//     read) that a Streams-transport config would take too.
-//
-// Two obligations were genuinely uncovered and are pinned below.
+// The tier's other contract obligations are already pinned elsewhere:
+// activation refcounting by TestUnit_StreamReader_ActivationRefcounts and
+// TestInteg_RoomActivated_RefCounted; Close not hanging by
+// TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock,
+// TestUnit_StreamTrim_CloseDoesNotHang and
+// TestInteg_Close_NothingFiresAfterReturn; Publish-after-Close by
+// TestUnit_Publish_AfterClose_ReturnsClosed, whose closed.Load() check runs
+// before Transport is ever read.
 package redis
 
 import (
@@ -132,36 +114,11 @@ func (s *serialGuardSink) count() int32                                     { re
 // exercise — see streams_reader_test.go:247's v1Update doc for the same
 // reasoning applied earlier in this package.
 //
-// The property that actually matters — the pub/sub subscriber and the
-// stream reader resolve to the SAME *roomWorker for room1, not merely to
-// "however many the map happens to hold" — is asserted directly below via
-// require.Same on the *roomWorker pointer, rather than only through
-// len(a.workers). workerForInbound is the one resolution point both
-// runSubscriber (redis.go) and handleStream (streams_reader.go) call, so
-// capturing its return value at two points spanning the whole delivery
-// window (once right after RoomActivated creates the worker, once after
-// both tiers have had a full chance to deliver the burst) and requiring
-// pointer identity pins that no second lane-tracking structure ever swaps
-// room1's worker out from under either tier.
-//
-// Verified non-vacuous three ways:
-//
-//  1. serialGuardSink's detector logic was exercised directly (in a scratch
-//     test, not committed) by calling Inject from two goroutines at once: it
-//     reported the injected error both times, confirming the guard fires
-//     rather than being a silent no-op.
-//  2. STRONG: the require.Same check below was verified to actually fire by
-//     temporarily inserting `a.stopWorker("room1"); a.workerFor("room1")`
-//     between the two capture points (a test-local mutation, not a
-//     production change) to force room1 onto a fresh *roomWorker mid-test.
-//     Result: failed with testify's "Not same:" (two distinct *roomWorker
-//     pointers printed). Reverted.
-//  3. WEAK: the `require.Equal(t, 1, lanes)` assertion below was flipped to
-//     expect 2 and re-run against the real relay: it failed ("expected: 2,
-//     actual: 1"). This only shows the count assertion is not trivially
-//     true today — it does NOT show the test would catch a regression like
-//     a second lane-tracking structure introduced elsewhere, which is what
-//     (2)'s require.Same is for. Reverted to 1.
+// The load-bearing assertion is require.Same on the *roomWorker pointer, not
+// len(a.workers): capturing workerForInbound's return at two points spanning
+// the whole delivery window pins that no second lane-tracking structure swaps
+// room1's worker out from under either tier. The count assertion alone would
+// not catch that.
 func TestIntegration_StreamLifecycle_BothModeOneLanePerRoom(t *testing.T) {
 	mr := newMiniRedis(t)
 

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -617,22 +617,25 @@ func (r *Relay) evictStaleCursorsLocked() {
 //  3. Close promises that nothing reaches the Sink after it returns
 //     (redis.go's Close doc), which drainLane enforces with its closed check.
 //     A direct Inject from a reader has no such gate.
-//  4. Lane.Push never blocks and never drops — an over-cap sync queue is
-//     merged, awareness is kept latest-only — so nothing is traded away for
-//     the isolation.
+//  4. Lane.Push never blocks on capacity and never drops — an over-cap sync
+//     queue is merged, awareness is kept latest-only — so nothing is traded
+//     away for the isolation. (It does take the lane's own mutex, which is
+//     why no relay-wide lock may be held across it — see deliverAwareness.)
 //
 // Sync entries are MERGED into a single payload first. Without that, a
 // catch-up of N entries would push N payloads, and each one is re-broadcast
 // to every local peer — turning one reader's restart into an N-fold broadcast
-// storm. Awareness is not merged: each payload carries its own clock and the
-// receiver's per-client gate handles staleness.
+// storm. Awareness is not merged — each payload carries its own clock and the
+// receiver's per-client gate handles staleness — but only the LAST payload of
+// a read is pushed, because the lane's awareness slot holds one blob and
+// would supersede the rest untouched.
 //
 // Awareness also takes a different route to the lane. It is handed over by
-// deliverAwareness, which drops the whole read if the room has changed
-// residency since the id vector was built, because presence published before
-// a reactivation must not reach the room's new occupants. Sync goes straight
-// to the lane resolved above: replaying a sync entry is harmless, so it
-// inherits the same accepted staleness runSubscriber has.
+// deliverAwareness, which drops the read if the room has changed residency
+// since the id vector was built, because presence published before a
+// reactivation must not reach the room's new occupants. Sync goes straight to
+// the lane resolved above: replaying a sync entry is harmless, so it inherits
+// the same accepted staleness runSubscriber has.
 func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOutcome {
 	if len(msgs) == 0 {
 		return streamConsumed
@@ -750,11 +753,14 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 	}
 
 	if tgt.isAwareness {
-		// Payloads and cursor together, accepted only if the room is still on
-		// the residency this read was issued for. A false return is a
-		// deliberate discard of presence published before a reactivation, not
-		// a deferral: the successor residency reads from the tail, so the
-		// outcome is still "these entries are dealt with".
+		// Cursor and latest payload, accepted only while the room is still on
+		// the residency this read was issued for. Declining is a deliberate
+		// discard of presence published before a reactivation, not a
+		// deferral — the successor residency reads from the tail, so the
+		// entries are dealt with either way, hence streamConsumed
+		// unconditionally. deliverAwareness pushes only the LAST of these
+		// payloads; see its doc for why the rest are not worth a lane
+		// acquisition each.
 		r.deliverAwareness(tgt.room, tgt.residency, awPayloads, lastID)
 		return streamConsumed
 	}

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -1,0 +1,54 @@
+package redis
+
+import (
+	"hash/fnv"
+	"sort"
+)
+
+// readerFor hash-assigns a room to one of the Readers goroutines.
+//
+// Stable by construction: a room that migrated between readers across cycles
+// would leave two readers holding cursors for it, and they would replay each
+// other's entries.
+func (r *Relay) readerFor(room string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(room))
+	return int(h.Sum32() % uint32(r.scfg.readers)) //nolint:gosec // readers is validated > 0
+}
+
+// roomsForReader returns the rooms currently assigned to one reader, sorted so
+// an XREAD's key order is deterministic (which makes test failures readable
+// and makes a cursor map easy to align with a response).
+func (r *Relay) roomsForReader(idx int) []string {
+	r.streamMu.Lock()
+	defer r.streamMu.Unlock()
+
+	var out []string
+	for room, n := range r.streamRooms {
+		if n > 0 && r.readerFor(room) == idx {
+			out = append(out, room)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// keyBatches splits keys into runs of at most max.
+//
+// XREAD takes N keys plus N IDs, so an unbounded key set builds an unbounded
+// command. Readers bounds concurrency; this bounds command size, and the two
+// are independent — 10k rooms across 4 readers is 2500 keys per reader.
+func keyBatches(keys []string, max int) [][]string {
+	if len(keys) == 0 {
+		return nil
+	}
+	var out [][]string
+	for i := 0; i < len(keys); i += max {
+		end := i + max
+		if end > len(keys) {
+			end = len(keys)
+		}
+		out = append(out, keys[i:end])
+	}
+	return out
+}

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -765,8 +765,27 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 		return streamConsumed
 	}
 
-	if len(syncPayloads) > 0 {
-		r.pushSync(w, tgt, syncPayloads)
+	return r.applySync(w, tgt, syncPayloads, lastID)
+}
+
+// applySync delivers one stream's sync entries and advances its cursor, but
+// only while w is still the room's residency: stopWorker can retire w after
+// handleStream resolved it, and a worker whose final drain has already run
+// leaves the payload on a lane nobody reads, so advancing past it would lose
+// the entry for good. Declining re-reads the entries next cycle onto the
+// successor residency; the duplicate push onto the retired lane is harmless
+// because V1 updates are idempotent.
+//
+// The check follows the push rather than sharing one lock with it because
+// Lane.Push holds the lane's mutex across crdt.MergeUpdatesV1, and workersMu
+// held across that couples every room on the node to one room's merge (#187).
+func (r *Relay) applySync(w *roomWorker, tgt streamTarget, payloads [][]byte, lastID string) streamOutcome {
+	if len(payloads) > 0 {
+		r.pushSync(w, tgt, payloads)
+		if !r.stillResident(tgt.room, w) {
+			r.deferred.Add(1)
+			return streamUnready
+		}
 	}
 	// One advance for every path that reaches here, because every path that
 	// reaches here has finished with the entries it read.

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -91,8 +91,8 @@ const (
 //
 // maxKeysPerRead bounds KEYS, so readOnce batches rooms in groups of
 // maxKeysPerRead/streamsPerRoom. Batching rooms directly against
-// maxKeysPerRead — as this task's brief did — would build a command with
-// twice the intended number of keys, defeating the bound it was reaching for.
+// maxKeysPerRead would build a command with twice the intended number of
+// keys, defeating the bound it is reaching for.
 const streamsPerRoom = 2
 
 // maxEntriesPerStream bounds how many entries one XREAD pulls from a single
@@ -100,91 +100,99 @@ const streamsPerRoom = 2
 // size of the batch handed to crdt.MergeUpdatesV1. A deeper backlog is not
 // lost: the cursor advances and the next cycle takes the next slice.
 //
-// Deliberately its own constant rather than reusing maxKeysPerRead (which the
-// brief passed as XREAD's Count): a key budget and an entry budget are
-// different quantities that happen to share a number today, and conflating
-// them means a future change to one silently moves the other.
+// Deliberately its own constant rather than reusing maxKeysPerRead as XREAD's
+// Count: a key budget and an entry budget are different quantities that
+// happen to share a number today, and conflating them means a future change
+// to one silently moves the other.
 const maxEntriesPerStream = 512
 
 // readErrorBackoff is the pause after a failed XREAD, so an unreachable Redis
 // is retried at a bounded rate instead of spun on.
 //
-// Not stalledBackoffBase, which the brief reused here: that constant is
-// documented as the LANE-backpressure backoff and is consumed by the
-// backpressure task. A Redis error and a full local lane are unrelated
-// conditions, and sharing one knob between them would make either one's
-// tuning silently change the other's behaviour.
+// Deliberately not stalledBackoffBase: that constant is documented as the
+// LANE-backpressure backoff. A Redis error and a full local lane are
+// unrelated conditions, and sharing one knob between them would make either
+// one's tuning silently change the other's behaviour.
 const readErrorBackoff = 100 * time.Millisecond
 
-// readerBlockCap caps how long one read cycle waits, independently of
-// Config.ReadBlock. ReadBlock remains the operator's upper bound — its doc
-// says it "bounds each XREAD BLOCK", and a cap keeps that literally true —
-// but two obligations make blocking for the FULL ReadBlock wrong, and neither
-// is satisfiable any other way.
+// deferredReadBackoff is the pause after a cycle that deliberately left
+// entries under their cursor (see handleStream's non-resident case).
 //
-// Close. There is no way to interrupt a blocked XREAD: go-redis honours a
-// context DEADLINE when it arms the socket read deadline, but a context
-// CANCELLED mid-read does nothing (internal/pool.(*Conn).deadline reads only
-// ctx.Deadline()). Close closes r.done and then joins r.wg, so a reader
-// blocking for the full default ReadBlock made Close take a measured 4.80s of
-// the 5s window — a five-second stall on every Server.Shutdown, in a
-// shutdown path the project has already had to fix twice (#202, #229).
+// Without it that cycle would spin: the entries are still there, so the next
+// XREAD returns immediately with the same ones, at whatever rate Redis can
+// answer. Re-reading is free per read and not free per second. The pause is
+// short because the condition it waits out is short — the window inside
+// RoomActivated between a room being assigned to a reader and its worker
+// existing — and it applies to the whole cycle rather than to the one stream,
+// which can cost a co-batched room this much extra latency during that
+// window. That trade is deliberate: it keeps the loop's control flow one
+// decision per cycle instead of one per stream.
+const deferredReadBackoff = 20 * time.Millisecond
+
+// nonBlockingRead is the XReadArgs.Block value for a read that must return
+// whatever is already there and not wait.
 //
-// Room membership. Config.ReadBlock's own doc promises that "a newly
-// activated room gets a fresh short read folded in immediately". A reader
-// parked in one long XREAD cannot see a room activated after that read
-// started, so the interval BETWEEN reads is the activation latency, and at
-// the default it would have been up to five seconds. Honouring that promise
-// properly — waking the reader from RoomActivated — needs a signal this task
-// is scoped out of adding; capping the interval delivers the promise's
-// substance without reaching into the activation path.
-//
-// 250ms buys both bounds for a handful of extra commands per reader per
-// second. An XREAD that finds nothing is cheap, and there are Readers of them
-// (4 by default), not one per room.
-const readerBlockCap = 250 * time.Millisecond
+// It must be NEGATIVE, not zero. go-redis emits the BLOCK argument for any
+// Block >= 0 (stream_commands.go), and Redis reads "BLOCK 0" as block
+// FOREVER; only a negative value omits BLOCK and makes XREAD non-blocking.
+const nonBlockingRead = -1 * time.Nanosecond
 
 // cursorLimit bounds how many stream cursors are remembered.
 //
-// Cursors are kept past a room's deactivation on purpose: dropping one at
-// deactivation would make ordinary room churn re-replay the room's whole
-// retention window on every reactivation. Bounding the map is what stops that
-// memory growing forever. See evictStaleCursorsLocked for which entries go.
+// The two kinds of cursor have deliberately different retention, because
+// they start from different defaults when they are missing:
+//
+//   - A SYNC cursor survives its room's deactivation. Its default is the
+//     oldest retained entry, so dropping it at deactivation would make
+//     ordinary room churn replay the room's whole retention window on every
+//     reactivation — the condition StreamStats.Replayed exists to alarm on.
+//   - An AWARENESS cursor is dropped at deactivation (see RoomDeactivated).
+//     Its default is the tail, so keeping it would resume a reactivated room
+//     mid-stream and replay presence for whoever was in the room last time.
+//
+// So sync cursors accumulate across churn and this limit is what stops that
+// growing forever. See evictStaleCursorsLocked for which entries go.
 const cursorLimit = 4096
 
 // streamTarget is one XREAD key together with what it means.
 //
 // readBatch builds the keys from room names, so it already knows the room and
-// which of the two streams the key is; carrying that forward means
-// handleStream never has to derive a room from a key. That mattered
-// enormously under the earlier key layout, where syncKey and awKey shared one
-// namespace and prefix+"aw:foo" was simultaneously room "aw:foo"'s sync key
-// and room "foo"'s awareness key — an ambiguity no amount of care at the read
-// site could resolve, because the two rooms genuinely shared one stream.
-//
-// The discriminated layout (see the kindDiscrim constants) removes the
-// collision at the source: distinct rooms now have provably distinct keys, and
-// parseStreamKey can recover room and kind exactly. streamTarget stays anyway,
-// because attributing an entry by the key set that ASKED for it is still the
-// stronger construction — it needs no parsing to be correct, and a returned
-// key that was never requested is then something to ignore rather than
-// something to interpret.
+// which of the two streams a key is; carrying that forward means handleStream
+// never has to derive a room from a key. Attributing an entry by the key set
+// that ASKED for it needs no parsing to be correct, which also makes a
+// returned key nobody asked for something to ignore rather than something to
+// interpret. parseStreamKey exists for the diagnostic path only.
 type streamTarget struct {
 	key         string
 	room        string
 	isAwareness bool
 }
 
+// readResult is what one batch's XREAD found, which is what the next batch's
+// blocking decision and the cycle's pacing are made from.
+type readResult struct {
+	// got is true when XREAD returned at least one entry for any key in the
+	// batch, whether or not that entry was delivered anywhere.
+	got bool
+	// deferred is true when a stream's entries were deliberately left under
+	// their cursor, so the same entries will be read again next cycle.
+	deferred bool
+}
+
 // streamReadCtx derives the readers' context from the relay's bound context so
 // that Close cancels it too.
 //
-// Load-bearing. A reader spends most of its life blocked inside XREAD for up
-// to ReadBlock, and Close closes r.done and then joins r.wg. A reader that
-// watched only the bound context would therefore make Close wait out a full
-// ReadBlock — and in the common case, where a caller closes the relay while
-// its bound context is still live (every test here, and any caller whose
-// context outlives the relay), Close would block forever. Cancelling the
-// derived context makes the in-flight XREAD return immediately.
+// The ordinary case is a caller whose context OUTLIVES the relay — every
+// test here, and Server, which cancels relayCtx after Close. Readers bound to
+// that context would keep issuing XREADs against a closed relay until it was
+// cancelled; the derived context is what makes Close stop them.
+//
+// What it does NOT do is shorten Close. An XREAD already in flight runs to
+// its block deadline whatever happens to its context, because go-redis arms
+// the socket deadline from ctx.Deadline() and never watches for cancellation
+// (v9.18.0). What ends a reader is the r.closed check at the top of
+// runStreamReader's loop, and what bounds how long that takes is
+// maxReadBlock.
 //
 // The watcher is registered on r.wg like every other relay goroutine. That is
 // safe rather than self-deadlocking because it exits on r.done, which Close
@@ -203,14 +211,32 @@ func (r *Relay) streamReadCtx(parent context.Context) context.Context {
 	return ctx
 }
 
-// readerBlock is how long one cycle waits: the operator's ReadBlock, capped
-// at readerBlockCap. Used for both the XREAD BLOCK and the idle wait, so
-// shutdown and activation latency are bounded the same way on both paths.
-func (r *Relay) readerBlock() time.Duration {
-	if r.scfg.readBlock < readerBlockCap {
+// blockForBatch is how long batch i of n may block.
+//
+// Only the LAST batch of a cycle blocks, and only when every batch before it
+// came back empty. Blocking on each batch in turn would make a reader's
+// inbound latency scale with its batch COUNT rather than with Redis: a reader
+// owning 2500 rooms has 10 batches, so an entry waiting in batch 10 would sit
+// there while batches 1-9 each waited out their own full block, up to 10 x
+// ReadBlock behind an idle cluster. Reading the earlier batches without
+// blocking costs one round trip each and finds anything that is already
+// there; the single trailing block is what keeps an idle reader from spinning.
+//
+// sawEntries also suppresses the trailing block: if an earlier batch returned
+// something there is work to do now, and the next cycle re-reads everything
+// anyway.
+//
+// The trade is command rate. A 10-batch reader used to spend 10 x ReadBlock
+// per cycle and so issued ~4 commands a second; it now completes a cycle in
+// one ReadBlock and issues ~40. That is the right side of the trade for this
+// tier — it also divides that reader's shutdown and activation latency by its
+// batch count, which is what Config.ReadBlock's bound is supposed to mean —
+// and an XREAD that finds nothing is cheap.
+func (r *Relay) blockForBatch(i, n int, sawEntries bool) time.Duration {
+	if i == n-1 && !sawEntries {
 		return r.scfg.readBlock
 	}
-	return readerBlockCap
+	return nonBlockingRead
 }
 
 // runStreamReader is one reader goroutine. It owns the rooms hash-assigned to
@@ -241,46 +267,75 @@ func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 //
 // A reader with NO assigned rooms idles instead of reading: XREAD with zero
 // keys is invalid.
+//
+// A failing batch abandons the cycle and runStreamReader restarts it from
+// batch 0, so the batches before the failure are read again. Deliberate: they
+// are non-blocking reads whose cursors did not move, so the re-read costs one
+// round trip each and cannot double-deliver anything (advancing a cursor is
+// what marks an entry consumed), whereas resuming mid-cycle would mean
+// carrying per-reader batch position across an error path for no correctness
+// gain.
 func (r *Relay) readOnce(ctx context.Context, idx int) error {
 	rooms := r.roomsForReader(idx)
 	if len(rooms) == 0 {
 		// XREAD with zero keys is invalid, so an idle reader cannot block on
-		// Redis; it sleeps and re-checks its assignment.
-		select {
-		case <-ctx.Done():
-		case <-r.done:
-		case <-time.After(r.readerBlock()):
-		}
+		// Redis; it sleeps and re-checks its assignment. Bounded by ReadBlock
+		// for the same reason the read is: this wait is also how long a
+		// newly activated room and Close wait on this reader.
+		r.pause(ctx, r.scfg.readBlock)
 		return nil
 	}
 
-	for _, batch := range keyBatches(rooms, maxKeysPerRead/streamsPerRoom) {
-		if err := r.readBatch(ctx, batch); err != nil {
+	batches := keyBatches(rooms, maxKeysPerRead/streamsPerRoom)
+	var cycle readResult
+	for i := range batches {
+		res, err := r.readBatch(ctx, batches[i], r.blockForBatch(i, len(batches), cycle.got))
+		if err != nil {
 			return err
 		}
+		cycle.got = cycle.got || res.got
+		cycle.deferred = cycle.deferred || res.deferred
+	}
+	if cycle.deferred {
+		// Entries are still waiting under a cursor, so the next XREAD will
+		// return immediately with the same ones; pace the retry instead of
+		// spinning. See deferredReadBackoff.
+		r.pause(ctx, deferredReadBackoff)
 	}
 	return nil
+}
+
+// pause waits for d unless the relay is shutting down first, so no wait in
+// the loop outlives Close by more than a scheduling hop.
+func (r *Relay) pause(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-r.done:
+	case <-time.After(d):
+	}
 }
 
 // readBatch reads one XREAD's worth of rooms: each room's sync stream from
 // its cursor (defaulting to the oldest retained entry) and its awareness
 // stream from its cursor (defaulting to the tail). See the oldestID/tailID
 // constants for why those two defaults differ.
-func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
+//
+// block is chosen by the caller per batch; see blockForBatch.
+func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Duration) (readResult, error) {
+	var out readResult
+
 	n := len(rooms) * streamsPerRoom
 	targets := make(map[string]streamTarget, n)
 	keys := make([]string, 0, n)
 	ids := make([]string, 0, n)
 
 	add := func(tgt streamTarget, dflt string) {
-		// Unreachable for distinct rooms under the discriminated key layout:
-		// syncKey and awKey cannot collide with each other for ANY pair of
-		// room names, and roomsForReader yields each room once. It survives as
+		// Unreachable for distinct rooms: syncKey and awKey cannot collide
+		// with each other for ANY pair of room names (see the kindDiscrim
+		// constants), and roomsForReader yields each room once. It survives as
 		// the structural guarantee that keys and ids stay index-aligned — a
 		// duplicate key would make XREAD's own command malformed — and it
 		// costs one lookup in a map the attribution below needs regardless.
-		// Under the earlier suffix layout it was load-bearing: a room named
-		// "aw:foo" really did produce room "foo"'s awareness key.
 		if _, dup := targets[tgt.key]; dup {
 			return
 		}
@@ -299,17 +354,22 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
 
 	res, err := r.client.XRead(ctx, &goredis.XReadArgs{
 		Streams: args,
-		Block:   r.readerBlock(),
+		Block:   block,
 		Count:   maxEntriesPerStream,
 	}).Result()
 	if err != nil {
 		if errors.Is(err, goredis.Nil) {
-			return nil // BLOCK expired with nothing new; normal
+			// Nothing new: the block expired, or this was a non-blocking read
+			// of streams that had nothing past their cursors. Normal.
+			return out, nil
 		}
-		return err
+		return out, err
 	}
 
 	for _, stream := range res {
+		if len(stream.Messages) > 0 {
+			out.got = true
+		}
 		tgt, ok := targets[stream.Stream]
 		if !ok {
 			// Ignored, never guessed at. Attribution comes from the key set
@@ -329,9 +389,11 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
 				"stream", stream.Stream, "room", room, "kind", kind)
 			continue
 		}
-		r.handleStream(tgt, stream.Messages)
+		if r.handleStream(tgt, stream.Messages) {
+			out.deferred = true
+		}
 	}
-	return nil
+	return out, nil
 }
 
 // cursorFor returns the remembered cursor for a key, or dflt when this reader
@@ -358,11 +420,11 @@ func (r *Relay) setCursor(key, id string) {
 // evictStaleCursorsLocked drops the cursors of rooms this relay no longer
 // reads, in one pass, and keeps every cursor whose room is still assigned.
 //
-// The selectivity is the point. Evicting an ARBITRARY entry on overflow — as
-// this task's brief did — costs "only a replay" per its own comment, but on a
-// node with more than cursorLimit/2 active rooms it lands on a LIVE room's
-// cursor about half the time, and a live room that loses its cursor replays
-// its entire retention window. That is exactly the condition
+// The selectivity is the point. Evicting an ARBITRARY entry on overflow costs
+// "only a replay", but on a node with more than cursorLimit/2 active rooms it
+// lands on a LIVE room's cursor about half the time, and a live room that
+// loses its cursor replays its entire retention window. That is exactly the
+// condition
 // StreamStats.Replayed tells operators to alert on ("cursors are being lost
 // repeatedly"), so arbitrary eviction would make the tier trip its own alarm
 // under nothing worse than ordinary scale.
@@ -383,10 +445,10 @@ func (r *Relay) evictStaleCursorsLocked() {
 }
 
 // handleStream applies one stream's returned entries and advances its cursor.
+// It reports whether the entries were left for a later cycle instead.
 //
-// Entries are handed to the room's LANE, not to Sink.Inject directly. This
-// deviates from the task brief, which called r.inject from here, and the
-// difference is load-bearing in four ways:
+// Entries are handed to the room's LANE, never to Sink.Inject directly, which
+// is load-bearing in four ways:
 //
 //  1. Inject is the caller's code and may be arbitrarily slow. One reader
 //     serves up to maxKeysPerRead/streamsPerRoom rooms, so injecting inline
@@ -410,21 +472,42 @@ func (r *Relay) evictStaleCursorsLocked() {
 // to every local peer — turning one reader's restart into an N-fold broadcast
 // storm. Awareness is not merged: each payload carries its own clock and the
 // receiver's per-client gate handles staleness.
-func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
+func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) (deferred bool) {
 	if len(msgs) == 0 {
-		return
+		return false
 	}
 
 	// Resolved once, as the router does: a room retired mid-batch leaves a
 	// stale handle, which is the same accepted staleness runSubscriber has.
 	w, resident := r.workerForInbound(tgt.room)
+	if !resident {
+		// The room is in this reader's assignment set but has no delivery
+		// worker: RoomActivated adds a room to streamRooms BEFORE it creates
+		// the worker, so a reader can pick the room up in between.
+		//
+		// Every entry stays under its cursor and is read again next cycle.
+		// Advancing here instead would consume the room's entire retained
+		// backlog — a reader that reaches a brand-new room in that window
+		// reads it from the oldest retained entry — and discard it before the
+		// worker that was about to exist could receive any of it. That is
+		// silent loss of precisely what this tier exists to prevent, and the
+		// stream is durable, so deferring costs one extra read.
+		//
+		// routerDrops is deliberately NOT incremented. Nothing was dropped:
+		// RouterDrops counts messages the router DISCARDED, and counting a
+		// deferral there would report loss that did not happen, on a counter
+		// operators are told to watch the rate of.
+		return true
+	}
 
 	syncPayloads := make([][]byte, 0, len(msgs))
 	lastID := ""
 	for _, msg := range msgs {
-		// Recorded before every skip below, deliberately: a malformed, foreign
-		// or self-published entry has been fully accounted for, and leaving it
-		// under the cursor would make the reader re-read it forever.
+		// Recorded before every skip below, deliberately: a malformed,
+		// foreign or self-published entry has been fully accounted for, and
+		// leaving it under the cursor would make the reader re-read it
+		// forever. Every remaining path in this loop is such a case — the one
+		// skip that must NOT advance the cursor returned above.
 		lastID = msg.ID
 
 		nodeID, seq, kind, data, err := decodeStreamEntry(msg.Values)
@@ -458,13 +541,6 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
 			r.routerDrops.Add(1)
 			continue
 		}
-		if !resident {
-			// No worker for this room: the same acceptable-drop class as the
-			// router's workerForInbound miss (see Stats.RouterDrops).
-			r.routerDrops.Add(1)
-			continue
-		}
-
 		if tgt.isAwareness {
 			// Not counted in noteSeq: awareness is read from the tail and
 			// bounded to AwarenessMaxLen, so skipped sequence numbers are the
@@ -479,30 +555,37 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
 	}
 
 	if len(syncPayloads) > 0 {
-		merged := syncPayloads[0]
-		if len(syncPayloads) > 1 {
-			m, err := crdt.MergeUpdatesV1(syncPayloads...)
-			if err != nil {
-				// Deliver individually rather than dropping the batch: the
-				// N-fold rebroadcast the merge exists to avoid is a cost,
-				// whereas losing the entries would be divergence.
-				r.log.Warn("cluster/redis: catch-up merge failed; injecting individually",
-					"room", tgt.room, "entries", len(syncPayloads), "err", err)
-				for _, p := range syncPayloads {
-					w.lane.Push(cluster.KindSync, p)
-				}
-				r.setCursor(tgt.key, lastID)
-				return
-			}
-			merged = m
-			r.replayed.Add(uint64(len(syncPayloads) - 1))
-		}
-		w.lane.Push(cluster.KindSync, merged)
+		r.pushSync(w, tgt, syncPayloads)
 	}
-
+	// One advance for every path that reaches here, because every path that
+	// reaches here has finished with the entries it read.
 	if lastID != "" {
 		r.setCursor(tgt.key, lastID)
 	}
+	return false
+}
+
+// pushSync hands a stream's sync entries to a room's lane as ONE merged
+// update where it can. See handleStream for why merging matters.
+func (r *Relay) pushSync(w *roomWorker, tgt streamTarget, payloads [][]byte) {
+	if len(payloads) == 1 {
+		w.lane.Push(cluster.KindSync, payloads[0])
+		return
+	}
+	merged, err := crdt.MergeUpdatesV1(payloads...)
+	if err != nil {
+		// Deliver individually rather than dropping the batch: the N-fold
+		// rebroadcast the merge exists to avoid is a cost, whereas losing the
+		// entries would be divergence.
+		r.log.Warn("cluster/redis: catch-up merge failed; injecting individually",
+			"room", tgt.room, "entries", len(payloads), "err", err)
+		for _, p := range payloads {
+			w.lane.Push(cluster.KindSync, p)
+		}
+		return
+	}
+	w.lane.Push(cluster.KindSync, merged)
+	r.replayed.Add(uint64(len(payloads) - 1))
 }
 
 // seqSource identifies one sequence series: one publishing node's entries in

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -1,8 +1,17 @@
 package redis
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"hash/fnv"
 	"sort"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
 )
 
 // readerFor hash-assigns a room to one of the Readers goroutines.
@@ -51,4 +60,461 @@ func keyBatches(keys []string, max int) [][]string {
 		out = append(out, keys[i:end])
 	}
 	return out
+}
+
+// --- The reader loop -------------------------------------------------------
+
+// Cursor start positions.
+//
+// oldestID starts a sync stream at the OLDEST retained entry rather than at
+// the tail. V1 updates are idempotent and commutative, so replaying entries
+// already applied is harmless, and starting at the oldest entry ELIMINATES
+// the race between loading a snapshot and beginning to read rather than
+// narrowing it. It also gives late-joiner catch-up for free, which the
+// pub/sub tier has to punt to the persistence layer. Nothing has to be
+// persisted anywhere for this to hold.
+//
+// tailID starts an awareness stream at the tail, because replaying presence
+// resurrects clients that are long gone. The cost is a narrow window: an
+// awareness entry appended between two XREADs of a never-yet-read awareness
+// stream is skipped, because "$" is re-resolved server-side on each call.
+// That is acceptable and self-healing — awareness is idempotent heartbeat
+// state that a client re-sends within one interval — and it is the reason
+// awareness entries are excluded from gap accounting (see handleStream).
+const (
+	oldestID = "0"
+	tailID   = "$"
+)
+
+// streamsPerRoom is how many stream keys one room contributes to an XREAD:
+// its sync stream and its awareness stream.
+//
+// maxKeysPerRead bounds KEYS, so readOnce batches rooms in groups of
+// maxKeysPerRead/streamsPerRoom. Batching rooms directly against
+// maxKeysPerRead — as this task's brief did — would build a command with
+// twice the intended number of keys, defeating the bound it was reaching for.
+const streamsPerRoom = 2
+
+// maxEntriesPerStream bounds how many entries one XREAD pulls from a single
+// stream, and so bounds both the memory one catch-up cycle allocates and the
+// size of the batch handed to crdt.MergeUpdatesV1. A deeper backlog is not
+// lost: the cursor advances and the next cycle takes the next slice.
+//
+// Deliberately its own constant rather than reusing maxKeysPerRead (which the
+// brief passed as XREAD's Count): a key budget and an entry budget are
+// different quantities that happen to share a number today, and conflating
+// them means a future change to one silently moves the other.
+const maxEntriesPerStream = 512
+
+// readErrorBackoff is the pause after a failed XREAD, so an unreachable Redis
+// is retried at a bounded rate instead of spun on.
+//
+// Not stalledBackoffBase, which the brief reused here: that constant is
+// documented as the LANE-backpressure backoff and is consumed by the
+// backpressure task. A Redis error and a full local lane are unrelated
+// conditions, and sharing one knob between them would make either one's
+// tuning silently change the other's behaviour.
+const readErrorBackoff = 100 * time.Millisecond
+
+// readerBlockCap caps how long one read cycle waits, independently of
+// Config.ReadBlock. ReadBlock remains the operator's upper bound — its doc
+// says it "bounds each XREAD BLOCK", and a cap keeps that literally true —
+// but two obligations make blocking for the FULL ReadBlock wrong, and neither
+// is satisfiable any other way.
+//
+// Close. There is no way to interrupt a blocked XREAD: go-redis honours a
+// context DEADLINE when it arms the socket read deadline, but a context
+// CANCELLED mid-read does nothing (internal/pool.(*Conn).deadline reads only
+// ctx.Deadline()). Close closes r.done and then joins r.wg, so a reader
+// blocking for the full default ReadBlock made Close take a measured 4.80s of
+// the 5s window — a five-second stall on every Server.Shutdown, in a
+// shutdown path the project has already had to fix twice (#202, #229).
+//
+// Room membership. Config.ReadBlock's own doc promises that "a newly
+// activated room gets a fresh short read folded in immediately". A reader
+// parked in one long XREAD cannot see a room activated after that read
+// started, so the interval BETWEEN reads is the activation latency, and at
+// the default it would have been up to five seconds. Honouring that promise
+// properly — waking the reader from RoomActivated — needs a signal this task
+// is scoped out of adding; capping the interval delivers the promise's
+// substance without reaching into the activation path.
+//
+// 250ms buys both bounds for a handful of extra commands per reader per
+// second. An XREAD that finds nothing is cheap, and there are Readers of them
+// (4 by default), not one per room.
+const readerBlockCap = 250 * time.Millisecond
+
+// cursorLimit bounds how many stream cursors are remembered.
+//
+// Cursors are kept past a room's deactivation on purpose: dropping one at
+// deactivation would make ordinary room churn re-replay the room's whole
+// retention window on every reactivation. Bounding the map is what stops that
+// memory growing forever. See evictStaleCursorsLocked for which entries go.
+const cursorLimit = 4096
+
+// streamTarget is one XREAD key together with what it means.
+//
+// readBatch builds the keys from room names, so it already knows the room and
+// which of the two streams the key is; carrying that forward is what lets
+// handleStream skip parsing a room back out of a key. That parsing is not
+// merely redundant, it is AMBIGUOUS: syncKey and awKey share one namespace,
+// so prefix+"aw:foo" is simultaneously room "aw:foo"'s sync key and room
+// "foo"'s awareness key. Deriving the room from the key (as this task's brief
+// did) silently mislabels the first of those as room "foo". Carrying the
+// target forward cannot fix the underlying key collision — two rooms really
+// can map to one key — but it does keep every entry attributed to the room
+// whose key set asked for it.
+type streamTarget struct {
+	key         string
+	room        string
+	isAwareness bool
+}
+
+// streamReadCtx derives the readers' context from the relay's bound context so
+// that Close cancels it too.
+//
+// Load-bearing. A reader spends most of its life blocked inside XREAD for up
+// to ReadBlock, and Close closes r.done and then joins r.wg. A reader that
+// watched only the bound context would therefore make Close wait out a full
+// ReadBlock — and in the common case, where a caller closes the relay while
+// its bound context is still live (every test here, and any caller whose
+// context outlives the relay), Close would block forever. Cancelling the
+// derived context makes the in-flight XREAD return immediately.
+//
+// The watcher is registered on r.wg like every other relay goroutine. That is
+// safe rather than self-deadlocking because it exits on r.done, which Close
+// closes BEFORE it calls wg.Wait.
+func (r *Relay) streamReadCtx(parent context.Context) context.Context {
+	ctx, cancel := context.WithCancel(parent)
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer cancel()
+		select {
+		case <-r.done:
+		case <-ctx.Done():
+		}
+	}()
+	return ctx
+}
+
+// readerBlock is how long one cycle waits: the operator's ReadBlock, capped
+// at readerBlockCap. Used for both the XREAD BLOCK and the idle wait, so
+// shutdown and activation latency are bounded the same way on both paths.
+func (r *Relay) readerBlock() time.Duration {
+	if r.scfg.readBlock < readerBlockCap {
+		return r.scfg.readBlock
+	}
+	return readerBlockCap
+}
+
+// runStreamReader is one reader goroutine. It owns the rooms hash-assigned to
+// idx and multiplexes them over XREAD.
+func (r *Relay) runStreamReader(ctx context.Context, idx int) {
+	defer r.wg.Done()
+	for {
+		if ctx.Err() != nil || r.closed.Load() {
+			return
+		}
+		if err := r.readOnce(ctx, idx); err != nil {
+			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+				return
+			}
+			r.log.Warn("cluster/redis: stream read failed", "reader", idx, "err", err)
+			select {
+			case <-r.done:
+				return
+			case <-ctx.Done():
+				return
+			case <-time.After(readErrorBackoff):
+			}
+		}
+	}
+}
+
+// readOnce performs one XREAD cycle for the reader's rooms.
+//
+// A reader with NO assigned rooms idles instead of reading: XREAD with zero
+// keys is invalid.
+func (r *Relay) readOnce(ctx context.Context, idx int) error {
+	rooms := r.roomsForReader(idx)
+	if len(rooms) == 0 {
+		// XREAD with zero keys is invalid, so an idle reader cannot block on
+		// Redis; it sleeps and re-checks its assignment.
+		select {
+		case <-ctx.Done():
+		case <-r.done:
+		case <-time.After(r.readerBlock()):
+		}
+		return nil
+	}
+
+	for _, batch := range keyBatches(rooms, maxKeysPerRead/streamsPerRoom) {
+		if err := r.readBatch(ctx, batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readBatch reads one XREAD's worth of rooms: each room's sync stream from
+// its cursor (defaulting to the oldest retained entry) and its awareness
+// stream from its cursor (defaulting to the tail). See the oldestID/tailID
+// constants for why those two defaults differ.
+func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
+	n := len(rooms) * streamsPerRoom
+	targets := make(map[string]streamTarget, n)
+	keys := make([]string, 0, n)
+	ids := make([]string, 0, n)
+
+	add := func(tgt streamTarget, dflt string) {
+		// The dup guard is not paranoia: syncKey and awKey share a namespace,
+		// so a room literally named "aw:foo" produces the same key as room
+		// "foo"'s awareness stream. Sending one key to XREAD twice would make
+		// a malformed command out of a merely unlucky room name.
+		if _, dup := targets[tgt.key]; dup {
+			return
+		}
+		targets[tgt.key] = tgt
+		keys = append(keys, tgt.key)
+		ids = append(ids, r.cursorFor(tgt.key, dflt))
+	}
+	for _, room := range rooms {
+		add(streamTarget{key: r.scfg.syncKey(room), room: room}, oldestID)
+		add(streamTarget{key: r.scfg.awKey(room), room: room, isAwareness: true}, tailID)
+	}
+
+	args := make([]string, 0, len(keys)+len(ids))
+	args = append(args, keys...)
+	args = append(args, ids...)
+
+	res, err := r.client.XRead(ctx, &goredis.XReadArgs{
+		Streams: args,
+		Block:   r.readerBlock(),
+		Count:   maxEntriesPerStream,
+	}).Result()
+	if err != nil {
+		if errors.Is(err, goredis.Nil) {
+			return nil // BLOCK expired with nothing new; normal
+		}
+		return err
+	}
+
+	for _, stream := range res {
+		tgt, ok := targets[stream.Stream]
+		if !ok {
+			// Nothing sane to do: recovering a room name from the key is the
+			// ambiguous operation streamTarget exists to avoid.
+			r.log.Warn("cluster/redis: XREAD returned an unrequested stream; skip",
+				"stream", stream.Stream)
+			continue
+		}
+		r.handleStream(tgt, stream.Messages)
+	}
+	return nil
+}
+
+// cursorFor returns the remembered cursor for a key, or dflt when this reader
+// has never read it.
+func (r *Relay) cursorFor(key, dflt string) string {
+	r.streamMu.Lock()
+	defer r.streamMu.Unlock()
+	if id, ok := r.cursors[key]; ok {
+		return id
+	}
+	return dflt
+}
+
+// setCursor remembers a key's last delivered ID.
+func (r *Relay) setCursor(key, id string) {
+	r.streamMu.Lock()
+	defer r.streamMu.Unlock()
+	if _, known := r.cursors[key]; !known && len(r.cursors) >= cursorLimit {
+		r.evictStaleCursorsLocked()
+	}
+	r.cursors[key] = id
+}
+
+// evictStaleCursorsLocked drops the cursors of rooms this relay no longer
+// reads, in one pass, and keeps every cursor whose room is still assigned.
+//
+// The selectivity is the point. Evicting an ARBITRARY entry on overflow — as
+// this task's brief did — costs "only a replay" per its own comment, but on a
+// node with more than cursorLimit/2 active rooms it lands on a LIVE room's
+// cursor about half the time, and a live room that loses its cursor replays
+// its entire retention window. That is exactly the condition
+// StreamStats.Replayed tells operators to alert on ("cursors are being lost
+// repeatedly"), so arbitrary eviction would make the tier trip its own alarm
+// under nothing worse than ordinary scale.
+//
+// If every cursor is live the map is left above cursorLimit. That is the
+// correct outcome: the residual is then bounded by streamsPerRoom x the
+// rooms this node actually reads, i.e. by real load, and it is the same order
+// as streamRooms itself.
+//
+// Caller must hold streamMu (which also guards streamRooms).
+func (r *Relay) evictStaleCursorsLocked() {
+	live := make(map[string]struct{}, len(r.streamRooms)*streamsPerRoom)
+	for room := range r.streamRooms {
+		live[r.scfg.syncKey(room)] = struct{}{}
+		live[r.scfg.awKey(room)] = struct{}{}
+	}
+	for key := range r.cursors {
+		if _, ok := live[key]; !ok {
+			delete(r.cursors, key)
+		}
+	}
+}
+
+// handleStream applies one stream's returned entries and advances its cursor.
+//
+// Entries are handed to the room's LANE, not to Sink.Inject directly. This
+// deviates from the task brief, which called r.inject from here, and the
+// difference is load-bearing in four ways:
+//
+//  1. Inject is the caller's code and may be arbitrarily slow. One reader
+//     serves up to maxKeysPerRead/streamsPerRoom rooms, so injecting inline
+//     would let one slow room stall inbound delivery for every other room on
+//     that reader — precisely the head-of-line stall #187 exists to remove,
+//     and the reason runSubscriber's own doc forbids Inject in that loop.
+//  2. The Sink contract (cluster/relay.go) requires calls for the SAME room
+//     to be serialised. Under Transport Both the pub/sub router pushes to the
+//     lane while the reader would be injecting directly, giving two concurrent
+//     Injects for one room. Both paths going through the lane means the room's
+//     single worker goroutine remains the only caller.
+//  3. Close promises that nothing reaches the Sink after it returns
+//     (redis.go's Close doc), which drainLane enforces with its closed check.
+//     A direct Inject from a reader has no such gate.
+//  4. Lane.Push never blocks and never drops — an over-cap sync queue is
+//     merged, awareness is kept latest-only — so nothing is traded away for
+//     the isolation.
+//
+// Sync entries are MERGED into a single payload first. Without that, a
+// catch-up of N entries would push N payloads, and each one is re-broadcast
+// to every local peer — turning one reader's restart into an N-fold broadcast
+// storm. Awareness is not merged: each payload carries its own clock and the
+// receiver's per-client gate handles staleness.
+func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
+	if len(msgs) == 0 {
+		return
+	}
+
+	// Resolved once, as the router does: a room retired mid-batch leaves a
+	// stale handle, which is the same accepted staleness runSubscriber has.
+	w, resident := r.workerForInbound(tgt.room)
+
+	syncPayloads := make([][]byte, 0, len(msgs))
+	lastID := ""
+	for _, msg := range msgs {
+		// Recorded before every skip below, deliberately: a malformed, foreign
+		// or self-published entry has been fully accounted for, and leaving it
+		// under the cursor would make the reader re-read it forever.
+		lastID = msg.ID
+
+		nodeID, seq, kind, data, err := decodeStreamEntry(msg.Values)
+		if err != nil {
+			r.log.Warn("cluster/redis: malformed stream entry; skip",
+				"stream", tgt.key, "id", msg.ID, "err", err)
+			r.routerDrops.Add(1)
+			continue
+		}
+		if bytes.Equal(nodeID, r.nodeID) {
+			continue // self-delivery
+		}
+		// Mirrors runSubscriber's H3: an unrecognised kind is dropped, never
+		// guessed at, because a non-V1 blob filed as KindSync makes the lane's
+		// merge fail and can cost the room its legitimate updates.
+		switch kind {
+		case cluster.KindSync, cluster.KindAwareness:
+		default:
+			r.log.Warn("cluster/redis: unrecognised kind in stream; drop",
+				"stream", tgt.key, "room", tgt.room, "kind", kind)
+			r.routerDrops.Add(1)
+			continue
+		}
+		// publishStream chooses the key from the kind, so the two always
+		// agree. A disagreement means a foreign or corrupt writer, and
+		// trusting either side over the other would either replay presence or
+		// merge a non-update blob. Drop instead.
+		if tgt.isAwareness != (kind == cluster.KindAwareness) {
+			r.log.Warn("cluster/redis: stream/kind mismatch; drop",
+				"stream", tgt.key, "room", tgt.room, "kind", kind)
+			r.routerDrops.Add(1)
+			continue
+		}
+		if !resident {
+			// No worker for this room: the same acceptable-drop class as the
+			// router's workerForInbound miss (see Stats.RouterDrops).
+			r.routerDrops.Add(1)
+			continue
+		}
+
+		if tgt.isAwareness {
+			// Not counted in noteSeq: awareness is read from the tail and
+			// bounded to AwarenessMaxLen, so skipped sequence numbers are the
+			// designed behaviour rather than evidence of loss, and feeding
+			// them to gap detection would make Gaps — a counter documented as
+			// "alert on presence" — nonzero on every healthy node.
+			w.lane.Push(cluster.KindAwareness, data)
+			continue
+		}
+		r.noteSeq(nodeID, seq)
+		syncPayloads = append(syncPayloads, data)
+	}
+
+	if len(syncPayloads) > 0 {
+		merged := syncPayloads[0]
+		if len(syncPayloads) > 1 {
+			m, err := crdt.MergeUpdatesV1(syncPayloads...)
+			if err != nil {
+				// Deliver individually rather than dropping the batch: the
+				// N-fold rebroadcast the merge exists to avoid is a cost,
+				// whereas losing the entries would be divergence.
+				r.log.Warn("cluster/redis: catch-up merge failed; injecting individually",
+					"room", tgt.room, "entries", len(syncPayloads), "err", err)
+				for _, p := range syncPayloads {
+					w.lane.Push(cluster.KindSync, p)
+				}
+				r.setCursor(tgt.key, lastID)
+				return
+			}
+			merged = m
+			r.replayed.Add(uint64(len(syncPayloads) - 1))
+		}
+		w.lane.Push(cluster.KindSync, merged)
+	}
+
+	if lastID != "" {
+		r.setCursor(tgt.key, lastID)
+	}
+}
+
+// noteSeq tracks a source node's sequence numbers and classifies what it sees.
+//
+// A JUMP is a provable gap: entries existed and were trimmed before this
+// reader got to them. It is the only detectable form of loss, because XREAD
+// from a trimmed ID returns the next surviving entry with no error and stream
+// IDs are ms-seq rather than contiguous.
+//
+// A DECREASE is a restart, not a gap. seq lives in memory, so a node restarts
+// it at 0 — and a node configured with a STATIC NodeID does that under the
+// same identity. Reporting it as a gap would cry data loss on every deploy;
+// worse, treating the lower numbers as already-seen would stall that source
+// forever. So a decrease resets the baseline and is counted separately.
+func (r *Relay) noteSeq(nodeID []byte, seq uint64) {
+	key := string(nodeID)
+
+	r.streamMu.Lock()
+	prev, known := r.lastSeq[key]
+	r.lastSeq[key] = seq
+	r.streamMu.Unlock()
+
+	switch {
+	case !known:
+		// First entry from this node: a baseline, not a gap.
+	case seq < prev:
+		r.restarts.Add(1)
+	case seq > prev+1:
+		r.gaps.Add(1)
+	}
 }

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -155,15 +155,20 @@ const cursorLimit = 4096
 // streamTarget is one XREAD key together with what it means.
 //
 // readBatch builds the keys from room names, so it already knows the room and
-// which of the two streams the key is; carrying that forward is what lets
-// handleStream skip parsing a room back out of a key. That parsing is not
-// merely redundant, it is AMBIGUOUS: syncKey and awKey share one namespace,
-// so prefix+"aw:foo" is simultaneously room "aw:foo"'s sync key and room
-// "foo"'s awareness key. Deriving the room from the key (as this task's brief
-// did) silently mislabels the first of those as room "foo". Carrying the
-// target forward cannot fix the underlying key collision — two rooms really
-// can map to one key — but it does keep every entry attributed to the room
-// whose key set asked for it.
+// which of the two streams the key is; carrying that forward means
+// handleStream never has to derive a room from a key. That mattered
+// enormously under the earlier key layout, where syncKey and awKey shared one
+// namespace and prefix+"aw:foo" was simultaneously room "aw:foo"'s sync key
+// and room "foo"'s awareness key — an ambiguity no amount of care at the read
+// site could resolve, because the two rooms genuinely shared one stream.
+//
+// The discriminated layout (see the kindDiscrim constants) removes the
+// collision at the source: distinct rooms now have provably distinct keys, and
+// parseStreamKey can recover room and kind exactly. streamTarget stays anyway,
+// because attributing an entry by the key set that ASKED for it is still the
+// stronger construction — it needs no parsing to be correct, and a returned
+// key that was never requested is then something to ignore rather than
+// something to interpret.
 type streamTarget struct {
 	key         string
 	room        string
@@ -268,10 +273,14 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
 	ids := make([]string, 0, n)
 
 	add := func(tgt streamTarget, dflt string) {
-		// The dup guard is not paranoia: syncKey and awKey share a namespace,
-		// so a room literally named "aw:foo" produces the same key as room
-		// "foo"'s awareness stream. Sending one key to XREAD twice would make
-		// a malformed command out of a merely unlucky room name.
+		// Unreachable for distinct rooms under the discriminated key layout:
+		// syncKey and awKey cannot collide with each other for ANY pair of
+		// room names, and roomsForReader yields each room once. It survives as
+		// the structural guarantee that keys and ids stay index-aligned — a
+		// duplicate key would make XREAD's own command malformed — and it
+		// costs one lookup in a map the attribution below needs regardless.
+		// Under the earlier suffix layout it was load-bearing: a room named
+		// "aw:foo" really did produce room "foo"'s awareness key.
 		if _, dup := targets[tgt.key]; dup {
 			return
 		}
@@ -303,10 +312,21 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string) error {
 	for _, stream := range res {
 		tgt, ok := targets[stream.Stream]
 		if !ok {
-			// Nothing sane to do: recovering a room name from the key is the
-			// ambiguous operation streamTarget exists to avoid.
+			// Ignored, never guessed at. Attribution comes from the key set
+			// this call built, so a key nobody asked for has no room to be
+			// delivered to; parseStreamKey is used only to make the log
+			// actionable, and a key that matches neither discriminator (a
+			// foreign key sharing the prefix, say) reports as unrecognised
+			// rather than being coerced into a room name.
+			room, kind := "", "unrecognised"
+			if parsed, isAw, ok := r.scfg.parseStreamKey(stream.Stream); ok {
+				room, kind = parsed, "sync"
+				if isAw {
+					kind = "awareness"
+				}
+			}
 			r.log.Warn("cluster/redis: XREAD returned an unrequested stream; skip",
-				"stream", stream.Stream)
+				"stream", stream.Stream, "room", room, "kind", kind)
 			continue
 		}
 		r.handleStream(tgt, stream.Messages)
@@ -354,11 +374,7 @@ func (r *Relay) setCursor(key, id string) {
 //
 // Caller must hold streamMu (which also guards streamRooms).
 func (r *Relay) evictStaleCursorsLocked() {
-	live := make(map[string]struct{}, len(r.streamRooms)*streamsPerRoom)
-	for room := range r.streamRooms {
-		live[r.scfg.syncKey(room)] = struct{}{}
-		live[r.scfg.awKey(room)] = struct{}{}
-	}
+	live := r.liveStreamKeysLocked()
 	for key := range r.cursors {
 		if _, ok := live[key]; !ok {
 			delete(r.cursors, key)
@@ -458,7 +474,7 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
 			w.lane.Push(cluster.KindAwareness, data)
 			continue
 		}
-		r.noteSeq(nodeID, seq)
+		r.noteSeq(tgt.key, nodeID, seq)
 		syncPayloads = append(syncPayloads, data)
 	}
 
@@ -489,32 +505,77 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) {
 	}
 }
 
-// noteSeq tracks a source node's sequence numbers and classifies what it sees.
+// seqSource identifies one sequence series: one publishing node's entries in
+// one stream.
+//
+// Both halves are load-bearing, and a struct key rather than a concatenated
+// string because both halves are arbitrary bytes — nodeID is caller-supplied
+// via Config.NodeID and a room name may contain anything — so any joining
+// character could be forged by one half into the other's territory. A struct
+// key has no encoding to get wrong.
+type seqSource struct {
+	node   string // publisher nodeID, as raw bytes held in a string
+	stream string // stream key the entry was read from
+}
+
+// noteSeq tracks one source node's sequence numbers ON ONE STREAM and
+// classifies what it sees.
+//
+// Keyed by (nodeID, stream key), matching nextSeq's per-stream counter. Both
+// halves are required. Without the nodeID, two nodes' independent series
+// would be compared against each other; without the stream key, one node's
+// two streams would be folded into one series, and their legitimate
+// interleaving — [1 3 5] in one stream, [2 4 6] in the other — would be
+// reported as gaps on a perfectly healthy node.
 //
 // A JUMP is a provable gap: entries existed and were trimmed before this
 // reader got to them. It is the only detectable form of loss, because XREAD
 // from a trimmed ID returns the next surviving entry with no error and stream
 // IDs are ms-seq rather than contiguous.
 //
-// A DECREASE is a restart, not a gap. seq lives in memory, so a node restarts
-// it at 0 — and a node configured with a STATIC NodeID does that under the
-// same identity. Reporting it as a gap would cry data loss on every deploy;
-// worse, treating the lower numbers as already-seen would stall that source
-// forever. So a decrease resets the baseline and is counted separately.
-func (r *Relay) noteSeq(nodeID []byte, seq uint64) {
-	key := string(nodeID)
+// A DECREASE is a restart, not a gap. Counters live in memory, so a node
+// restarts them at 0 — and a node configured with a STATIC NodeID does that
+// under the same identity. Reporting it as a gap would cry data loss on every
+// deploy; worse, treating the lower numbers as already-seen would stall that
+// source forever. So a decrease resets the baseline and is counted separately.
+func (r *Relay) noteSeq(streamKey string, nodeID []byte, seq uint64) {
+	src := seqSource{node: string(nodeID), stream: streamKey}
 
 	r.streamMu.Lock()
-	prev, known := r.lastSeq[key]
-	r.lastSeq[key] = seq
+	prev, known := r.lastSeq[src]
+	if !known && len(r.lastSeq) >= seqLimit {
+		r.evictStaleLastSeqLocked()
+	}
+	r.lastSeq[src] = seq
 	r.streamMu.Unlock()
 
 	switch {
 	case !known:
-		// First entry from this node: a baseline, not a gap.
+		// First entry from this node on this stream: a baseline, not a gap.
 	case seq < prev:
 		r.restarts.Add(1)
 	case seq > prev+1:
 		r.gaps.Add(1)
+	}
+}
+
+// evictStaleLastSeqLocked drops the baselines of streams this relay no longer
+// reads, keeping every baseline whose room is still assigned.
+//
+// Needed because keying by (node, stream) rather than by node alone turns a
+// map bounded by CLUSTER SIZE into one that also grows with room churn. Same
+// selective policy as evictStaleCursorsLocked, and safe in the same
+// direction: a dropped baseline makes the next entry from that source a
+// FIRST entry, which is counted as neither a gap nor a restart. It can only
+// hide a gap on a stream this node had stopped reading — where nothing was
+// being delivered to lose — and can never invent one.
+//
+// Caller must hold streamMu.
+func (r *Relay) evictStaleLastSeqLocked() {
+	live := r.liveStreamKeysLocked()
+	for src := range r.lastSeq {
+		if _, ok := live[src.stream]; !ok {
+			delete(r.lastSeq, src)
+		}
 	}
 }

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -14,20 +14,17 @@ import (
 	"github.com/reearth/ygo/crdt"
 )
 
-// readerFor hash-assigns a room to one of the Readers goroutines.
-//
-// Stable by construction: a room that migrated between readers across cycles
-// would leave two readers holding cursors for it, and they would replay each
-// other's entries.
+// readerFor hash-assigns a room to one of the Readers goroutines. Stable by
+// construction: a room migrating between readers would leave two readers
+// holding cursors for it, replaying each other's entries.
 func (r *Relay) readerFor(room string) int {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(room))
 	return int(h.Sum32() % uint32(r.scfg.readers)) //nolint:gosec // readers is validated > 0
 }
 
-// roomsForReader returns the rooms currently assigned to one reader, sorted so
-// an XREAD's key order is deterministic (which makes test failures readable
-// and makes a cursor map easy to align with a response).
+// roomsForReader returns the rooms assigned to one reader, sorted so an XREAD's
+// key order is deterministic and easy to align a cursor map with.
 func (r *Relay) roomsForReader(idx int) []string {
 	r.streamMu.Lock()
 	defer r.streamMu.Unlock()
@@ -42,11 +39,9 @@ func (r *Relay) roomsForReader(idx int) []string {
 	return out
 }
 
-// keyBatches splits keys into runs of at most max.
-//
-// XREAD takes N keys plus N IDs, so an unbounded key set builds an unbounded
-// command. Readers bounds concurrency; this bounds command size, and the two
-// are independent — 10k rooms across 4 readers is 2500 keys per reader.
+// keyBatches splits keys into runs of at most max, bounding one XREAD's command
+// size (it takes N keys plus N IDs). Independent of Readers, which bounds
+// concurrency: 10k rooms across 4 readers is 2500 keys per reader.
 func keyBatches(keys []string, max int) [][]string {
 	if len(keys) == 0 {
 		return nil
@@ -66,188 +61,126 @@ func keyBatches(keys []string, max int) [][]string {
 
 // Cursor start positions.
 //
-// oldestID starts a sync stream at the OLDEST retained entry rather than at
-// the tail. V1 updates are idempotent and commutative, so replaying entries
-// already applied is harmless, and starting at the oldest entry ELIMINATES
-// the race between loading a snapshot and beginning to read rather than
-// narrowing it. It also gives late-joiner catch-up for free, which the
-// pub/sub tier has to punt to the persistence layer. Nothing has to be
-// persisted anywhere for this to hold.
+// oldestID starts a sync stream at the OLDEST retained entry, not the tail: V1
+// updates are idempotent and commutative, so replay is harmless, and this
+// ELIMINATES rather than narrows the race between loading a snapshot and
+// beginning to read, with late-joiner catch-up free and nothing persisted.
 //
 // tailID starts an awareness stream at the tail, because replaying presence
-// resurrects clients that are long gone. The cost is a narrow window: an
-// awareness entry appended between two XREADs of a never-yet-read awareness
-// stream is skipped, because "$" is re-resolved server-side on each call.
-// That is acceptable and self-healing — awareness is idempotent heartbeat
-// state that a client re-sends within one interval — and it is the reason
-// awareness entries are excluded from gap accounting (see handleStream).
+// resurrects clients long gone. Cost: an entry appended between two XREADs of a
+// never-yet-read awareness stream is skipped, "$" being re-resolved server-side
+// per call — self-healing, and the reason awareness is excluded from gaps.
 const (
 	oldestID = "0"
 	tailID   = "$"
 )
 
-// streamsPerRoom is how many stream keys one room contributes to an XREAD:
-// its sync stream and its awareness stream.
-//
-// maxKeysPerRead bounds KEYS, so readOnce batches rooms in groups of
-// maxKeysPerRead/streamsPerRoom. Batching rooms directly against
-// maxKeysPerRead would build a command with twice the intended number of
-// keys, defeating the bound it is reaching for.
+// streamsPerRoom is how many stream keys one room contributes to an XREAD: its
+// sync stream and its awareness stream. readOnce batches rooms in groups of
+// maxKeysPerRead/streamsPerRoom; batching against maxKeysPerRead directly would
+// build a command with twice the intended number of keys.
 const streamsPerRoom = 2
 
 // maxEntriesPerStream bounds how many entries one XREAD pulls from a single
-// stream, and so bounds both the memory one catch-up cycle allocates and the
-// size of the batch handed to crdt.MergeUpdatesV1. A deeper backlog is not
-// lost: the cursor advances and the next cycle takes the next slice.
-//
-// Deliberately its own constant rather than reusing maxKeysPerRead as XREAD's
-// Count: a key budget and an entry budget are different quantities that
-// happen to share a number today, and conflating them means a future change
-// to one silently moves the other.
+// stream, and so bounds one catch-up cycle's memory and the batch handed to
+// crdt.MergeUpdatesV1. A deeper backlog is not lost: the cursor advances and
+// the next cycle takes the next slice. Its own constant rather than reusing
+// maxKeysPerRead as XREAD's Count, since a key budget and an entry budget only
+// happen to share a number today.
 const maxEntriesPerStream = 512
 
 // readErrorBackoff is the pause after a failed XREAD, so an unreachable Redis
-// is retried at a bounded rate instead of spun on.
-//
-// Deliberately not stalledBackoffBase: that constant is documented as the
-// LANE-backpressure backoff. A Redis error and a full local lane are
-// unrelated conditions, and sharing one knob between them would make either
-// one's tuning silently change the other's behaviour.
+// is retried at a bounded rate. Deliberately not stalledBackoffBase, which is
+// the LANE-backpressure backoff: one knob for both would make either one's
+// tuning change the other's behaviour.
 const readErrorBackoff = 100 * time.Millisecond
 
-// deferredReadBackoff is the pause after a cycle that deliberately left
-// entries under their cursor because a room had no delivery worker yet (see
-// handleStream's non-resident case). The other cause of a declined advance,
-// lane backpressure, escalates instead — see stallBackoff for why the two are
-// paced differently.
+// deferredReadBackoff is the pause after a cycle that left entries under their
+// cursor because a room had no delivery worker yet (see handleStream). Without
+// it the cycle spins, re-reading the same entries as fast as Redis can answer.
 //
-// Without it that cycle would spin: the entries are still there, so the next
-// XREAD returns immediately with the same ones, at whatever rate Redis can
-// answer. Re-reading is free per read and not free per second. The pause is
-// short because the condition it waits out is short — the window inside
-// RoomActivated between a room being assigned to a reader and its worker
-// existing — and it applies to the whole cycle rather than to the one stream,
-// which can cost a co-batched room this much extra latency during that
-// window. That trade is deliberate: it keeps the loop's control flow one
-// decision per cycle instead of one per stream.
+// Short because the window it waits out is short — inside RoomActivated,
+// between a room being assigned to a reader and its worker existing. Applied
+// per cycle, not per stream, so a co-batched room can pay this much latency in
+// that window: deliberate, to keep pacing one decision per cycle. Lane
+// backpressure escalates instead — see stallBackoff.
 const deferredReadBackoff = 20 * time.Millisecond
 
-// nonBlockingRead is the XReadArgs.Block value for a read that must return
-// whatever is already there and not wait.
-//
-// It must be NEGATIVE, not zero. go-redis emits the BLOCK argument for any
-// Block >= 0 (stream_commands.go), and Redis reads "BLOCK 0" as block
-// FOREVER; only a negative value omits BLOCK and makes XREAD non-blocking.
+// nonBlockingRead is the XReadArgs.Block value for a read that must not wait. It
+// must be NEGATIVE, not zero: go-redis emits the BLOCK argument for any
+// Block >= 0, and Redis reads "BLOCK 0" as block FOREVER.
 const nonBlockingRead = -1 * time.Nanosecond
 
-// cursorLimit bounds how many stream cursors are remembered.
-//
-// It bounds SYNC cursors only, because those are the only kind this map
-// holds. The two kinds need opposite retention across a room's
-// deactivate/reactivate cycle, since they start from opposite defaults when
-// they are missing, and they are stored in different places so that each
-// retention follows from where the cursor lives rather than from remembering
-// to delete it:
-//
-//   - A SYNC cursor survives its room's deactivation. Its default is the
-//     oldest retained entry, so dropping it at deactivation would make
-//     ordinary room churn replay the room's whole retention window on every
-//     reactivation — the condition StreamStats.Replayed exists to alarm on.
-//     Hence a relay-scoped map, outliving any one residency, and hence this
-//     limit: sync cursors accumulate across churn and something has to stop
-//     that growing forever. See evictStaleCursorsLocked for which entries go.
-//   - An AWARENESS cursor must NOT survive it. Its default is the tail, so
-//     keeping it would resume a reactivated room mid-stream and replay
-//     presence for whoever was in the room last time. Hence it is not in
-//     this map at all: it lives on the room's delivery worker
-//     (roomWorker.awCursor), whose lifetime IS the residency, so a
-//     reactivated room starts at the tail with nothing to delete and no
-//     in-flight read able to write the old position back.
+// cursorLimit bounds how many stream cursors are remembered. SYNC cursors only
+// — the only kind this map holds, and they deliberately outlive any one
+// residency (see roomWorker.awCursor for the retention rule), so they
+// accumulate across room churn. See evictStaleCursorsLocked for what goes.
 const cursorLimit = 4096
 
-// streamTarget is one XREAD key together with what it means.
-//
-// readBatch builds the keys from room names, so it already knows the room and
-// which of the two streams a key is; carrying that forward means handleStream
-// never has to derive a room from a key. Attributing an entry by the key set
-// that ASKED for it needs no parsing to be correct, which also makes a
-// returned key nobody asked for something to ignore rather than something to
-// interpret. parseStreamKey exists for the diagnostic path only.
+// streamTarget is one XREAD key together with what it means. readBatch already
+// knows the room and the kind, so carrying them forward means handleStream
+// never derives a room from a key, and a returned key nobody asked for is
+// something to ignore rather than to interpret.
 type streamTarget struct {
 	key         string
 	room        string
 	isAwareness bool
 	// residency is the roomWorker that owned the room when this read's id
-	// vector was built, and is the fence awareness delivery is accepted
-	// against — see awarenessCursor and deliverAwareness. Meaningful for
-	// awareness targets only.
+	// vector was built, and is the fence awareness delivery is accepted against
+	// (see deliverAwareness). Sync delivery is deliberately unfenced, because
+	// replaying a sync entry is idempotent whereas replaying presence
+	// resurrects departed clients.
 	//
-	// Sync delivery is deliberately NOT fenced this way: re-delivering a sync
-	// entry to a reactivated room is idempotent and commutative (see
-	// oldestID), whereas re-delivering presence resurrects departed clients.
-	// A worker POINTER rather than a generation counter because the worker is
-	// already the object whose lifetime is exactly one residency, so it needs
-	// no second map to bound, and because a live reference to the retired
-	// worker keeps its address from being recycled — a counter that could be
-	// deleted and reissued would compare equal across residencies.
+	// A worker POINTER, not a generation counter: a live reference keeps a
+	// retired worker's address from being recycled, where a counter could be
+	// deleted and reissued, comparing equal across residencies.
 	residency *roomWorker
 }
 
-// readResult is what one batch's XREAD found, which is what the next batch's
-// blocking decision and the cycle's pacing are made from.
+// readResult is what one batch's XREAD found: what the next batch's blocking
+// decision and the cycle's pacing are made from.
 type readResult struct {
-	// got is true when XREAD returned at least one entry for any key in the
-	// batch, whether or not that entry was delivered anywhere.
+	// got: at least one entry came back for some key in the batch.
 	got bool
-	// deferred is true when a stream's entries were deliberately left under
-	// their cursor, so the same entries will be read again next cycle. True
-	// for EITHER cause (see streamOutcome), because either one means the next
-	// XREAD returns immediately with the same entries and so has to be paced.
+	// deferred: entries were deliberately left under their cursor, for EITHER
+	// cause (see streamOutcome) — both mean the next XREAD returns them again
+	// immediately and so has to be paced.
 	deferred bool
-	// stalled narrows that to the lane-backpressure cause, which is paced
-	// differently: a missing worker is a sub-millisecond window inside
-	// RoomActivated, whereas a wedged consumer can last minutes, so only this
-	// one escalates its backoff. See stallBackoff.
+	// stalled narrows that to lane backpressure, which escalates its backoff: a
+	// wedged consumer can last minutes where a missing worker is a
+	// sub-millisecond window. See stallBackoff.
 	stalled bool
 }
 
-// streamOutcome is what handleStream did with one stream's entries.
-//
-// Three outcomes rather than the bool this started as, because the two
-// non-consuming ones are indistinguishable to a caller that only learns "the
-// cursor did not move" and yet need different pacing and different counters.
+// streamOutcome is what handleStream did with one stream's entries. Three
+// outcomes rather than a bool, because the two non-consuming ones look alike to
+// a caller that only learns "the cursor did not move", yet need different
+// pacing and different counters.
 type streamOutcome int
 
 const (
-	// streamConsumed: the entries were dealt with — delivered, filtered or
-	// dropped — and the cursor advanced past them.
+	// streamConsumed: entries dealt with — delivered, filtered or dropped —
+	// and the cursor advanced past them.
 	streamConsumed streamOutcome = iota
-	// streamUnready: the room has no delivery worker yet, so there is nowhere
-	// to put the entries. Counted as StreamStats.Deferred.
+	// streamUnready: no delivery worker yet, so nowhere to put them.
+	// StreamStats.Deferred.
 	streamUnready
 	// streamStalled: the room's lane is at capacity, so delivering would force
-	// it to coalesce. Counted as StreamStats.Stalled.
+	// it to coalesce. StreamStats.Stalled.
 	streamStalled
 )
 
 // streamReadCtx derives the readers' context from the relay's bound context so
-// that Close cancels it too.
+// that Close cancels it too: a caller's context ordinarily OUTLIVES the relay
+// (Server cancels relayCtx after Close), and readers bound to one would keep
+// issuing XREADs against a closed relay.
 //
-// The ordinary case is a caller whose context OUTLIVES the relay — every
-// test here, and Server, which cancels relayCtx after Close. Readers bound to
-// that context would keep issuing XREADs against a closed relay until it was
-// cancelled; the derived context is what makes Close stop them.
+// It does NOT shorten Close — an in-flight XREAD runs to its block deadline
+// whatever happens to its context (see maxReadBlock). What ends a reader is the
+// r.closed check in runStreamReader's loop, bounded by ReadBlock.
 //
-// What it does NOT do is shorten Close. An XREAD already in flight runs to
-// its block deadline whatever happens to its context, because go-redis arms
-// the socket deadline from ctx.Deadline() and never watches for cancellation
-// (v9.18.0). What ends a reader is the r.closed check at the top of
-// runStreamReader's loop, and what bounds how long that takes is
-// maxReadBlock.
-//
-// The watcher is registered on r.wg like every other relay goroutine. That is
-// safe rather than self-deadlocking because it exits on r.done, which Close
-// closes BEFORE it calls wg.Wait.
+// The watcher is on r.wg like every other relay goroutine, and cannot
+// self-deadlock: it exits on r.done, which Close closes BEFORE wg.Wait.
 func (r *Relay) streamReadCtx(parent context.Context) context.Context {
 	ctx, cancel := context.WithCancel(parent)
 	r.wg.Add(1)
@@ -262,27 +195,15 @@ func (r *Relay) streamReadCtx(parent context.Context) context.Context {
 	return ctx
 }
 
-// blockForBatch is how long batch i of n may block.
+// blockForBatch is how long batch i of n may block: only the LAST batch of a
+// cycle does, and only when every batch before it came back empty.
 //
-// Only the LAST batch of a cycle blocks, and only when every batch before it
-// came back empty. Blocking on each batch in turn would make a reader's
-// inbound latency scale with its batch COUNT rather than with Redis: a reader
-// owning 2500 rooms has 10 batches, so an entry waiting in batch 10 would sit
-// there while batches 1-9 each waited out their own full block, up to 10 x
-// ReadBlock behind an idle cluster. Reading the earlier batches without
-// blocking costs one round trip each and finds anything that is already
-// there; the single trailing block is what keeps an idle reader from spinning.
-//
-// sawEntries also suppresses the trailing block: if an earlier batch returned
-// something there is work to do now, and the next cycle re-reads everything
-// anyway.
-//
-// The trade is command rate. A 10-batch reader used to spend 10 x ReadBlock
-// per cycle and so issued ~4 commands a second; it now completes a cycle in
-// one ReadBlock and issues ~40. That is the right side of the trade for this
-// tier — it also divides that reader's shutdown and activation latency by its
-// batch count, which is what Config.ReadBlock's bound is supposed to mean —
-// and an XREAD that finds nothing is cheap.
+// Blocking each batch in turn would make inbound latency scale with batch COUNT
+// rather than with Redis — a reader owning 2500 rooms has 10 batches, so an
+// entry in batch 10 would sit up to 10 x ReadBlock behind an idle cluster. The
+// trade is command rate: that reader went from ~4 commands a second to ~40, and
+// its shutdown and activation latency divided by its batch count, which is what
+// Config.ReadBlock's bound is supposed to mean.
 func (r *Relay) blockForBatch(i, n int, sawEntries bool) time.Duration {
 	if i == n-1 && !sawEntries {
 		return r.scfg.readBlock
@@ -290,27 +211,19 @@ func (r *Relay) blockForBatch(i, n int, sawEntries bool) time.Duration {
 	return nonBlockingRead
 }
 
-// stallBackoff is the pause after n consecutive cycles that ended by declining
-// a cursor advance for lane backpressure.
+// stallBackoff is the pause after n consecutive cycles that declined a cursor
+// advance for lane backpressure: doubling from stalledBackoffBase, capped at
+// limit (the reader's ReadBlock). Doubling stops a room whose consumer is
+// wedged for minutes from re-reading as fast as Redis can answer; the streak
+// resets on any non-stalled cycle, so recovery takes one cycle.
 //
-// It doubles from stalledBackoffBase and is capped at limit (the reader's
-// ReadBlock). Doubling is what stops a room whose consumer is wedged for
-// minutes from re-reading the same entries as fast as Redis can answer:
-// re-reading is free per read and not free per second. Resetting the streak on
-// any cycle that does NOT stall is what keeps recovery prompt — one burst
-// leaves the reader at full speed on the very next cycle rather than serving
-// out an escalated penalty it no longer needs.
+// Capped at ReadBlock because that is already this tier's stated bound on
+// inbound latency and on how long Close and a newly activated room wait (see
+// maxReadBlock). The cap can therefore be SMALLER than stalledBackoffBase —
+// ReadBlock accepts values down to 1ms — and the cap wins.
 //
-// Capped at ReadBlock, not at some larger number, because ReadBlock is already
-// this tier's stated bound on inbound latency and on how long Close and a
-// newly activated room wait (see maxReadBlock); a backoff past it would
-// silently break a bound Config.ReadBlock documents. The cap can therefore be
-// SMALLER than stalledBackoffBase — ReadBlock accepts values down to 1ms — and
-// the cap wins, because a reader must never pause longer than its own read
-// interval.
-//
-// Doubled by multiplication rather than by shifting stalledBackoffBase << n-1:
-// the streak has no upper bound, and that shift goes negative at n=38.
+// Multiplication, not stalledBackoffBase << n-1: the streak has no upper bound
+// and that shift goes negative at n=38.
 func stallBackoff(n int, limit time.Duration) time.Duration {
 	d := stalledBackoffBase
 	for i := 1; i < n && d < limit; i++ {
@@ -323,47 +236,32 @@ func stallBackoff(n int, limit time.Duration) time.Duration {
 }
 
 // nextPause is a reader's whole pacing decision for one finished cycle: how
-// long to wait before the next XREAD, and what the stall streak becomes.
+// long to wait, and what the stall streak becomes. Pure, so escalate-and-reset
+// is asserted directly rather than inferred from goroutine timing.
 //
-// A pure function of (what the cycle saw, the streak so far, the read
-// interval), so the escalate-and-reset behaviour can be asserted directly
-// instead of inferred from how fast a goroutine happens to loop.
-//
-// stalls counts CONSECUTIVE cycles that ended by declining a cursor advance
-// for lane backpressure, and any cycle that did not stall resets it — which is
-// what makes recovery prompt after a single burst. It is per READER rather
-// than per room for three reasons: the pause is one decision per cycle (see
-// deferredReadBackoff), so a per-room map would have to be collapsed to one
-// number here anyway; escalation is driven by the worst room on the reader,
-// which is what that collapse would pick; and a per-room map would grow with
-// room churn and so need its own bound and eviction pass, a cost cursors and
-// lastSeq already each pay once.
-//
-// A stalled cycle outranks a merely deferred one because a wedged consumer
-// outlasts an activation window by orders of magnitude, and a cycle that was
-// both should be paced for the longer-lived condition.
+// stalls is per READER, not per room: the pause is one decision per cycle
+// anyway, escalation is driven by the reader's worst room, and a per-room map
+// would need its own bound and eviction pass. A stalled cycle outranks a merely
+// deferred one, a wedged consumer outlasting an activation window by orders of
+// magnitude.
 func nextPause(res readResult, stalls int, readBlock time.Duration) (time.Duration, int) {
 	switch {
 	case res.stalled:
 		stalls++
 		return stallBackoff(stalls, readBlock), stalls
 	case res.deferred:
-		// Entries are still waiting under a cursor, so the next XREAD will
-		// return immediately with the same ones; pace the retry instead of
-		// spinning. See deferredReadBackoff.
+		// The next XREAD returns the same entries immediately; pace the retry
+		// instead of spinning. See deferredReadBackoff.
 		return deferredReadBackoff, 0
 	default:
 		return 0, 0
 	}
 }
 
-// runStreamReader is one reader goroutine. It owns the rooms hash-assigned to
-// idx and multiplexes them over XREAD.
-//
-// It also carries the cycle's pacing state, because pacing is the one decision
-// in this loop that needs something from the PREVIOUS cycle (the stall streak)
-// and readOnce is deliberately stateless. Goroutine-local, so no reader can
-// contend with another for it.
+// runStreamReader is one reader goroutine: it owns the rooms hash-assigned to
+// idx and multiplexes them over XREAD. It carries the pacing state, because the
+// stall streak is the one thing this loop needs from the PREVIOUS cycle and
+// readOnce is deliberately stateless.
 func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 	defer r.wg.Done()
 
@@ -385,8 +283,8 @@ func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 				return
 			case <-time.After(readErrorBackoff):
 			}
-			// The streak is deliberately left alone: a Redis error says
-			// nothing about whether the lane that stalled has drained.
+			// The streak is deliberately left alone: a Redis error says nothing
+			// about whether the lane that stalled has drained.
 			continue
 		}
 		var d time.Duration
@@ -396,31 +294,22 @@ func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 	}
 }
 
-// readOnce performs one XREAD cycle for the reader's rooms.
+// readOnce performs one XREAD cycle for the reader's rooms and reports what it
+// saw. It does not pace itself: the retry pause depends on the stall streak,
+// which runStreamReader keeps.
 //
-// A reader with NO assigned rooms idles instead of reading: XREAD with zero
-// keys is invalid.
-//
-// A failing batch abandons the cycle and runStreamReader restarts it from
-// batch 0, so the batches before the failure are read again. Deliberate: they
-// are non-blocking reads whose cursors did not move, so the re-read costs one
-// round trip each and cannot double-deliver anything (advancing a cursor is
-// what marks an entry consumed), whereas resuming mid-cycle would mean
-// carrying per-reader batch position across an error path for no correctness
-// gain.
-//
-// It reports what the cycle saw and does NOT pace itself: the retry pause
-// depends on how many cycles in a row have stalled, which is state
-// runStreamReader keeps.
+// A failing batch abandons the cycle and runStreamReader restarts from batch 0,
+// re-reading the earlier batches. Deliberate: those are non-blocking reads
+// whose cursors did not move, so the re-read costs one round trip each and
+// cannot double-deliver — advancing a cursor is what marks an entry consumed.
 func (r *Relay) readOnce(ctx context.Context, idx int) (readResult, error) {
 	var cycle readResult
 
 	rooms := r.roomsForReader(idx)
 	if len(rooms) == 0 {
-		// XREAD with zero keys is invalid, so an idle reader cannot block on
-		// Redis; it sleeps and re-checks its assignment. Bounded by ReadBlock
-		// for the same reason the read is: this wait is also how long a
-		// newly activated room and Close wait on this reader.
+		// XREAD with zero keys is invalid, so an idle reader sleeps instead of
+		// blocking on Redis. Bounded by ReadBlock, because this wait is also
+		// how long a newly activated room and Close wait on this reader.
 		r.pause(ctx, r.scfg.readBlock)
 		return cycle, nil
 	}
@@ -448,13 +337,10 @@ func (r *Relay) pause(ctx context.Context, d time.Duration) {
 	}
 }
 
-// readBatch reads one XREAD's worth of rooms: each room's sync stream from
-// the relay's cursor (defaulting to the oldest retained entry) and its
-// awareness stream from its RESIDENCY's cursor (defaulting to the tail). See
-// the oldestID/tailID constants for why those two defaults differ, and
-// roomWorker.awCursor for why the two cursors are kept in different places.
-//
-// block is chosen by the caller per batch; see blockForBatch.
+// readBatch reads one XREAD's worth of rooms: each room's sync stream from the
+// relay's cursor (default: oldest retained entry) and its awareness stream from
+// its RESIDENCY's cursor (default: the tail). See oldestID/tailID for why the
+// defaults differ and roomWorker.awCursor for why the cursors live apart.
 func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Duration) (readResult, error) {
 	var out readResult
 
@@ -463,17 +349,14 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 	keys := make([]string, 0, n)
 	ids := make([]string, 0, n)
 
-	// from is the ID this stream is read from, resolved by the caller: the two
-	// kinds read their cursor out of different places (see
-	// roomWorker.awCursor), and the awareness one has to be resolved together
-	// with the residency that owns it.
+	// from is resolved by the caller: the two kinds read their cursor out of
+	// different places, and the awareness one has to be resolved together with
+	// the residency that owns it.
 	add := func(tgt streamTarget, from string) {
-		// Unreachable for distinct rooms: syncKey and awKey cannot collide
-		// with each other for ANY pair of room names (see the kindDiscrim
-		// constants), and roomsForReader yields each room once. It survives as
-		// the structural guarantee that keys and ids stay index-aligned — a
-		// duplicate key would make XREAD's own command malformed — and it
-		// costs one lookup in a map the attribution below needs regardless.
+		// Unreachable for distinct rooms — syncKey and awKey cannot collide for
+		// ANY pair of room names (see the kindDiscrim constants) and
+		// roomsForReader yields each room once — but kept as the structural
+		// guarantee that keys and ids stay index-aligned.
 		if _, dup := targets[tgt.key]; dup {
 			return
 		}
@@ -484,9 +367,8 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 	for _, room := range rooms {
 		syncKey := r.scfg.syncKey(room)
 		add(streamTarget{key: syncKey, room: room}, r.cursorFor(syncKey, oldestID))
-		// Resolved as a pair, under one lock: the awareness position and the
-		// residency it belongs to are one fact, and handleStream delivers the
-		// response only while that residency is still the room's.
+		// Resolved as a pair under one lock: the awareness position and the
+		// residency it belongs to are one fact.
 		residency, awFrom := r.awarenessCursor(room)
 		add(streamTarget{
 			key:         r.scfg.awKey(room),
@@ -507,8 +389,8 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 	}).Result()
 	if err != nil {
 		if errors.Is(err, goredis.Nil) {
-			// Nothing new: the block expired, or this was a non-blocking read
-			// of streams that had nothing past their cursors. Normal.
+			// The block expired, or a non-blocking read found nothing past the
+			// cursors. Normal.
 			return out, nil
 		}
 		return out, err
@@ -520,12 +402,11 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 		}
 		tgt, ok := targets[stream.Stream]
 		if !ok {
-			// Ignored, never guessed at. Attribution comes from the key set
+			// Ignored, never guessed at: attribution comes from the key set
 			// this call built, so a key nobody asked for has no room to be
-			// delivered to; parseStreamKey is used only to make the log
-			// actionable, and a key that matches neither discriminator (a
-			// foreign key sharing the prefix, say) reports as unrecognised
-			// rather than being coerced into a room name.
+			// delivered to. parseStreamKey only makes the log actionable, and
+			// says "unrecognised" rather than coercing a foreign key into a
+			// room name.
 			room, kind := "", "unrecognised"
 			if parsed, isAw, ok := r.scfg.parseStreamKey(stream.Stream); ok {
 				room, kind = parsed, "sync"
@@ -571,22 +452,15 @@ func (r *Relay) setCursor(key, id string) {
 }
 
 // evictStaleCursorsLocked drops the cursors of rooms this relay no longer
-// reads, in one pass, and keeps every cursor whose room is still assigned.
+// reads, keeping every cursor whose room is still assigned.
 //
-// The selectivity is the point. Evicting an ARBITRARY entry on overflow costs
-// "only a replay", but on a node with more than cursorLimit/2 active rooms it
-// lands on a LIVE room's cursor about half the time, and a live room that
-// loses its cursor replays its entire retention window. That is exactly the
-// condition
-// StreamStats.Replayed tells operators to alert on ("cursors are being lost
-// repeatedly"), so arbitrary eviction would make the tier trip its own alarm
-// under nothing worse than ordinary scale.
+// The selectivity is the point: on a node with more than cursorLimit/2 active
+// rooms, evicting an ARBITRARY entry lands on a LIVE room's cursor about half
+// the time, and a live room that loses its cursor replays its entire retention
+// window — the condition StreamStats.Replayed tells operators to alert on.
 //
-// If every cursor is live the map is left above cursorLimit. That is the
-// correct outcome: the residual is then bounded by the rooms this node
-// actually reads — one sync cursor each, awareness being held on the workers
-// instead (see roomWorker.awCursor) — i.e. by real load, and it is the same
-// order as streamRooms itself.
+// If every cursor is live the map is left above cursorLimit, which is correct:
+// the residual is then bounded by real load, the same order as streamRooms.
 //
 // Caller must hold streamMu (which also guards streamRooms).
 func (r *Relay) evictStaleCursorsLocked() {
@@ -599,113 +473,87 @@ func (r *Relay) evictStaleCursorsLocked() {
 }
 
 // handleStream applies one stream's returned entries and advances its cursor,
-// or reports which of the two reasons it left them for a later cycle instead.
+// or reports which of the two reasons it left them for a later cycle.
 //
-// Entries are handed to the room's LANE, never to Sink.Inject directly, which
-// is load-bearing in four ways:
+// Entries go to the room's LANE, never to Sink.Inject directly, for four
+// reasons:
 //
-//  1. Inject is the caller's code and may be arbitrarily slow. One reader
-//     serves up to maxKeysPerRead/streamsPerRoom rooms, so injecting inline
-//     would let one slow room stall inbound delivery for every other room on
-//     that reader — precisely the head-of-line stall #187 exists to remove,
-//     and the reason runSubscriber's own doc forbids Inject in that loop.
-//  2. The Sink contract (cluster/relay.go) requires calls for the SAME room
-//     to be serialised. Under Transport Both the pub/sub router pushes to the
-//     lane while the reader would be injecting directly, giving two concurrent
-//     Injects for one room. Both paths going through the lane means the room's
-//     single worker goroutine remains the only caller.
-//  3. Close promises that nothing reaches the Sink after it returns
-//     (redis.go's Close doc), which drainLane enforces with its closed check.
-//     A direct Inject from a reader has no such gate.
-//  4. Lane.Push never blocks on capacity and never drops — an over-cap sync
-//     queue is merged, awareness is kept latest-only — so nothing is traded
-//     away for the isolation. (It does take the lane's own mutex, which is
-//     why no relay-wide lock may be held across it — see deliverAwareness.)
+//  1. Inject is the caller's code and may be arbitrarily slow, and one reader
+//     serves up to maxKeysPerRead/streamsPerRoom rooms — injecting inline is
+//     the head-of-line stall #187 exists to remove.
+//  2. The Sink contract (cluster/relay.go) requires calls for the SAME room to
+//     be serialised, and under Transport Both the pub/sub router pushes to the
+//     lane while a direct Inject ran — two concurrent Injects for one room.
+//  3. Close promises nothing reaches the Sink after it returns (redis.go),
+//     enforced by drainLane's closed check; a direct Inject has no such gate.
+//  4. Lane.Push never blocks on capacity and never drops, so the isolation
+//     costs nothing.
 //
-// Sync entries are MERGED into a single payload first. Without that, a
-// catch-up of N entries would push N payloads, and each one is re-broadcast
-// to every local peer — turning one reader's restart into an N-fold broadcast
-// storm. Awareness is not merged — each payload carries its own clock and the
-// receiver's per-client gate handles staleness — but only the LAST payload of
-// a read is pushed, because the lane's awareness slot holds one blob and
-// would supersede the rest untouched.
+// Push does take the lane's mutex, so no relay-wide lock may be held across it
+// — see deliverAwareness.
 //
-// Awareness also takes a different route to the lane. It is handed over by
-// deliverAwareness, which drops the read if the room has changed residency
-// since the id vector was built, because presence published before a
-// reactivation must not reach the room's new occupants. Sync goes straight to
-// the lane resolved above: replaying a sync entry is harmless, so it inherits
-// the same accepted staleness runSubscriber has.
+// Sync entries are MERGED into one payload first: otherwise a catch-up of N
+// entries pushes N payloads, each re-broadcast to every local peer, turning one
+// reader's restart into an N-fold broadcast storm. Awareness is not merged
+// (each payload carries its own clock and the receiver gates per client), but
+// only the LAST payload of a read is pushed, because the lane's awareness slot
+// holds one blob and would supersede the rest untouched. Awareness also goes
+// via deliverAwareness, which drops the read if the room changed residency
+// (see streamTarget.residency).
 func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOutcome {
 	if len(msgs) == 0 {
 		return streamConsumed
 	}
 
 	// Resolved once, as the router does: a room retired mid-batch leaves a
-	// stale handle, which is the same accepted staleness runSubscriber has.
+	// stale handle, the same accepted staleness runSubscriber has.
 	w, resident := r.workerForInbound(tgt.room)
 	if !resident {
 		// The room is in this reader's assignment set but has no delivery
-		// worker: RoomActivated adds a room to streamRooms BEFORE it creates
-		// the worker, so a reader can pick the room up in between.
+		// worker: RoomActivated adds to streamRooms BEFORE it creates one.
 		//
 		// Every entry stays under its cursor and is read again next cycle.
-		// Advancing here instead would consume the room's entire retained
-		// backlog — a reader that reaches a brand-new room in that window
-		// reads it from the oldest retained entry — and discard it before the
-		// worker that was about to exist could receive any of it. That is
-		// silent loss of precisely what this tier exists to prevent, and the
-		// stream is durable, so deferring costs one extra read.
+		// Advancing would consume the room's entire retained backlog — a reader
+		// reaching a brand-new room reads from the oldest retained entry — and
+		// discard it before the worker existed to receive any of it: silent
+		// loss of precisely what this tier prevents. Deferring costs one read.
 		//
-		// routerDrops is deliberately NOT incremented. Nothing was dropped:
-		// RouterDrops counts messages the router DISCARDED, and counting a
-		// deferral there would report loss that did not happen, on a counter
-		// operators are told to watch the rate of. StreamStats.Deferred counts
-		// it instead, which is a declined advance rather than a loss.
+		// routerDrops is deliberately NOT incremented: nothing was dropped, and
+		// operators watch its rate. StreamStats.Deferred counts this instead.
 		r.deferred.Add(1)
 		return streamUnready
 	}
 
-	// This branch is the whole argument for this tier over pub/sub. When a
-	// room's local consumer falls behind, pub/sub can only choose between
-	// merging the backlog and dropping it, because the message it holds exists
-	// nowhere else. A stream entry is durable, so there is a third option:
-	// leave the entries under the cursor and read them again next cycle. That
-	// costs one re-read, discards nothing, and asks the lane to merge nothing
-	// — which is what makes backpressure toward Redis safe here.
+	// This branch is the whole argument for this tier over pub/sub: when a
+	// room's consumer falls behind, pub/sub can only merge the backlog or drop
+	// it, because the message exists nowhere else. A stream entry is durable, so
+	// there is a third option — leave the entries under the cursor and read them
+	// again next cycle, discarding nothing and merging nothing.
 	//
-	// Placed BEFORE the decode loop, not before the push as would be the
-	// obvious reading, because the loop is not side-effect free: it calls
-	// noteSeq, which records each source's latest sequence number. Deciding to
-	// stall after that would leave lastSeq holding sequences from entries we
-	// are about to re-read, and next cycle's lower numbers would then be
-	// classified as a publisher RESTART — inflating StreamStats.Restarts once
-	// per stalled cycle on a perfectly healthy cluster. The unready branch
-	// above returns before the loop for the same reason.
+	// Placed BEFORE the decode loop, not before the push, because the loop calls
+	// noteSeq: stalling after it would leave lastSeq holding sequences from
+	// entries about to be re-read, so next cycle's lower numbers would classify
+	// as a publisher RESTART — inflating StreamStats.Restarts once per stalled
+	// cycle on a healthy cluster. The unready branch returns early likewise.
 	//
-	// Awareness streams are deliberately exempt. Lane.Full reports on the
-	// SYNC queue, the only thing the lane's capacity governs; an awareness
-	// push replaces a single latest-only slot, so it can neither deepen the
-	// backlog this backoff exists to bound nor trigger a merge. Declining one
-	// would cost presence freshness and buy nothing, and would re-read
-	// presence entries that the next push supersedes anyway.
+	// Awareness is exempt: an awareness push replaces a single latest-only
+	// slot, which Lane.Full's cap does not govern, so declining would cost
+	// presence freshness and buy nothing.
 	if !tgt.isAwareness && w.lane.Full() {
 		r.stalled.Add(1)
 		return streamStalled
 	}
 
 	syncPayloads := make([][]byte, 0, len(msgs))
-	// Collected rather than pushed inline, because the push and the cursor
-	// advance have to happen as ONE residency-fenced operation — see
-	// deliverAwareness.
+	// Collected rather than pushed inline: the push and the cursor advance have
+	// to happen as ONE residency-fenced operation — see deliverAwareness.
 	var awPayloads [][]byte
 	lastID := ""
 	for _, msg := range msgs {
-		// Recorded before every skip below, deliberately: a malformed,
-		// foreign or self-published entry has been fully accounted for, and
-		// leaving it under the cursor would make the reader re-read it
-		// forever. Every remaining path in this loop is such a case — the one
-		// skip that must NOT advance the cursor returned above.
+		// Recorded before every skip below, deliberately: a malformed, foreign
+		// or self-published entry is fully accounted for, and leaving it under
+		// the cursor would re-read it forever. The one skip that must NOT
+		// advance the cursor returned above.
 		lastID = msg.ID
 
 		nodeID, seq, kind, data, err := decodeStreamEntry(msg.Values)
@@ -729,10 +577,9 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 			r.routerDrops.Add(1)
 			continue
 		}
-		// publishStream chooses the key from the kind, so the two always
-		// agree. A disagreement means a foreign or corrupt writer, and
-		// trusting either side over the other would either replay presence or
-		// merge a non-update blob. Drop instead.
+		// publishStream chooses the key from the kind, so a disagreement means
+		// a foreign or corrupt writer; trusting either side would either replay
+		// presence or merge a non-update blob.
 		if tgt.isAwareness != (kind == cluster.KindAwareness) {
 			r.log.Warn("cluster/redis: stream/kind mismatch; drop",
 				"stream", tgt.key, "room", tgt.room, "kind", kind)
@@ -742,9 +589,8 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 		if tgt.isAwareness {
 			// Not counted in noteSeq: awareness is read from the tail and
 			// bounded to AwarenessMaxLen, so skipped sequence numbers are the
-			// designed behaviour rather than evidence of loss, and feeding
-			// them to gap detection would make Gaps — a counter documented as
-			// "alert on presence" — nonzero on every healthy node.
+			// designed behaviour, and feeding them to gap detection would make
+			// Gaps — "alert on presence" — nonzero on every healthy node.
 			awPayloads = append(awPayloads, data)
 			continue
 		}
@@ -753,14 +599,9 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 	}
 
 	if tgt.isAwareness {
-		// Cursor and latest payload, accepted only while the room is still on
-		// the residency this read was issued for. Declining is a deliberate
-		// discard of presence published before a reactivation, not a
-		// deferral — the successor residency reads from the tail, so the
-		// entries are dealt with either way, hence streamConsumed
-		// unconditionally. deliverAwareness pushes only the LAST of these
-		// payloads; see its doc for why the rest are not worth a lane
-		// acquisition each.
+		// Declining inside deliverAwareness is a deliberate discard of presence
+		// published before a reactivation, not a deferral — the successor
+		// residency reads from the tail — hence streamConsumed unconditionally.
 		r.deliverAwareness(tgt.room, tgt.residency, awPayloads, lastID)
 		return streamConsumed
 	}
@@ -772,13 +613,12 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 // only while w is still the room's residency: stopWorker can retire w after
 // handleStream resolved it, and a worker whose final drain has already run
 // leaves the payload on a lane nobody reads, so advancing past it would lose
-// the entry for good. Declining re-reads the entries next cycle onto the
-// successor residency; the duplicate push onto the retired lane is harmless
-// because V1 updates are idempotent.
+// the entry for good. Declining re-reads next cycle onto the successor; the
+// duplicate push onto the retired lane is harmless because V1 is idempotent.
 //
-// The check follows the push rather than sharing one lock with it because
-// Lane.Push holds the lane's mutex across crdt.MergeUpdatesV1, and workersMu
-// held across that couples every room on the node to one room's merge (#187).
+// The check follows the push rather than sharing one lock with it, for the
+// reason set out in deliverAwareness: workersMu held across a Push couples
+// every room on the node to one room's merge (#187).
 func (r *Relay) applySync(w *roomWorker, tgt streamTarget, payloads [][]byte, lastID string) streamOutcome {
 	if len(payloads) > 0 {
 		r.pushSync(w, tgt, payloads)
@@ -787,8 +627,7 @@ func (r *Relay) applySync(w *roomWorker, tgt streamTarget, payloads [][]byte, la
 			return streamUnready
 		}
 	}
-	// One advance for every path that reaches here, because every path that
-	// reaches here has finished with the entries it read.
+	// Every path that reaches here has finished with the entries it read.
 	if lastID != "" {
 		r.setCursor(tgt.key, lastID)
 	}
@@ -805,8 +644,7 @@ func (r *Relay) pushSync(w *roomWorker, tgt streamTarget, payloads [][]byte) {
 	merged, err := crdt.MergeUpdatesV1(payloads...)
 	if err != nil {
 		// Deliver individually rather than dropping the batch: the N-fold
-		// rebroadcast the merge exists to avoid is a cost, whereas losing the
-		// entries would be divergence.
+		// rebroadcast is a cost, losing the entries would be divergence.
 		r.log.Warn("cluster/redis: catch-up merge failed; injecting individually",
 			"room", tgt.room, "entries", len(payloads), "err", err)
 		for _, p := range payloads {
@@ -815,31 +653,24 @@ func (r *Relay) pushSync(w *roomWorker, tgt streamTarget, payloads [][]byte) {
 		return
 	}
 	w.lane.Push(cluster.KindSync, merged)
-	// Counted on EVERY successful multi-entry merge, whether or not any of the
-	// entries had been delivered before — which is why StreamStats.Replayed is
-	// documented as a merge/batching gauge and explicitly not a counter to
-	// alert on the rate of.
+	// Counted on EVERY successful multi-entry merge, delivered before or not,
+	// which is why StreamStats.Replayed is a merge/batching gauge rather than a
+	// counter to alert on.
 	r.replayed.Add(uint64(len(payloads) - 1))
 }
 
 // seqSource identifies one sequence series: one publishing node's entries in
-// one stream.
-//
-// Both halves are load-bearing, and a struct key rather than a concatenated
-// string because both halves are arbitrary bytes — nodeID is caller-supplied
-// via Config.NodeID and a room name may contain anything — so any joining
-// character could be forged by one half into the other's territory. A struct
-// key has no encoding to get wrong.
+// one stream. A struct key rather than a concatenated string because both
+// halves are arbitrary bytes, so any joining character could be forged by one
+// half into the other's territory.
 type seqSource struct {
 	node   string // publisher nodeID, as raw bytes held in a string
 	stream string // stream key the entry was read from
 }
 
 // seqState is what this reader remembers about one sequence series.
-//
-// afterDecrease rides alongside the number rather than being derived from it,
-// because "the previous observation went backwards" is not recoverable from
-// the baseline value alone. See noteSeq for what it suppresses and why.
+// afterDecrease rides alongside the number because "the previous observation
+// went backwards" is not recoverable from the baseline value alone; see noteSeq.
 type seqState struct {
 	last          uint64
 	afterDecrease bool
@@ -849,51 +680,33 @@ type seqState struct {
 // classifies what it sees.
 //
 // Keyed by (nodeID, stream key), matching nextSeq's per-stream counter. Both
-// halves are required. Without the nodeID, two nodes' independent series
-// would be compared against each other; without the stream key, one node's
-// two streams would be folded into one series, and their legitimate
-// interleaving — [1 3 5] in one stream, [2 4 6] in the other — would be
-// reported as gaps on a perfectly healthy node.
+// halves are needed: nodeID keeps two nodes' series apart, and the stream key
+// keeps one node's two streams apart — their legitimate interleaving, [1 3 5]
+// in one and [2 4 6] in the other, would otherwise read as gaps.
 //
-// A JUMP is a provable gap: entries existed and were trimmed before this
-// reader got to them. It is the only detectable form of loss, because XREAD
-// from a trimmed ID returns the next surviving entry with no error and stream
-// IDs are ms-seq rather than contiguous.
+// A JUMP is a provable gap, and the only detectable form of loss: XREAD from a
+// trimmed ID returns the next surviving entry with no error, and stream IDs are
+// ms-seq rather than contiguous.
 //
-// A DECREASE is a restart, not a gap. Counters live in memory, so a node
-// restarts them at 0 — and a node configured with a STATIC NodeID does that
-// under the same identity. Reporting it as a gap would cry data loss on every
-// deploy; worse, treating the lower numbers as already-seen would stall that
-// source forever. So a decrease resets the baseline and is counted separately.
+// A DECREASE is a restart, not a gap — counters are in-memory, so a node
+// restarts them at 0, under the same identity if its NodeID is STATIC. As a gap
+// it would cry data loss on every deploy; as already-seen it would stall that
+// source forever.
 //
-// THE FIRST COMPARISON AFTER A DECREASE CANNOT REPORT A GAP. A decrease is
-// itself the statement "this source's numbering is not, right now, a reliable
-// basis for inference", so the very next entry re-baselines instead of
-// accusing. Two causes need this, and neither is exotic:
+// THE FIRST COMPARISON AFTER A DECREASE CANNOT REPORT A GAP, because two
+// routine causes put entries out of order. nextSeq releases streamMu before its
+// XADD and Relay.Publish's contract requires tolerating two concurrent
+// Publishes for one room (an eviction/reload handoff does exactly that,
+// continuously), so entries can land as [seq2, seq1] — a decrease, then a jump
+// seq1→seq3; holding streamMu across the XAdd is refused, being a lock across a
+// Redis call that couples every room to one slow write (#187/#200). And a
+// restarted node's fresh [1 2 3…] can interleave with its own pre-restart tail.
 //
-//   - nextSeq releases streamMu before the XADD it numbered is issued, and
-//     Relay.Publish's contract explicitly requires tolerating two concurrent
-//     Publish calls for the same room (a room's eviction/reload handoff does
-//     exactly that, and room churn is continuous). So one publisher's entries
-//     can land in the stream as [seq2, seq1] — a decrease, then a jump from
-//     seq1 to seq3. The alternative fix is to hold streamMu across the XAdd,
-//     which is refused: that is a lock held across a Redis call, and it would
-//     couple every room on the node to one slow write — the cross-room
-//     head-of-line coupling #187/#200 removed and this branch had to fix once
-//     already.
-//   - a restarted node's fresh [1 2 3…] can be read interleaved with the tail
-//     of its own pre-restart series for the same reason.
-//
-// The trade is explicit and deliberate: this suppresses one REAL gap in the
-// case where a genuine trim-away lands immediately after a genuine restart on
-// the same series, and nothing else — the suppression is one comparison deep
-// and clears on the next entry, so a persistent gap is still reported. That is
-// the right way to be wrong for this counter. StreamStats.Gaps is documented
-// "ALERT ON PRESENCE… a single gap means data was lost": its entire value is
-// that a non-zero reading means something, and a signal that fires on healthy
-// room churn is worth less than no signal at all. Losing one increment in a
-// narrow conjunction costs an alert that a stall of any duration would raise
-// again; a false positive costs the counter its credibility permanently.
+// The suppression is one comparison deep, so it loses exactly one REAL gap: a
+// trim-away landing immediately after a restart on the same series. Worth it,
+// because StreamStats.Gaps is documented "ALERT ON PRESENCE… a single gap means
+// data was lost" — a signal firing on healthy room churn is worth less than no
+// signal, while one missed increment costs an alert any longer stall raises.
 func (r *Relay) noteSeq(streamKey string, nodeID []byte, seq uint64) {
 	src := seqSource{node: string(nodeID), stream: streamKey}
 
@@ -921,15 +734,14 @@ func (r *Relay) noteSeq(streamKey string, nodeID []byte, seq uint64) {
 }
 
 // evictStaleLastSeqLocked drops the baselines of streams this relay no longer
-// reads, keeping every baseline whose room is still assigned.
+// reads, keeping every baseline whose room is still assigned: keying by (node,
+// stream) turns a map bounded by CLUSTER SIZE into one that also grows with
+// room churn. Same selective policy as evictStaleCursorsLocked.
 //
-// Needed because keying by (node, stream) rather than by node alone turns a
-// map bounded by CLUSTER SIZE into one that also grows with room churn. Same
-// selective policy as evictStaleCursorsLocked, and safe in the same
-// direction: a dropped baseline makes the next entry from that source a
-// FIRST entry, which is counted as neither a gap nor a restart. It can only
-// hide a gap on a stream this node had stopped reading — where nothing was
-// being delivered to lose — and can never invent one.
+// Safe in the same direction: a dropped baseline makes the next entry a FIRST
+// entry, counted as neither gap nor restart. It can only hide a gap on a stream
+// this node had stopped reading — where nothing was being delivered to lose —
+// and can never invent one.
 //
 // Caller must hold streamMu.
 func (r *Relay) evictStaleLastSeqLocked() {

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -116,7 +116,10 @@ const maxEntriesPerStream = 512
 const readErrorBackoff = 100 * time.Millisecond
 
 // deferredReadBackoff is the pause after a cycle that deliberately left
-// entries under their cursor (see handleStream's non-resident case).
+// entries under their cursor because a room had no delivery worker yet (see
+// handleStream's non-resident case). The other cause of a declined advance,
+// lane backpressure, escalates instead — see stallBackoff for why the two are
+// paced differently.
 //
 // Without it that cycle would spin: the entries are still there, so the next
 // XREAD returns immediately with the same ones, at whatever rate Redis can
@@ -175,9 +178,35 @@ type readResult struct {
 	// batch, whether or not that entry was delivered anywhere.
 	got bool
 	// deferred is true when a stream's entries were deliberately left under
-	// their cursor, so the same entries will be read again next cycle.
+	// their cursor, so the same entries will be read again next cycle. True
+	// for EITHER cause (see streamOutcome), because either one means the next
+	// XREAD returns immediately with the same entries and so has to be paced.
 	deferred bool
+	// stalled narrows that to the lane-backpressure cause, which is paced
+	// differently: a missing worker is a sub-millisecond window inside
+	// RoomActivated, whereas a wedged consumer can last minutes, so only this
+	// one escalates its backoff. See stallBackoff.
+	stalled bool
 }
+
+// streamOutcome is what handleStream did with one stream's entries.
+//
+// Three outcomes rather than the bool this started as, because the two
+// non-consuming ones are indistinguishable to a caller that only learns "the
+// cursor did not move" and yet need different pacing and different counters.
+type streamOutcome int
+
+const (
+	// streamConsumed: the entries were dealt with — delivered, filtered or
+	// dropped — and the cursor advanced past them.
+	streamConsumed streamOutcome = iota
+	// streamUnready: the room has no delivery worker yet, so there is nowhere
+	// to put the entries. Counted as StreamStats.Deferred.
+	streamUnready
+	// streamStalled: the room's lane is at capacity, so delivering would force
+	// it to coalesce. Counted as StreamStats.Stalled.
+	streamStalled
+)
 
 // streamReadCtx derives the readers' context from the relay's bound context so
 // that Close cancels it too.
@@ -239,15 +268,90 @@ func (r *Relay) blockForBatch(i, n int, sawEntries bool) time.Duration {
 	return nonBlockingRead
 }
 
+// stallBackoff is the pause after n consecutive cycles that ended by declining
+// a cursor advance for lane backpressure.
+//
+// It doubles from stalledBackoffBase and is capped at limit (the reader's
+// ReadBlock). Doubling is what stops a room whose consumer is wedged for
+// minutes from re-reading the same entries as fast as Redis can answer:
+// re-reading is free per read and not free per second. Resetting the streak on
+// any cycle that does NOT stall is what keeps recovery prompt — one burst
+// leaves the reader at full speed on the very next cycle rather than serving
+// out an escalated penalty it no longer needs.
+//
+// Capped at ReadBlock, not at some larger number, because ReadBlock is already
+// this tier's stated bound on inbound latency and on how long Close and a
+// newly activated room wait (see maxReadBlock); a backoff past it would
+// silently break a bound Config.ReadBlock documents. The cap can therefore be
+// SMALLER than stalledBackoffBase — ReadBlock accepts values down to 1ms — and
+// the cap wins, because a reader must never pause longer than its own read
+// interval.
+//
+// Doubled by multiplication rather than by shifting stalledBackoffBase << n-1:
+// the streak has no upper bound, and that shift goes negative at n=38.
+func stallBackoff(n int, limit time.Duration) time.Duration {
+	d := stalledBackoffBase
+	for i := 1; i < n && d < limit; i++ {
+		d *= 2
+	}
+	if d > limit {
+		d = limit
+	}
+	return d
+}
+
+// nextPause is a reader's whole pacing decision for one finished cycle: how
+// long to wait before the next XREAD, and what the stall streak becomes.
+//
+// A pure function of (what the cycle saw, the streak so far, the read
+// interval), so the escalate-and-reset behaviour can be asserted directly
+// instead of inferred from how fast a goroutine happens to loop.
+//
+// stalls counts CONSECUTIVE cycles that ended by declining a cursor advance
+// for lane backpressure, and any cycle that did not stall resets it — which is
+// what makes recovery prompt after a single burst. It is per READER rather
+// than per room for three reasons: the pause is one decision per cycle (see
+// deferredReadBackoff), so a per-room map would have to be collapsed to one
+// number here anyway; escalation is driven by the worst room on the reader,
+// which is what that collapse would pick; and a per-room map would grow with
+// room churn and so need its own bound and eviction pass, a cost cursors and
+// lastSeq already each pay once.
+//
+// A stalled cycle outranks a merely deferred one because a wedged consumer
+// outlasts an activation window by orders of magnitude, and a cycle that was
+// both should be paced for the longer-lived condition.
+func nextPause(res readResult, stalls int, readBlock time.Duration) (time.Duration, int) {
+	switch {
+	case res.stalled:
+		stalls++
+		return stallBackoff(stalls, readBlock), stalls
+	case res.deferred:
+		// Entries are still waiting under a cursor, so the next XREAD will
+		// return immediately with the same ones; pace the retry instead of
+		// spinning. See deferredReadBackoff.
+		return deferredReadBackoff, 0
+	default:
+		return 0, 0
+	}
+}
+
 // runStreamReader is one reader goroutine. It owns the rooms hash-assigned to
 // idx and multiplexes them over XREAD.
+//
+// It also carries the cycle's pacing state, because pacing is the one decision
+// in this loop that needs something from the PREVIOUS cycle (the stall streak)
+// and readOnce is deliberately stateless. Goroutine-local, so no reader can
+// contend with another for it.
 func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 	defer r.wg.Done()
+
+	stalls := 0
 	for {
 		if ctx.Err() != nil || r.closed.Load() {
 			return
 		}
-		if err := r.readOnce(ctx, idx); err != nil {
+		res, err := r.readOnce(ctx, idx)
+		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 				return
 			}
@@ -259,6 +363,13 @@ func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 				return
 			case <-time.After(readErrorBackoff):
 			}
+			// The streak is deliberately left alone: a Redis error says
+			// nothing about whether the lane that stalled has drained.
+			continue
+		}
+		var d time.Duration
+		if d, stalls = nextPause(res, stalls, r.scfg.readBlock); d > 0 {
+			r.pause(ctx, d)
 		}
 	}
 }
@@ -275,7 +386,13 @@ func (r *Relay) runStreamReader(ctx context.Context, idx int) {
 // what marks an entry consumed), whereas resuming mid-cycle would mean
 // carrying per-reader batch position across an error path for no correctness
 // gain.
-func (r *Relay) readOnce(ctx context.Context, idx int) error {
+//
+// It reports what the cycle saw and does NOT pace itself: the retry pause
+// depends on how many cycles in a row have stalled, which is state
+// runStreamReader keeps.
+func (r *Relay) readOnce(ctx context.Context, idx int) (readResult, error) {
+	var cycle readResult
+
 	rooms := r.roomsForReader(idx)
 	if len(rooms) == 0 {
 		// XREAD with zero keys is invalid, so an idle reader cannot block on
@@ -283,26 +400,20 @@ func (r *Relay) readOnce(ctx context.Context, idx int) error {
 		// for the same reason the read is: this wait is also how long a
 		// newly activated room and Close wait on this reader.
 		r.pause(ctx, r.scfg.readBlock)
-		return nil
+		return cycle, nil
 	}
 
 	batches := keyBatches(rooms, maxKeysPerRead/streamsPerRoom)
-	var cycle readResult
 	for i := range batches {
 		res, err := r.readBatch(ctx, batches[i], r.blockForBatch(i, len(batches), cycle.got))
 		if err != nil {
-			return err
+			return cycle, err
 		}
 		cycle.got = cycle.got || res.got
 		cycle.deferred = cycle.deferred || res.deferred
+		cycle.stalled = cycle.stalled || res.stalled
 	}
-	if cycle.deferred {
-		// Entries are still waiting under a cursor, so the next XREAD will
-		// return immediately with the same ones; pace the retry instead of
-		// spinning. See deferredReadBackoff.
-		r.pause(ctx, deferredReadBackoff)
-	}
-	return nil
+	return cycle, nil
 }
 
 // pause waits for d unless the relay is shutting down first, so no wait in
@@ -389,8 +500,13 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 				"stream", stream.Stream, "room", room, "kind", kind)
 			continue
 		}
-		if r.handleStream(tgt, stream.Messages) {
+		switch r.handleStream(tgt, stream.Messages) {
+		case streamUnready:
 			out.deferred = true
+		case streamStalled:
+			out.deferred = true
+			out.stalled = true
+		case streamConsumed:
 		}
 	}
 	return out, nil
@@ -444,8 +560,8 @@ func (r *Relay) evictStaleCursorsLocked() {
 	}
 }
 
-// handleStream applies one stream's returned entries and advances its cursor.
-// It reports whether the entries were left for a later cycle instead.
+// handleStream applies one stream's returned entries and advances its cursor,
+// or reports which of the two reasons it left them for a later cycle instead.
 //
 // Entries are handed to the room's LANE, never to Sink.Inject directly, which
 // is load-bearing in four ways:
@@ -472,9 +588,9 @@ func (r *Relay) evictStaleCursorsLocked() {
 // to every local peer — turning one reader's restart into an N-fold broadcast
 // storm. Awareness is not merged: each payload carries its own clock and the
 // receiver's per-client gate handles staleness.
-func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) (deferred bool) {
+func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOutcome {
 	if len(msgs) == 0 {
-		return false
+		return streamConsumed
 	}
 
 	// Resolved once, as the router does: a room retired mid-batch leaves a
@@ -496,8 +612,38 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) (deferre
 		// routerDrops is deliberately NOT incremented. Nothing was dropped:
 		// RouterDrops counts messages the router DISCARDED, and counting a
 		// deferral there would report loss that did not happen, on a counter
-		// operators are told to watch the rate of.
-		return true
+		// operators are told to watch the rate of. StreamStats.Deferred counts
+		// it instead, which is a declined advance rather than a loss.
+		r.deferred.Add(1)
+		return streamUnready
+	}
+
+	// This branch is the whole argument for this tier over pub/sub. When a
+	// room's local consumer falls behind, pub/sub can only choose between
+	// merging the backlog and dropping it, because the message it holds exists
+	// nowhere else. A stream entry is durable, so there is a third option:
+	// leave the entries under the cursor and read them again next cycle. That
+	// costs one re-read, discards nothing, and asks the lane to merge nothing
+	// — which is what makes backpressure toward Redis safe here.
+	//
+	// Placed BEFORE the decode loop, not before the push as would be the
+	// obvious reading, because the loop is not side-effect free: it calls
+	// noteSeq, which records each source's latest sequence number. Deciding to
+	// stall after that would leave lastSeq holding sequences from entries we
+	// are about to re-read, and next cycle's lower numbers would then be
+	// classified as a publisher RESTART — inflating StreamStats.Restarts once
+	// per stalled cycle on a perfectly healthy cluster. The unready branch
+	// above returns before the loop for the same reason.
+	//
+	// Awareness streams are deliberately exempt. Lane.Full reports on the
+	// SYNC queue, the only thing the lane's capacity governs; an awareness
+	// push replaces a single latest-only slot, so it can neither deepen the
+	// backlog this backoff exists to bound nor trigger a merge. Declining one
+	// would cost presence freshness and buy nothing, and would re-read
+	// presence entries that the next push supersedes anyway.
+	if !tgt.isAwareness && w.lane.Full() {
+		r.stalled.Add(1)
+		return streamStalled
 	}
 
 	syncPayloads := make([][]byte, 0, len(msgs))
@@ -562,7 +708,7 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) (deferre
 	if lastID != "" {
 		r.setCursor(tgt.key, lastID)
 	}
-	return false
+	return streamConsumed
 }
 
 // pushSync hands a stream's sync entries to a room's lane as ONE merged

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -142,19 +142,27 @@ const nonBlockingRead = -1 * time.Nanosecond
 
 // cursorLimit bounds how many stream cursors are remembered.
 //
-// The two kinds of cursor have deliberately different retention, because
-// they start from different defaults when they are missing:
+// It bounds SYNC cursors only, because those are the only kind this map
+// holds. The two kinds need opposite retention across a room's
+// deactivate/reactivate cycle, since they start from opposite defaults when
+// they are missing, and they are stored in different places so that each
+// retention follows from where the cursor lives rather than from remembering
+// to delete it:
 //
 //   - A SYNC cursor survives its room's deactivation. Its default is the
 //     oldest retained entry, so dropping it at deactivation would make
 //     ordinary room churn replay the room's whole retention window on every
 //     reactivation — the condition StreamStats.Replayed exists to alarm on.
-//   - An AWARENESS cursor is dropped at deactivation (see RoomDeactivated).
-//     Its default is the tail, so keeping it would resume a reactivated room
-//     mid-stream and replay presence for whoever was in the room last time.
-//
-// So sync cursors accumulate across churn and this limit is what stops that
-// growing forever. See evictStaleCursorsLocked for which entries go.
+//     Hence a relay-scoped map, outliving any one residency, and hence this
+//     limit: sync cursors accumulate across churn and something has to stop
+//     that growing forever. See evictStaleCursorsLocked for which entries go.
+//   - An AWARENESS cursor must NOT survive it. Its default is the tail, so
+//     keeping it would resume a reactivated room mid-stream and replay
+//     presence for whoever was in the room last time. Hence it is not in
+//     this map at all: it lives on the room's delivery worker
+//     (roomWorker.awCursor), whose lifetime IS the residency, so a
+//     reactivated room starts at the tail with nothing to delete and no
+//     in-flight read able to write the old position back.
 const cursorLimit = 4096
 
 // streamTarget is one XREAD key together with what it means.
@@ -169,6 +177,20 @@ type streamTarget struct {
 	key         string
 	room        string
 	isAwareness bool
+	// residency is the roomWorker that owned the room when this read's id
+	// vector was built, and is the fence awareness delivery is accepted
+	// against — see awarenessCursor and deliverAwareness. Meaningful for
+	// awareness targets only.
+	//
+	// Sync delivery is deliberately NOT fenced this way: re-delivering a sync
+	// entry to a reactivated room is idempotent and commutative (see
+	// oldestID), whereas re-delivering presence resurrects departed clients.
+	// A worker POINTER rather than a generation counter because the worker is
+	// already the object whose lifetime is exactly one residency, so it needs
+	// no second map to bound, and because a live reference to the retired
+	// worker keeps its address from being recycled — a counter that could be
+	// deleted and reissued would compare equal across residencies.
+	residency *roomWorker
 }
 
 // readResult is what one batch's XREAD found, which is what the next batch's
@@ -427,9 +449,10 @@ func (r *Relay) pause(ctx context.Context, d time.Duration) {
 }
 
 // readBatch reads one XREAD's worth of rooms: each room's sync stream from
-// its cursor (defaulting to the oldest retained entry) and its awareness
-// stream from its cursor (defaulting to the tail). See the oldestID/tailID
-// constants for why those two defaults differ.
+// the relay's cursor (defaulting to the oldest retained entry) and its
+// awareness stream from its RESIDENCY's cursor (defaulting to the tail). See
+// the oldestID/tailID constants for why those two defaults differ, and
+// roomWorker.awCursor for why the two cursors are kept in different places.
 //
 // block is chosen by the caller per batch; see blockForBatch.
 func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Duration) (readResult, error) {
@@ -440,7 +463,11 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 	keys := make([]string, 0, n)
 	ids := make([]string, 0, n)
 
-	add := func(tgt streamTarget, dflt string) {
+	// from is the ID this stream is read from, resolved by the caller: the two
+	// kinds read their cursor out of different places (see
+	// roomWorker.awCursor), and the awareness one has to be resolved together
+	// with the residency that owns it.
+	add := func(tgt streamTarget, from string) {
 		// Unreachable for distinct rooms: syncKey and awKey cannot collide
 		// with each other for ANY pair of room names (see the kindDiscrim
 		// constants), and roomsForReader yields each room once. It survives as
@@ -452,11 +479,21 @@ func (r *Relay) readBatch(ctx context.Context, rooms []string, block time.Durati
 		}
 		targets[tgt.key] = tgt
 		keys = append(keys, tgt.key)
-		ids = append(ids, r.cursorFor(tgt.key, dflt))
+		ids = append(ids, from)
 	}
 	for _, room := range rooms {
-		add(streamTarget{key: r.scfg.syncKey(room), room: room}, oldestID)
-		add(streamTarget{key: r.scfg.awKey(room), room: room, isAwareness: true}, tailID)
+		syncKey := r.scfg.syncKey(room)
+		add(streamTarget{key: syncKey, room: room}, r.cursorFor(syncKey, oldestID))
+		// Resolved as a pair, under one lock: the awareness position and the
+		// residency it belongs to are one fact, and handleStream delivers the
+		// response only while that residency is still the room's.
+		residency, awFrom := r.awarenessCursor(room)
+		add(streamTarget{
+			key:         r.scfg.awKey(room),
+			room:        room,
+			isAwareness: true,
+			residency:   residency,
+		}, awFrom)
 	}
 
 	args := make([]string, 0, len(keys)+len(ids))
@@ -546,9 +583,10 @@ func (r *Relay) setCursor(key, id string) {
 // under nothing worse than ordinary scale.
 //
 // If every cursor is live the map is left above cursorLimit. That is the
-// correct outcome: the residual is then bounded by streamsPerRoom x the
-// rooms this node actually reads, i.e. by real load, and it is the same order
-// as streamRooms itself.
+// correct outcome: the residual is then bounded by the rooms this node
+// actually reads — one sync cursor each, awareness being held on the workers
+// instead (see roomWorker.awCursor) — i.e. by real load, and it is the same
+// order as streamRooms itself.
 //
 // Caller must hold streamMu (which also guards streamRooms).
 func (r *Relay) evictStaleCursorsLocked() {
@@ -588,6 +626,13 @@ func (r *Relay) evictStaleCursorsLocked() {
 // to every local peer — turning one reader's restart into an N-fold broadcast
 // storm. Awareness is not merged: each payload carries its own clock and the
 // receiver's per-client gate handles staleness.
+//
+// Awareness also takes a different route to the lane. It is handed over by
+// deliverAwareness, which drops the whole read if the room has changed
+// residency since the id vector was built, because presence published before
+// a reactivation must not reach the room's new occupants. Sync goes straight
+// to the lane resolved above: replaying a sync entry is harmless, so it
+// inherits the same accepted staleness runSubscriber has.
 func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOutcome {
 	if len(msgs) == 0 {
 		return streamConsumed
@@ -647,6 +692,10 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 	}
 
 	syncPayloads := make([][]byte, 0, len(msgs))
+	// Collected rather than pushed inline, because the push and the cursor
+	// advance have to happen as ONE residency-fenced operation — see
+	// deliverAwareness.
+	var awPayloads [][]byte
 	lastID := ""
 	for _, msg := range msgs {
 		// Recorded before every skip below, deliberately: a malformed,
@@ -693,11 +742,21 @@ func (r *Relay) handleStream(tgt streamTarget, msgs []goredis.XMessage) streamOu
 			// designed behaviour rather than evidence of loss, and feeding
 			// them to gap detection would make Gaps — a counter documented as
 			// "alert on presence" — nonzero on every healthy node.
-			w.lane.Push(cluster.KindAwareness, data)
+			awPayloads = append(awPayloads, data)
 			continue
 		}
 		r.noteSeq(tgt.key, nodeID, seq)
 		syncPayloads = append(syncPayloads, data)
+	}
+
+	if tgt.isAwareness {
+		// Payloads and cursor together, accepted only if the room is still on
+		// the residency this read was issued for. A false return is a
+		// deliberate discard of presence published before a reactivation, not
+		// a deferral: the successor residency reads from the tail, so the
+		// outcome is still "these entries are dealt with".
+		r.deliverAwareness(tgt.room, tgt.residency, awPayloads, lastID)
+		return streamConsumed
 	}
 
 	if len(syncPayloads) > 0 {

--- a/cluster/redis/streams_reader.go
+++ b/cluster/redis/streams_reader.go
@@ -796,6 +796,10 @@ func (r *Relay) pushSync(w *roomWorker, tgt streamTarget, payloads [][]byte) {
 		return
 	}
 	w.lane.Push(cluster.KindSync, merged)
+	// Counted on EVERY successful multi-entry merge, whether or not any of the
+	// entries had been delivered before — which is why StreamStats.Replayed is
+	// documented as a merge/batching gauge and explicitly not a counter to
+	// alert on the rate of.
 	r.replayed.Add(uint64(len(payloads) - 1))
 }
 
@@ -810,6 +814,16 @@ func (r *Relay) pushSync(w *roomWorker, tgt streamTarget, payloads [][]byte) {
 type seqSource struct {
 	node   string // publisher nodeID, as raw bytes held in a string
 	stream string // stream key the entry was read from
+}
+
+// seqState is what this reader remembers about one sequence series.
+//
+// afterDecrease rides alongside the number rather than being derived from it,
+// because "the previous observation went backwards" is not recoverable from
+// the baseline value alone. See noteSeq for what it suppresses and why.
+type seqState struct {
+	last          uint64
+	afterDecrease bool
 }
 
 // noteSeq tracks one source node's sequence numbers ON ONE STREAM and
@@ -832,6 +846,35 @@ type seqSource struct {
 // under the same identity. Reporting it as a gap would cry data loss on every
 // deploy; worse, treating the lower numbers as already-seen would stall that
 // source forever. So a decrease resets the baseline and is counted separately.
+//
+// THE FIRST COMPARISON AFTER A DECREASE CANNOT REPORT A GAP. A decrease is
+// itself the statement "this source's numbering is not, right now, a reliable
+// basis for inference", so the very next entry re-baselines instead of
+// accusing. Two causes need this, and neither is exotic:
+//
+//   - nextSeq releases streamMu before the XADD it numbered is issued, and
+//     Relay.Publish's contract explicitly requires tolerating two concurrent
+//     Publish calls for the same room (a room's eviction/reload handoff does
+//     exactly that, and room churn is continuous). So one publisher's entries
+//     can land in the stream as [seq2, seq1] — a decrease, then a jump from
+//     seq1 to seq3. The alternative fix is to hold streamMu across the XAdd,
+//     which is refused: that is a lock held across a Redis call, and it would
+//     couple every room on the node to one slow write — the cross-room
+//     head-of-line coupling #187/#200 removed and this branch had to fix once
+//     already.
+//   - a restarted node's fresh [1 2 3…] can be read interleaved with the tail
+//     of its own pre-restart series for the same reason.
+//
+// The trade is explicit and deliberate: this suppresses one REAL gap in the
+// case where a genuine trim-away lands immediately after a genuine restart on
+// the same series, and nothing else — the suppression is one comparison deep
+// and clears on the next entry, so a persistent gap is still reported. That is
+// the right way to be wrong for this counter. StreamStats.Gaps is documented
+// "ALERT ON PRESENCE… a single gap means data was lost": its entire value is
+// that a non-zero reading means something, and a signal that fires on healthy
+// room churn is worth less than no signal at all. Losing one increment in a
+// narrow conjunction costs an alert that a stall of any duration would raise
+// again; a false positive costs the counter its credibility permanently.
 func (r *Relay) noteSeq(streamKey string, nodeID []byte, seq uint64) {
 	src := seqSource{node: string(nodeID), stream: streamKey}
 
@@ -840,15 +883,20 @@ func (r *Relay) noteSeq(streamKey string, nodeID []byte, seq uint64) {
 	if !known && len(r.lastSeq) >= seqLimit {
 		r.evictStaleLastSeqLocked()
 	}
-	r.lastSeq[src] = seq
+	decreased := known && seq < prev.last
+	r.lastSeq[src] = seqState{last: seq, afterDecrease: decreased}
 	r.streamMu.Unlock()
 
 	switch {
 	case !known:
 		// First entry from this node on this stream: a baseline, not a gap.
-	case seq < prev:
+	case decreased:
 		r.restarts.Add(1)
-	case seq > prev+1:
+	case seq > prev.last+1:
+		if prev.afterDecrease {
+			// Re-baselining, not accusing. See the doc comment.
+			return
+		}
 		r.gaps.Add(1)
 	}
 }

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -1607,3 +1607,68 @@ func TestUnit_StreamReader_ReadOnceReportsEachDeferralCauseSeparately(t *testing
 	require.Equal(t, oldestID, r.cursorFor(r.scfg.syncKey("unready"), oldestID))
 	require.Equal(t, oldestID, r.cursorFor(r.scfg.syncKey("wedged"), oldestID))
 }
+
+// The sync half of the residency fence, and the one place the tier can lose an
+// entry outright.
+//
+// handleStream resolves the room's worker, pushes onto its lane, and then
+// advances the cursor. stopWorker can land in between, and if the retiring
+// worker's final drainLane has ALREADY run, the pushed payload sits on a lane
+// with no consumer left — so an unconditional advance would move the cursor
+// past an entry nothing ever read, and the successor residency, which starts
+// from that cursor, would skip it permanently.
+func TestUnit_StreamReader_SyncOntoARetiredResidencyKeepsTheCursor(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: registering workers by hand keeps this to the
+	// residency transition, with no goroutine draining a lane whose depth is
+	// the assertion.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	register := func(room string) *roomWorker {
+		w := &roomWorker{room: room, lane: relaylane.New(r.laneCap), done: make(chan struct{})}
+		r.workersMu.Lock()
+		r.workers[room] = w
+		r.workersMu.Unlock()
+		return w
+	}
+
+	key := r.scfg.syncKey("room1")
+	r.setCursor(key, "5-0")
+	tgt := streamTarget{key: key, room: "room1"}
+	payloads := [][]byte{v1Update(t, "edit")}
+
+	// The residency the read resolved, retired and replaced before the push
+	// lands. stopWorker is the real production path.
+	old := register("room1")
+	r.stopWorker("room1")
+	fresh := register("room1")
+	require.NotSame(t, old, fresh, "a reactivation must be a new residency")
+
+	require.Equal(t, streamUnready, r.applySync(old, tgt, payloads, "6-0"))
+	require.Equal(t, "5-0", r.cursorFor(key, oldestID),
+		"the cursor must not advance past an entry pushed onto a retired lane: the successor reads from it and would skip the entry for good")
+	require.Equal(t, uint64(1), r.StreamStats().Deferred,
+		"a declined advance on entries that were kept is a deferral, and reports as one")
+	require.Equal(t, uint64(0), r.Stats().RouterDrops, "nothing was discarded")
+	require.Equal(t, 0, fresh.lane.Depth(),
+		"the successor gets these entries from the re-read, not from this push")
+	require.Equal(t, 1, old.lane.Depth(),
+		"the duplicate push onto the dead lane is the accepted cost: V1 updates are idempotent")
+
+	// The other half of the promise: on the live residency the same entries
+	// are delivered and the cursor does move on.
+	require.Equal(t, streamConsumed, r.applySync(fresh, tgt, payloads, "6-0"))
+	require.Equal(t, "6-0", r.cursorFor(key, oldestID), "a live residency must advance the cursor")
+	require.Equal(t, 1, fresh.lane.Depth())
+	require.Equal(t, uint64(1), r.StreamStats().Deferred, "a clean pass must not count as a deferral")
+
+	// Entries that produced no payload at all — self-published, malformed —
+	// have nothing to lose, so a residency change must not defer them: they
+	// would be read and skipped again forever.
+	r.stopWorker("room1")
+	require.Equal(t, streamConsumed, r.applySync(fresh, tgt, nil, "7-0"))
+	require.Equal(t, "7-0", r.cursorFor(key, oldestID))
+	require.Equal(t, uint64(1), r.StreamStats().Deferred)
+}

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -851,6 +851,13 @@ func TestUnit_StreamReader_AwarenessFromAPriorResidencyIsNotDelivered(t *testing
 		"the entries are dealt with, not deferred: the successor reads from the tail")
 	require.Equal(t, 0, fresh.lane.Depth(),
 		"presence published before the reactivation must not reach the new occupants")
+	// And not onto the RETIRED residency's lane either, which is the half a
+	// residency check performed separately from the push would miss. A
+	// stopped worker performs one final drain into Sink.Inject (see
+	// runRoomWorker), and Inject is addressed by ROOM — so a blob parked on
+	// the old lane still reaches room1, whose occupants are now the new ones.
+	require.Equal(t, 0, old.lane.Depth(),
+		"a read from a prior residency must not push anywhere: the retired lane still drains into the room")
 	residency, awFrom := r.awarenessCursor("room1")
 	require.Same(t, fresh, residency)
 	require.Equal(t, tailID, awFrom,

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -574,3 +574,144 @@ func TestIntegration_StreamReader_ActivationDoesNotWaitOutReadBlock(t *testing.T
 		3*time.Second, 10*time.Millisecond,
 		"a room activated mid-read must not wait out ReadBlock (%s)", defaultReadBlock)
 }
+
+// --- Gap detection ---------------------------------------------------------
+
+// noteSeq must key its baseline by (nodeID, stream key). One node's two
+// streams carry two INDEPENDENT series — nextSeq counts per stream — so
+// folding them into one series by nodeID alone compares numbers that were
+// never meant to be compared.
+//
+// The A,A,A,B,B,B ordering below is what makes this test discriminating: with
+// per-node keying it reads as 1,2,3 then a DECREASE to 1, so Restarts climbs
+// on a node that merely publishes to two rooms. Ordering the two series
+// strictly alternately would hide the defect, since 1,1,2,2,3,3 contains
+// neither a jump nor a decrease.
+func TestUnit_StreamReader_NoteSeqIsPerNodePerStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: no reader goroutine, so nothing else touches
+	// the counters this test asserts on.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	keyA, keyB := r.scfg.syncKey("room1"), r.scfg.syncKey("room2")
+	src := []byte(nodeB)
+
+	for _, seq := range []uint64{1, 2, 3} {
+		r.noteSeq(keyA, src, seq)
+	}
+	for _, seq := range []uint64{1, 2, 3} {
+		r.noteSeq(keyB, src, seq)
+	}
+	require.Equal(t, uint64(0), r.StreamStats().Gaps,
+		"two contiguous per-stream series from one node are not a gap")
+	require.Equal(t, uint64(0), r.StreamStats().Restarts,
+		"the second stream's series starting over is not a restart")
+
+	// A real jump within ONE stream is still a gap.
+	r.noteSeq(keyA, src, 9)
+	require.Equal(t, uint64(1), r.StreamStats().Gaps, "a jump on one stream must be reported")
+
+	// And the other stream's baseline was untouched by it.
+	r.noteSeq(keyB, src, 4)
+	require.Equal(t, uint64(1), r.StreamStats().Gaps, "streams must not interfere")
+
+	// A different node on the same stream is its own series, so its first
+	// entry is a baseline rather than a decrease.
+	r.noteSeq(keyA, []byte(nodeA), 1)
+	require.Equal(t, uint64(0), r.StreamStats().Restarts)
+	require.Equal(t, uint64(1), r.StreamStats().Gaps)
+
+	// A genuine decrease on one series is still a restart.
+	r.noteSeq(keyA, src, 2)
+	require.Equal(t, uint64(1), r.StreamStats().Restarts)
+}
+
+// A healthy node publishing to SEVERAL rooms must leave a reader's Gaps and
+// Restarts at zero. This is the assertion that protects the contract:
+// StreamStats.Gaps is documented "ALERT ON PRESENCE, not on rate — a single
+// gap means data was lost", so a counter that ticks during ordinary
+// multi-room operation is worse than no counter at all, and issue #196 reads
+// this number directly.
+//
+// Two phases, because the two halves of the defect need different traffic
+// shapes to expose them, and one of them is invisible under the other's
+// shape:
+//
+//   - Interleaved across rooms catches the PUBLISHER half. With one counter
+//     shared across rooms, room1's stream held [1 3 5] and room2's [2 4 6];
+//     measured Gaps=4 against that counter.
+//   - Room-at-a-time catches the READER half. With lastSeq keyed by nodeID
+//     alone, one node's two per-stream series concatenate into 4,5,6 then
+//     4,5,6 and the second one reads as a DECREASE; measured Restarts=1
+//     against that keying. Interleaved traffic hides it entirely, because
+//     4,4,5,5,6,6 contains neither a jump nor a decrease — which is why this
+//     phase exists and why it waits for delivery between rooms.
+//
+// Both mutations recorded in task-6-report.md.
+func TestIntegration_StreamReader_HealthyMultiRoomReaderRecordsNoGaps(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+	a.RoomActivated("room1")
+	a.RoomActivated("room2")
+
+	publish := func(room, text string) {
+		require.NoError(t, b.Publish(ctx, cluster.Outbound{
+			Room: room, Kind: cluster.KindSync, Data: v1Update(t, text),
+		}))
+	}
+	// A witness on every phase: without it a Gaps assertion would pass on a
+	// reader that never delivered anything at all.
+	waitSeen := func(texts ...string) {
+		require.Eventually(t, func() bool {
+			for _, text := range texts {
+				if !sink.payloadSeen(text) {
+					return false
+				}
+			}
+			return true
+		}, 5*time.Second, 10*time.Millisecond, "every edit must be delivered: %v", texts)
+	}
+
+	// Phase 1: interleaved across rooms, which is what a node hosting two
+	// rooms ordinarily does.
+	var interleaved []string
+	for i := 0; i < 3; i++ {
+		for _, room := range []string{"room1", "room2"} {
+			text := fmt.Sprintf("edit-%s-%d", room, i)
+			interleaved = append(interleaved, text)
+			publish(room, text)
+		}
+	}
+	waitSeen(interleaved...)
+
+	// Phase 2: one room's whole batch delivered before the other's starts, so
+	// the reader observes the two per-stream series back to back.
+	for _, room := range []string{"room1", "room2"} {
+		var batch []string
+		for i := 3; i < 6; i++ {
+			text := fmt.Sprintf("edit-%s-%d", room, i)
+			batch = append(batch, text)
+			publish(room, text)
+		}
+		waitSeen(batch...)
+	}
+
+	require.Equal(t, uint64(0), a.StreamStats().Gaps,
+		"a healthy multi-room node must produce NO gaps: Gaps is an alert-on-presence signal")
+	require.Equal(t, uint64(0), a.StreamStats().Restarts,
+		"no node restarted, so nothing may be reported as one")
+}

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -80,26 +80,17 @@ func TestUnit_StreamReader_KeyBatchingEmpty(t *testing.T) {
 // predecessor's RoomDeactivated, in either order. Refcounting rides that out;
 // treating deactivation as an unconditional removal would drop a live room.
 //
-// r.Start is required here even though the brief's version of this test
-// omitted it: RoomActivated/RoomDeactivated both return immediately when
-// !r.started.Load(), before ever reaching the pub/sub work this task's
-// stream block is appended after — so without Start, streamRooms would
-// never be touched and this test would fail regardless of whether the new
-// refcounting code is correct (the same class of gap already caught and
-// documented in streams_test.go's Both/PubSub Publish tests).
+// r.Start is REQUIRED: RoomActivated/RoomDeactivated both return immediately
+// when !r.started.Load(), before ever reaching the stream block, so without it
+// streamRooms would never be touched and this test would pass or fail
+// regardless of the refcounting code.
 //
-// The brief's version of this test asserted only presence/absence via
-// roomsForReader, which does not actually distinguish a true integer refcount
-// from a naive boolean flag that merely mirrors whether activeRooms[room] is
-// zero: since every RoomActivated/RoomDeactivated call drives BOTH activeRooms
-// and streamRooms off the exact same events, a flag that flips on the 0->1
-// and >0->0 crossings would show identically "present" after the successor
-// activation and "absent" after the final deactivation, with no assertion
-// ever distinguishing it from streamRooms holding the real count (2, then 1).
-// Added a direct read of r.streamRooms (this is package redis, so the
-// unexported field is reachable) to require the count itself is 2 after both
-// activations, and 1 after the predecessor's deactivation — the "reference
-// count" the interface's own doc comment calls for, not just a derived flag.
+// It asserts r.streamRooms's count directly rather than presence/absence via
+// roomsForReader, because presence cannot distinguish a real integer refcount
+// from a boolean flag: both drive off the same events, so a flag would read
+// "present" after the successor activation and "absent" after the final
+// deactivation either way. The counts (2, then 1) are the discriminating
+// assertion.
 func TestUnit_StreamReader_ActivationRefcounts(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{Transport: Streams})
@@ -130,23 +121,18 @@ func TestUnit_StreamReader_ActivationRefcounts(t *testing.T) {
 
 // --- Reader loop -----------------------------------------------------------
 //
-// Test-double naming: this file uses recordingSink rather than the fakeSink
-// the brief named. redis_test.go (package redis_test) already has a DIFFERENT
-// fakeSink, and internal_test.go (package redis) has countingSink; a third
-// type sharing the name fakeSink in the same directory compiles but is a
-// readability trap. countingSink could not simply be extended either — it
-// records only a count, and half of these tests need to assert on the actual
-// payload bytes, and widening a helper five existing tests depend on is a
-// larger change than adding a purpose-built one.
+// Test-double naming: recordingSink, not fakeSink — redis_test.go already has
+// a different fakeSink and internal_test.go has countingSink, so a third
+// same-named type in one directory compiles but misleads. countingSink records
+// only a count, and half these tests assert on payload bytes.
 
 // recordingSink records what a relay injects, so a test can assert on the
 // payload rather than only on a count.
 //
-// It has no room registry, unlike the brief's version: workerForInbound
-// routes on r.workers (populated by RoomActivated), and cluster/redis never
-// calls Sink.Rooms() at all — verified by grep. A rooms map here would have
-// implied that Sink residency gates inbound delivery, which is false, and the
-// next reader of this file would have believed it.
+// No room registry, deliberately: workerForInbound routes on r.workers
+// (populated by RoomActivated), and cluster/redis never calls Sink.Rooms(). A
+// rooms map here would imply Sink residency gates inbound delivery, which is
+// false.
 type recordingSink struct {
 	mu       sync.Mutex
 	injected [][]byte
@@ -265,7 +251,7 @@ func v1Update(t *testing.T, text string) []byte {
 //
 // Verified non-vacuous: with the reader loop absent (Start not launching
 // runStreamReader) this fails at the FIRST require.Eventually, because
-// nothing is ever injected. See task-6-report.md for the recorded output.
+// nothing is ever injected.
 func TestIntegration_StreamReader_ResumesAfterStopAndDeliversMissedUpdates(t *testing.T) {
 	mr := newMiniRedis(t)
 
@@ -367,14 +353,12 @@ func TestIntegration_StreamReader_CatchUpMergedIntoSingleInject(t *testing.T) {
 // Awareness is read from the tail and never replayed: replaying it would
 // resurrect presence for clients that are long gone.
 //
-// The brief's version of this test asserted ONLY that the stale awareness
-// payload is absent, after a fixed sleep. That would have passed even if the
-// reader never ran at all, or never read awareness streams at all — which is
-// the same vacuous-test class already caught in tasks 3 and 4. Two positive
-// witnesses are added: a sync entry published before start MUST be replayed
-// (proving the reader reached this room), and an awareness entry published
-// after start MUST arrive (proving awareness delivery works at all, so the
-// absence below is about the replay policy and not about a dead code path).
+// Asserting only the stale payload's absence would pass even if the reader
+// never ran, or never read awareness streams at all. Two positive witnesses
+// make it non-vacuous: a sync entry published before start MUST be replayed
+// (the reader reached this room), and an awareness entry published after start
+// MUST arrive (awareness delivery works at all), so the absence below is about
+// replay policy rather than a dead code path.
 func TestIntegration_StreamReader_AwarenessIsNotReplayed(t *testing.T) {
 	mr := newMiniRedis(t)
 	b, err := New(newClient(t, mr), readerConfig(nodeB))
@@ -417,10 +401,9 @@ func TestIntegration_StreamReader_AwarenessIsNotReplayed(t *testing.T) {
 
 // A node must not re-inject its own writes.
 //
-// Strengthened over the brief, which asserted only the absence of the node's
-// own payload after a fixed sleep — vacuous if the reader had not yet read
-// anything. Node B's payload is the witness: it proves the reader consumed
-// the same stream past A's own entry.
+// Absence of A's own payload alone would be vacuous if the reader had not yet
+// read anything. Node B's payload is the witness: it proves the reader
+// consumed the same stream past A's own entry.
 func TestIntegration_StreamReader_SelfFilter(t *testing.T) {
 	mr := newMiniRedis(t)
 	sink := &recordingSink{}
@@ -451,15 +434,12 @@ func TestIntegration_StreamReader_SelfFilter(t *testing.T) {
 
 // Transport's zero value is PubSub, and a PubSub relay must not grow a reader.
 //
-// The second half of this test is what actually pins the usesStreams gate in
-// Start. The first half — activate a room on a PubSub relay and see nothing
-// arrive — passes even with that gate removed, because RoomActivated has its
-// own usesStreams gate on streamRooms (task 5), so a launched reader would
-// simply idle with no assignment. Verified by mutation: replacing the Start
-// gate with `if true` left the first half green. So the second half forces
-// streamRooms to hold the room, which is the only other thing standing
-// between a reader and this stream; then the gate in Start is the sole
-// remaining defence, and removing it makes this test fail.
+// The second half is what pins the usesStreams gate in Start. The first half
+// passes even with that gate removed, because RoomActivated has its own
+// usesStreams gate on streamRooms, so a launched reader would idle with no
+// assignment (verified by mutation: `if true` in Start left it green). The
+// second half forces streamRooms to hold the room, leaving Start's gate as the
+// sole remaining defence.
 func TestIntegration_StreamReader_PubSubModeReadsNoStreams(t *testing.T) {
 	mr := newMiniRedis(t)
 
@@ -518,13 +498,11 @@ func TestUnit_StreamReader_CursorDefaultsAndRoundTrip(t *testing.T) {
 
 // Cursor eviction must not evict a room this relay is still reading.
 //
-// This deviates from the brief, which evicted an ARBITRARY map entry on
-// overflow. Doing that on a node with more than cursorLimit/2 active rooms
-// drops a live room's cursor roughly half the time, and losing a live
-// cursor replays that room's whole retention window — which is precisely
-// the condition StreamStats.Replayed tells operators to alert on. Evicting
-// only cursors whose room is no longer in streamRooms bounds the map by real
-// load instead.
+// Evicting an ARBITRARY entry on overflow drops a live room's cursor roughly
+// half the time on a node with more than cursorLimit/2 active rooms, and a
+// live room that loses its cursor replays its whole retention window — the
+// condition StreamStats.Replayed tells operators to alert on. Evicting only
+// cursors whose room has left streamRooms bounds the map by real load.
 func TestUnit_StreamReader_CursorEvictionKeepsActiveRooms(t *testing.T) {
 	mr := newMiniRedis(t)
 	// Deliberately NOT Started: no reader goroutine, so nothing races the
@@ -1151,8 +1129,6 @@ func TestUnit_StreamReader_FirstSeqEstablishesBaselineRegardlessOfValue(t *testi
 //     against that keying. Interleaved traffic hides it entirely, because
 //     4,4,5,5,6,6 contains neither a jump nor a decrease — which is why this
 //     phase exists and why it waits for delivery between rooms.
-//
-// Both mutations recorded in task-6-report.md.
 func TestIntegration_StreamReader_HealthyMultiRoomReaderRecordsNoGaps(t *testing.T) {
 	mr := newMiniRedis(t)
 

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
 	"github.com/reearth/ygo/awareness"
 	"github.com/reearth/ygo/cluster"
 	"github.com/reearth/ygo/crdt"
+	"github.com/reearth/ygo/internal/relaylane"
 )
 
 // Assignment must be stable: a room that moved readers between cycles would
@@ -148,9 +150,30 @@ func TestUnit_StreamReader_ActivationRefcounts(t *testing.T) {
 type recordingSink struct {
 	mu       sync.Mutex
 	injected [][]byte
+
+	// gate, when non-nil, parks every Inject until it is closed, standing in
+	// for a room whose consumer is wedged. Nil (the zero value) is the
+	// ordinary non-blocking sink every other test here uses, so adding this
+	// changed no existing behaviour and did not need a fourth sink type.
+	gate chan struct{}
+	// entered is closed the first time an Inject parks on gate, so a test can
+	// wait until delivery is genuinely stuck rather than guessing with a
+	// sleep.
+	entered     chan struct{}
+	enteredOnce sync.Once
 }
 
-func (s *recordingSink) Inject(_ context.Context, in cluster.Inbound) error {
+func (s *recordingSink) Inject(ctx context.Context, in cluster.Inbound) error {
+	if s.gate != nil {
+		s.enteredOnce.Do(func() { close(s.entered) })
+		select {
+		case <-s.gate:
+		case <-ctx.Done():
+			// Honour cancellation so Close's wg.Wait cannot hang on this
+			// worker if a test forgets to open the gate.
+			return ctx.Err()
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.injected = append(s.injected, append([]byte(nil), in.Data...))
@@ -1033,4 +1056,346 @@ func TestIntegration_StreamReader_HealthyMultiRoomReaderRecordsNoGaps(t *testing
 		"a healthy multi-room node must produce NO gaps: Gaps is an alert-on-presence signal")
 	require.Equal(t, uint64(0), a.StreamStats().Restarts,
 		"no node restarted, so nothing may be reported as one")
+}
+
+// --- Backpressure: declining the cursor advance ----------------------------
+
+// streamEntry builds one XREAD entry the way go-redis surfaces it, so a unit
+// test can drive handleStream without a round trip through Redis.
+//
+// Built from streamFields, the real encoder, rather than from a hand-written
+// map: a literal here would keep passing if the wire field names changed under
+// it, and would then be testing a format nothing writes.
+func streamEntry(t *testing.T, id, node string, seq uint64, kind cluster.Kind, data []byte) goredis.XMessage {
+	t.Helper()
+	fields := streamFields([]byte(node), seq, kind, data)
+	vals := make(map[string]any, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		name, ok := fields[i].(string)
+		require.True(t, ok, "field name %d is not a string", i)
+		switch v := fields[i+1].(type) {
+		case string:
+			vals[name] = v
+		case []byte:
+			// Redis returns every field as a bulk string; go-redis hands them
+			// back as Go strings. See streams_test.go's note on this.
+			vals[name] = string(v)
+		default:
+			t.Fatalf("field %q has unexpected type %T", name, v)
+		}
+	}
+	return goredis.XMessage{ID: id, Values: vals}
+}
+
+// wedgeLane registers a room worker whose lane is at capacity and which has NO
+// goroutine, so nothing drains it. That is exactly the state a room reaches
+// when its Sink.Inject is wedged, and it is reachable here without a running
+// websocket server and without a test-only hook in production code — an
+// earlier draft of this change carried a laneFullForTest func on Relay, which
+// this makes unnecessary.
+func wedgeLane(t *testing.T, r *Relay, room string, capacity int) *roomWorker {
+	t.Helper()
+	w := &roomWorker{room: room, lane: relaylane.New(capacity), done: make(chan struct{})}
+	r.workersMu.Lock()
+	r.workers[room] = w
+	r.workersMu.Unlock()
+
+	for i := 0; i < capacity; i++ {
+		w.lane.Push(cluster.KindSync, v1Update(t, fmt.Sprintf("filler-%d", i)))
+	}
+	require.True(t, w.lane.Full(), "the lane must really be at capacity")
+	require.Zero(t, r.Stats().Coalesced, "filling to capacity must not itself have merged")
+	return w
+}
+
+// This is what a durable stream buys that pub/sub cannot. With the local lane
+// at capacity, pub/sub's only options are to merge the backlog or drop it,
+// because the message exists nowhere else. Here the reader declines to advance
+// the cursor and reads the same entries again next cycle: nothing is
+// discarded, and the lane is not made to merge.
+func TestUnit_StreamReader_FullLaneDeclinesTheCursorAdvance(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: no reader goroutine and no worker goroutine,
+	// so the lane this test fills stays full and the counters it asserts on
+	// are touched by nothing else.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1, RoomQueueSize: 2})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	w := wedgeLane(t, r, "room1", 2)
+	key := r.scfg.syncKey("room1")
+	r.setCursor(key, "5-0")
+
+	tgt := streamTarget{key: key, room: "room1"}
+	msgs := []goredis.XMessage{
+		streamEntry(t, "6-0", nodeB, 1, cluster.KindSync, v1Update(t, "held-back")),
+	}
+
+	require.Equal(t, streamStalled, r.handleStream(tgt, msgs))
+	require.Equal(t, "5-0", r.cursorFor(key, oldestID),
+		"the cursor must stay put so the entry is read again next cycle")
+	require.Equal(t, uint64(1), r.StreamStats().Stalled)
+	require.Equal(t, uint64(0), r.StreamStats().Deferred,
+		"the room HAS a worker; this is backpressure, not the activation window")
+	require.Equal(t, uint64(0), r.Stats().RouterDrops, "nothing was discarded, only deferred")
+	require.Equal(t, 2, w.lane.Depth(), "the payload must not be pushed onto a full lane")
+	require.Equal(t, uint64(0), r.Stats().Coalesced, "and the lane must not be made to merge")
+
+	// The sequence number must NOT have been recorded. The entry is going to be
+	// read again, and a lastSeq holding it would make the re-read's lower
+	// number look like the publisher had restarted.
+	r.streamMu.Lock()
+	_, known := r.lastSeq[seqSource{node: nodeB, stream: key}]
+	r.streamMu.Unlock()
+	require.False(t, known, "a stalled stream must not record sequences it did not consume")
+
+	// The other half of the promise: once the lane drains, the SAME entries go
+	// through and the cursor moves on.
+	_, ok := w.lane.TakeSync()
+	require.True(t, ok)
+	require.Equal(t, streamConsumed, r.handleStream(tgt, msgs))
+	require.Equal(t, "6-0", r.cursorFor(key, oldestID), "a drained lane must advance the cursor")
+	require.Equal(t, 1, w.lane.Depth(), "and the held-back payload must be delivered")
+	require.Equal(t, uint64(1), r.StreamStats().Stalled, "a clean pass must not count as a stall")
+}
+
+// Awareness must NOT be held back by a full lane. Lane.Full reports on the
+// sync queue, the only thing the lane's capacity governs; an awareness push
+// replaces a single latest-only slot, so declining one would cost presence
+// freshness and buy nothing — and would re-read presence that the next push
+// supersedes anyway.
+func TestUnit_StreamReader_AwarenessIsExemptFromLaneBackpressure(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1, RoomQueueSize: 2})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	w := wedgeLane(t, r, "room1", 2)
+	awKey := r.scfg.awKey("room1")
+	tgt := streamTarget{key: awKey, room: "room1", isAwareness: true}
+	msgs := []goredis.XMessage{
+		streamEntry(t, "7-0", nodeB, 1, cluster.KindAwareness, []byte("presence")),
+	}
+
+	require.Equal(t, streamConsumed, r.handleStream(tgt, msgs))
+	require.Equal(t, "7-0", r.cursorFor(awKey, tailID), "an awareness stream advances regardless")
+	require.Equal(t, uint64(0), r.StreamStats().Stalled, "awareness must not register as a stall")
+	require.Equal(t, 3, w.lane.Depth(), "the awareness blob must be delivered to the lane")
+	require.Equal(t, uint64(0), r.Stats().Coalesced,
+		"and the awareness slot is separate, so nothing merged")
+}
+
+// Backoff must grow so a wedged room is not re-read as fast as Redis can
+// answer, and must be capped at the reader's own read interval so recovery
+// stays prompt and no pause outlives a bound ReadBlock documents.
+func TestUnit_StreamReader_StallBackoffGrowsAndCaps(t *testing.T) {
+	const limit = maxReadBlock // 250ms, the largest ReadBlock accepted
+
+	require.Equal(t, stalledBackoffBase, stallBackoff(1, limit))
+	require.Equal(t, 2*stalledBackoffBase, stallBackoff(2, limit))
+	require.Equal(t, 4*stalledBackoffBase, stallBackoff(3, limit))
+	require.Equal(t, limit, stallBackoff(4, limit),
+		"the fourth doubling would be 400ms, past the cap")
+
+	// Monotone, positive and capped for every streak length, including ones
+	// long past the point where a shift of the base would have overflowed to a
+	// negative duration (stalledBackoffBase << 37 does).
+	prev := time.Duration(0)
+	for n := 1; n <= 64; n++ {
+		d := stallBackoff(n, limit)
+		require.GreaterOrEqual(t, d, prev, "backoff must be monotone at n=%d", n)
+		require.LessOrEqual(t, d, limit, "backoff must never exceed the cap at n=%d", n)
+		require.Positive(t, d, "backoff must stay positive at n=%d", n)
+		prev = d
+	}
+
+	// A ReadBlock below the base is legal, down to minReadBlock, and then the
+	// cap wins outright: a reader must never pause longer than its own read
+	// interval.
+	require.Equal(t, minReadBlock, stallBackoff(1, minReadBlock))
+	require.Equal(t, minReadBlock, stallBackoff(9, minReadBlock))
+}
+
+// THE BACKPRESSURE HEADLINE, end to end. A room whose consumer is wedged
+// stalls its reader, and when the consumer frees up every entry published
+// during the stall is still delivered. Delivery is at-least-once within
+// min(retention, MaxLen/publish-rate); this test stays far inside that window,
+// which is what makes the entries still be there.
+//
+// The pub/sub tier structurally cannot pass this: at a full lane it must
+// either merge the backlog or drop it.
+func TestIntegration_StreamReader_WedgedConsumerLosesNothing(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	// RoomQueueSize 1: a single queued payload makes the lane full, so the
+	// stall is reached in a few cycles instead of dozens.
+	acfg := readerConfig(nodeA)
+	acfg.RoomQueueSize = 1
+
+	sink := &recordingSink{gate: make(chan struct{}), entered: make(chan struct{})}
+	gateOnce := sync.Once{}
+	openGate := func() { gateOnce.Do(func() { close(sink.gate) }) }
+	defer openGate() // never leave a worker parked, even on a failure path
+
+	a, err := New(newClient(t, mr), acfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+	a.RoomActivated("room1")
+
+	// Publish until the reader has actually declined an advance. A fixed
+	// number of publishes could race the cycle boundary and never observe the
+	// stall; every publish here appends a real entry, so the loop always makes
+	// progress toward the condition, and every text it published is asserted
+	// on below.
+	var texts []string
+	deadline := time.Now().Add(20 * time.Second)
+	for a.StreamStats().Stalled == 0 {
+		require.False(t, time.Now().After(deadline),
+			"the reader never declined an advance after %d publishes", len(texts))
+		text := fmt.Sprintf("wedged-edit-%d", len(texts))
+		texts = append(texts, text)
+		require.NoError(t, b.Publish(ctx, cluster.Outbound{
+			Room: "room1", Kind: cluster.KindSync, Data: v1Update(t, text),
+		}))
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, len(texts), 2, "a stall needs the lane to have filled first")
+
+	// Delivery is genuinely parked, and the cursor is being held back rather
+	// than the entries discarded.
+	select {
+	case <-sink.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the sink never parked, so nothing was wedged")
+	}
+	require.Equal(t, uint64(0), a.Stats().RouterDrops, "a stall discards nothing")
+	require.Equal(t, uint64(0), a.Stats().HardDrops)
+
+	// Let the consumer go. Everything published during the stall must arrive.
+	openGate()
+	require.Eventually(t, func() bool {
+		for _, text := range texts {
+			if !sink.payloadSeen(text) {
+				return false
+			}
+		}
+		return true
+	}, 20*time.Second, 20*time.Millisecond,
+		"every entry held back by the stall must be delivered once the lane drains")
+
+	require.Equal(t, uint64(0), a.StreamStats().Gaps,
+		"nothing was trimmed out from under the reader, so no gap may be reported")
+	require.Equal(t, uint64(0), a.Stats().RouterDrops)
+	require.Equal(t, uint64(0), a.Stats().HardDrops)
+}
+
+// The pacing decision itself: a stall streak must escalate, any non-stalled
+// cycle must reset it, and a cycle that both stalled and deferred must be
+// paced for the stall — the longer-lived of the two conditions.
+func TestUnit_StreamReader_PacingEscalatesAndResets(t *testing.T) {
+	const readBlock = maxReadBlock
+	stalledCycle := readResult{got: true, deferred: true, stalled: true}
+	unreadyCycle := readResult{got: true, deferred: true}
+	cleanCycle := readResult{got: true}
+
+	// A consecutive run escalates.
+	stalls := 0
+	var seen []time.Duration
+	for i := 0; i < 4; i++ {
+		var d time.Duration
+		d, stalls = nextPause(stalledCycle, stalls, readBlock)
+		seen = append(seen, d)
+	}
+	require.Equal(t, []time.Duration{
+		stalledBackoffBase, 2 * stalledBackoffBase, 4 * stalledBackoffBase, readBlock,
+	}, seen, "consecutive stalls must double until the cap")
+	require.Equal(t, 4, stalls)
+
+	// A clean cycle resets the streak outright, so the next stall starts over
+	// at the base rather than resuming an escalation it no longer needs.
+	d, stalls := nextPause(cleanCycle, stalls, readBlock)
+	require.Zero(t, d, "a clean cycle must not pause at all")
+	require.Zero(t, stalls)
+	d, stalls = nextPause(stalledCycle, stalls, readBlock)
+	require.Equal(t, stalledBackoffBase, d, "recovery must be prompt, not penalised")
+	require.Equal(t, 1, stalls)
+
+	// So does a cycle deferred only for a missing worker: no lane was full, so
+	// there is no backpressure streak to continue. That one gets the short flat
+	// pause, because the window it waits out is short.
+	d, stalls = nextPause(unreadyCycle, stalls, readBlock)
+	require.Equal(t, deferredReadBackoff, d)
+	require.Zero(t, stalls, "an unready cycle is not a stall")
+
+	// Both at once is paced as a stall.
+	d, _ = nextPause(stalledCycle, 0, readBlock)
+	require.Equal(t, stalledBackoffBase, d, "a stalled cycle outranks a merely deferred one")
+	require.Greater(t, stallBackoff(3, readBlock), deferredReadBackoff,
+		"and escalation must be able to exceed the flat deferral pause, or it buys nothing")
+}
+
+// The cycle must carry the stall out to the pacer, and must carry the two
+// deferral causes out SEPARATELY. A cycle that reported a stall only as a
+// plain deferral would be paced with the short flat pause forever, so the
+// escalation would never happen and a wedged room would be re-read at
+// deferredReadBackoff's rate indefinitely.
+//
+// Driven by calling readOnce directly on a relay that was never Started, so
+// there is no reader goroutine and no worker goroutine to race the assertions.
+func TestUnit_StreamReader_ReadOnceReportsEachDeferralCauseSeparately(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport: Streams, Readers: 1, ReadBlock: readerTestBlock, RoomQueueSize: 1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	// Two rooms on the one reader: "wedged" has a worker whose lane is full,
+	// "unready" has no worker at all.
+	appendEntry := func(room, text string) {
+		require.NoError(t, r.client.XAdd(context.Background(), &goredis.XAddArgs{
+			Stream: r.scfg.syncKey(room),
+			Values: streamFields([]byte(nodeB), 1, cluster.KindSync, v1Update(t, text)),
+		}).Err())
+	}
+	r.streamMu.Lock()
+	r.streamRooms["unready"] = 1
+	r.streamMu.Unlock()
+	appendEntry("unready", "unready-edit")
+
+	res, err := r.readOnce(context.Background(), 0)
+	require.NoError(t, err)
+	require.True(t, res.got)
+	require.True(t, res.deferred, "a missing worker defers")
+	require.False(t, res.stalled, "but it is not lane backpressure")
+	require.Equal(t, uint64(1), r.StreamStats().Deferred)
+	require.Equal(t, uint64(0), r.StreamStats().Stalled)
+
+	// Now the wedged room, alongside it.
+	wedgeLane(t, r, "wedged", 1)
+	r.streamMu.Lock()
+	r.streamRooms["wedged"] = 1
+	r.streamMu.Unlock()
+	appendEntry("wedged", "wedged-edit")
+
+	res, err = r.readOnce(context.Background(), 0)
+	require.NoError(t, err)
+	require.True(t, res.stalled,
+		"a stalled stream must reach the pacer as a stall, or nothing ever escalates")
+	require.True(t, res.deferred, "a stall is also a deferral: the same entries come back")
+	require.Equal(t, uint64(1), r.StreamStats().Stalled)
+	require.Equal(t, uint64(2), r.StreamStats().Deferred,
+		"the unready room deferred again; the two causes are counted apart")
+
+	// And neither cursor moved, so both entries are still there to be read.
+	require.Equal(t, oldestID, r.cursorFor(r.scfg.syncKey("unready"), oldestID))
+	require.Equal(t, oldestID, r.cursorFor(r.scfg.syncKey("wedged"), oldestID))
 }

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -1045,6 +1045,62 @@ func TestUnit_StreamReader_GapDetectionResumesAfterARestart(t *testing.T) {
 	require.Equal(t, uint64(1), r.StreamStats().Gaps, "gap detection must work after a restart")
 }
 
+// Two Publish calls for the SAME room can overlap — Relay.Publish's contract
+// requires tolerating exactly that across a room's eviction/reload handoff,
+// and nextSeq deliberately releases streamMu before the XADD it numbered is
+// issued (holding it across a Redis call would recouple every room on the node
+// to one slow write). So a publisher's entries can be written to the stream in
+// the order [2, 1, 3]: the reader sees a DECREASE and then, from the new
+// baseline of 1, what looks like a jump to 3.
+//
+// That must not score a Gaps. Gaps is documented "ALERT ON PRESENCE… a single
+// gap means data was lost", so a counter that ticks on routine room churn is
+// worth less than no counter at all. The first comparison after a decrease
+// re-baselines instead of accusing.
+//
+// The Restarts increment for the decrease is expected and asserted here: the
+// suppression must be exactly one comparison deep, not a general amnesty.
+//
+// Confirmed by mutation: deleting noteSeq's `prev.afterDecrease` early return
+// (so every jump counts, as before this fix) leaves this test as the ONLY
+// failing test in the package — no existing gap/restart test covers a jump
+// adjacent to a decrease.
+func TestUnit_StreamReader_NoGapOnTheEntryAfterADecrease(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: nothing else may touch these counters.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := r.scfg.syncKey("room1")
+	src := []byte(nodeB)
+
+	// Entries land as [2, 1, 3] — two overlapping publishes, then the next.
+	r.noteSeq(key, src, 2) // baseline
+	r.noteSeq(key, src, 1) // the reordered partner: a decrease
+	require.Equal(t, uint64(1), r.StreamStats().Restarts,
+		"a decrease is still classified and counted; only the gap is suppressed")
+	r.noteSeq(key, src, 3) // 3 > 1+1: a jump only because of the reordering
+	require.Zero(t, r.StreamStats().Gaps,
+		"a jump in the first comparison after a decrease must re-baseline, not accuse")
+
+	// One comparison deep: the very next jump, no longer adjacent to a
+	// decrease, is reported normally. Without this the suppression would be a
+	// latch that disables gap detection for a source forever.
+	r.noteSeq(key, src, 40)
+	require.Equal(t, uint64(1), r.StreamStats().Gaps,
+		"the suppression must clear after one comparison")
+
+	// And the suppression is per series: a decrease on one source must not
+	// license a silent gap on another source reading the same stream.
+	other := []byte(nodeA)
+	r.noteSeq(key, other, 1)
+	r.noteSeq(key, src, 1) // decrease on src arms src's suppression only
+	r.noteSeq(key, other, 9)
+	require.Equal(t, uint64(2), r.StreamStats().Gaps,
+		"a decrease on one source must not suppress another source's gap")
+}
+
 // The first sequence number ever seen from a source establishes a baseline,
 // however large it is — it must never be compared against an implicit zero.
 // A relay that only just started tracking a stream (or a source whose first

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -201,6 +201,22 @@ func (s *recordingSink) payloadSeen(want string) bool {
 	return false
 }
 
+// payloadCount is how many INJECTED PAYLOADS carried want, which is what
+// tells a delivery from a re-delivery. Not the number of occurrences within a
+// payload: a catch-up merge folds several entries into one blob, and that
+// blob is still one delivery.
+func (s *recordingSink) payloadCount(want string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, got := range s.injected {
+		if bytes.Contains(got, []byte(want)) {
+			n++
+		}
+	}
+	return n
+}
+
 // readerTestNodeIDs are 16-byte node identities, matching nodeIDLen so these
 // look like the real thing rather than relying on a short id being accepted.
 const (
@@ -688,6 +704,23 @@ func TestIntegration_StreamReader_BacklogSurvivesAMissingWorker(t *testing.T) {
 // OPPOSITE retention (see cursorLimit), so a fix that dropped both would stop
 // the replay and reintroduce the whole-window sync replay it exists to
 // prevent.
+//
+// BOTH halves are asserted through DELIVERY, never by reading a cursor. An
+// earlier version read Relay.cursors at an instant just after
+// RoomDeactivated, and that assertion was flaky at ~25% for a reason worth
+// keeping written down: RoomDeactivated's contract (cluster/relay.go)
+// explicitly does not stop a read whose id vector predates it, so "the
+// awareness cursor is absent right now" was never an invariant the relay
+// offered — the state was reachable, just not at that instant. What an
+// operator actually needs IS invariant, and is what this asserts: after a
+// reactivation, no presence published before it is delivered.
+//
+// The closing assertion is an ordering argument rather than a timing one.
+// presence-while-gone sits EARLIER in the same awareness stream than
+// presence-after, so a residency resuming from a surviving cursor would read
+// it in the same XREAD as presence-after, or in an earlier one. Waiting for
+// presence-after therefore proves presence-while-gone had every chance to
+// arrive, without this test having to guess at a duration.
 func TestIntegration_StreamReader_AwarenessNotReplayedAcrossReactivation(t *testing.T) {
 	mr := newMiniRedis(t)
 
@@ -726,18 +759,14 @@ func TestIntegration_StreamReader_AwarenessNotReplayedAcrossReactivation(t *test
 	}, 5*time.Second, 20*time.Millisecond, "both kinds must flow before the room is deactivated")
 
 	a.RoomDeactivated("room1")
-	// Outwait any read that was already in flight: its id vector was built
-	// before the deactivation, so it can still write a cursor back once.
+	// Outwait the DEPARTING residency, not just the read. A read in flight at
+	// the deactivation can still push onto a lane whose worker has not yet
+	// performed its final drain, and presence delivered to the occupants who
+	// are leaving is legitimate — it is not the replay this test hunts. This
+	// wait is what makes everything published below unambiguously "published
+	// while the room was gone", so the closing assertion cannot mistake a
+	// teardown delivery for a resurrection.
 	time.Sleep(3 * readerTestBlock)
-
-	a.streamMu.Lock()
-	_, awKnown := a.cursors[a.scfg.awKey("room1")]
-	_, syncKnown := a.cursors[a.scfg.syncKey("room1")]
-	a.streamMu.Unlock()
-	require.False(t, awKnown,
-		"deactivation must forget the awareness cursor, or reactivation resumes mid-presence-stream")
-	require.True(t, syncKnown,
-		"deactivation must KEEP the sync cursor, or room churn replays the whole retention window")
 
 	// Published to a room nothing is reading: this presence belongs to
 	// clients that left with the room.
@@ -765,6 +794,69 @@ func TestIntegration_StreamReader_AwarenessNotReplayedAcrossReactivation(t *test
 
 	require.False(t, sink.payloadSeen("presence-while-gone"),
 		"presence published while the room was gone must not be replayed to its new occupants")
+
+	// The opposite half of the retention rule, asserted the same way. A sync
+	// cursor that did NOT survive the deactivation reads from the oldest
+	// retained entry, so the reactivated room would be handed edit-before a
+	// second time — inside the catch-up merge that also carries
+	// edit-while-gone, hence a second payload containing it rather than a
+	// second occurrence inside the first.
+	require.Equal(t, 1, sink.payloadCount("edit-before"),
+		"deactivation must KEEP the sync cursor, or room churn replays the whole retention window")
+}
+
+// The fence that makes the test above hold under the read it cannot stop.
+//
+// Deterministic where the integration test is opportunistic: it plays out the
+// exact interleaving — a read's id vector is built on one residency, the room
+// is deactivated and reactivated, and only THEN does the response apply. The
+// entries in that response are presence published before the reactivation, so
+// none of them may reach the successor residency, and neither may the cursor
+// they would have advanced.
+func TestUnit_StreamReader_AwarenessFromAPriorResidencyIsNotDelivered(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: registering workers by hand keeps this to the
+	// two lifecycle transitions under test, with no goroutine draining a lane
+	// whose depth is the assertion.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	register := func(room string) *roomWorker {
+		w := &roomWorker{room: room, lane: relaylane.New(r.laneCap), done: make(chan struct{})}
+		r.workersMu.Lock()
+		r.workers[room] = w
+		r.workersMu.Unlock()
+		return w
+	}
+
+	// The residency the read was issued for, mid-stream on its own cursor.
+	old := register("room1")
+	_, from := r.awarenessCursor("room1")
+	require.Equal(t, tailID, from, "a fresh residency starts at the tail")
+	tgt := streamTarget{
+		key: r.scfg.awKey("room1"), room: "room1", isAwareness: true, residency: old,
+	}
+	msgs := []goredis.XMessage{
+		streamEntry(t, "7-0", nodeB, 1, cluster.KindAwareness, []byte("presence-while-gone")),
+	}
+
+	// Deactivate, then reactivate: a NEW worker, which is what makes the
+	// reset structural. stopWorker is the real production path.
+	r.stopWorker("room1")
+	fresh := register("room1")
+	require.NotSame(t, old, fresh, "a reactivation must be a new residency")
+
+	require.Equal(t, streamConsumed, r.handleStream(tgt, msgs),
+		"the entries are dealt with, not deferred: the successor reads from the tail")
+	require.Equal(t, 0, fresh.lane.Depth(),
+		"presence published before the reactivation must not reach the new occupants")
+	residency, awFrom := r.awarenessCursor("room1")
+	require.Same(t, fresh, residency)
+	require.Equal(t, tailID, awFrom,
+		"and the stale read must not advance the successor's cursor, or the next read resumes mid-presence-stream")
+	require.Equal(t, uint64(0), r.Stats().RouterDrops,
+		"a fenced presence blob is a policy discard, not a router drop operators alert on")
 }
 
 // Inbound latency must not scale with a reader's batch COUNT.
@@ -1172,13 +1264,16 @@ func TestUnit_StreamReader_AwarenessIsExemptFromLaneBackpressure(t *testing.T) {
 
 	w := wedgeLane(t, r, "room1", 2)
 	awKey := r.scfg.awKey("room1")
-	tgt := streamTarget{key: awKey, room: "room1", isAwareness: true}
+	// residency is what readBatch would have captured: the worker the room was
+	// on when the id vector was built. See deliverAwareness.
+	tgt := streamTarget{key: awKey, room: "room1", isAwareness: true, residency: w}
 	msgs := []goredis.XMessage{
 		streamEntry(t, "7-0", nodeB, 1, cluster.KindAwareness, []byte("presence")),
 	}
 
 	require.Equal(t, streamConsumed, r.handleStream(tgt, msgs))
-	require.Equal(t, "7-0", r.cursorFor(awKey, tailID), "an awareness stream advances regardless")
+	_, from := r.awarenessCursor("room1")
+	require.Equal(t, "7-0", from, "an awareness stream advances regardless")
 	require.Equal(t, uint64(0), r.StreamStats().Stalled, "awareness must not register as a stall")
 	require.Equal(t, 3, w.lane.Depth(), "the awareness blob must be delivered to the lane")
 	require.Equal(t, uint64(0), r.Stats().Coalesced,

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -837,8 +837,14 @@ func TestUnit_StreamReader_AwarenessFromAPriorResidencyIsNotDelivered(t *testing
 	tgt := streamTarget{
 		key: r.scfg.awKey("room1"), room: "room1", isAwareness: true, residency: old,
 	}
+	// A batch rather than a single entry: deliverAwareness pushes only the
+	// last payload of a read, so a fence applied to that one payload and a
+	// fence applied to the read are the same code — but a single-entry batch
+	// could not tell the two apart if that ever stopped being true.
 	msgs := []goredis.XMessage{
 		streamEntry(t, "7-0", nodeB, 1, cluster.KindAwareness, []byte("presence-while-gone")),
+		streamEntry(t, "8-0", nodeB, 2, cluster.KindAwareness, []byte("presence-while-gone-2")),
+		streamEntry(t, "9-0", nodeB, 3, cluster.KindAwareness, []byte("presence-while-gone-3")),
 	}
 
 	// Deactivate, then reactivate: a NEW worker, which is what makes the
@@ -1285,6 +1291,50 @@ func TestUnit_StreamReader_AwarenessIsExemptFromLaneBackpressure(t *testing.T) {
 	require.Equal(t, 3, w.lane.Depth(), "the awareness blob must be delivered to the lane")
 	require.Equal(t, uint64(0), r.Stats().Coalesced,
 		"and the awareness slot is separate, so nothing merged")
+}
+
+// One read of a busy presence stream returns several blobs; the lane holds
+// ONE. Pushing all of them would supersede the reader's own work N-1 times —
+// N-1 lane-mutex acquisitions and Signal sends discarded on the spot, and N-1
+// AwarenessSuperseded increments reporting a backlog this room's worker never
+// had. Only the last payload of a read is pushed. See deliverAwareness.
+func TestUnit_StreamReader_AwarenessBatchPushesOnlyTheLatest(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: with no worker goroutine, the lane's depth and
+	// contents are assertions rather than a race with a concurrent drain.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	w := &roomWorker{room: "room1", lane: relaylane.New(r.laneCap), done: make(chan struct{})}
+	r.workersMu.Lock()
+	r.workers["room1"] = w
+	r.workersMu.Unlock()
+
+	tgt := streamTarget{
+		key: r.scfg.awKey("room1"), room: "room1", isAwareness: true, residency: w,
+	}
+	msgs := []goredis.XMessage{
+		streamEntry(t, "7-0", nodeB, 1, cluster.KindAwareness, []byte("presence-1")),
+		streamEntry(t, "8-0", nodeB, 2, cluster.KindAwareness, []byte("presence-2")),
+		streamEntry(t, "9-0", nodeB, 3, cluster.KindAwareness, []byte("presence-3")),
+	}
+
+	require.Equal(t, streamConsumed, r.handleStream(tgt, msgs))
+
+	require.Equal(t, uint64(0), r.Stats().AwarenessSuperseded,
+		"a three-entry read must cost ONE push, not three: the other two would be "+
+			"superseded before anything could read them, and each would leave an "+
+			"AwarenessSuperseded increment claiming this room's worker fell behind")
+	require.Equal(t, 1, w.lane.Depth(), "so the lane holds exactly one blob")
+	got, ok := w.lane.TakeAwareness()
+	require.True(t, ok)
+	require.Equal(t, []byte("presence-3"), got,
+		"and it is the LAST payload of the read, the only one still current")
+
+	_, from := r.awarenessCursor("room1")
+	require.Equal(t, "9-0", from,
+		"the cursor still advances past the WHOLE read, or the superseded entries are re-read forever")
 }
 
 // Backoff must grow so a wedged room is not re-read as fast as Redis can

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -1,11 +1,18 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/awareness"
+	"github.com/reearth/ygo/cluster"
+	"github.com/reearth/ygo/crdt"
 )
 
 // Assignment must be stable: a room that moved readers between cycles would
@@ -117,4 +124,453 @@ func TestUnit_StreamReader_ActivationRefcounts(t *testing.T) {
 
 	r.RoomDeactivated("room1")
 	require.NotContains(t, r.roomsForReader(idx), "room1")
+}
+
+// --- Reader loop -----------------------------------------------------------
+//
+// Test-double naming: this file uses recordingSink rather than the fakeSink
+// the brief named. redis_test.go (package redis_test) already has a DIFFERENT
+// fakeSink, and internal_test.go (package redis) has countingSink; a third
+// type sharing the name fakeSink in the same directory compiles but is a
+// readability trap. countingSink could not simply be extended either — it
+// records only a count, and half of these tests need to assert on the actual
+// payload bytes, and widening a helper five existing tests depend on is a
+// larger change than adding a purpose-built one.
+
+// recordingSink records what a relay injects, so a test can assert on the
+// payload rather than only on a count.
+//
+// It has no room registry, unlike the brief's version: workerForInbound
+// routes on r.workers (populated by RoomActivated), and cluster/redis never
+// calls Sink.Rooms() at all — verified by grep. A rooms map here would have
+// implied that Sink residency gates inbound delivery, which is false, and the
+// next reader of this file would have believed it.
+type recordingSink struct {
+	mu       sync.Mutex
+	injected [][]byte
+}
+
+func (s *recordingSink) Inject(_ context.Context, in cluster.Inbound) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.injected = append(s.injected, append([]byte(nil), in.Data...))
+	return nil
+}
+
+func (s *recordingSink) Rooms() []string                                  { return nil }
+func (s *recordingSink) GetAwareness(string) (*awareness.Awareness, bool) { return nil, false }
+func (s *recordingSink) GetDoc(string) *crdt.Doc                          { return nil }
+
+func (s *recordingSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.injected)
+}
+
+func (s *recordingSink) payloadSeen(want string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, got := range s.injected {
+		if bytes.Contains(got, []byte(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+// readerTestNodeIDs are 16-byte node identities, matching nodeIDLen so these
+// look like the real thing rather than relying on a short id being accepted.
+const (
+	nodeA = "aaaaaaaaaaaaaaaa"
+	nodeB = "bbbbbbbbbbbbbbbb"
+)
+
+// readerConfig is the shared Streams config for the reader tests.
+//
+// Readers: 1 makes every room land on reader 0, so a test never has to guess
+// which goroutine owns its room. ReadBlock is shortened from the 5s default
+// because it also bounds how long an idle reader waits for Redis; leaving it
+// at 5s would put the tests' own assertions inside a single XREAD's blocking
+// window and make them race the default rather than the code.
+func readerConfig(node string) Config {
+	return Config{
+		Transport: Streams,
+		NodeID:    []byte(node),
+		Readers:   1,
+		ReadBlock: 200 * time.Millisecond,
+	}
+}
+
+// v1Update produces a real V1 update blob containing text verbatim, so the
+// catch-up path exercises crdt.MergeUpdatesV1 for real instead of falling
+// into the merge-failure fallback that a non-update payload would take.
+func v1Update(t *testing.T, text string) []byte {
+	t.Helper()
+	d := crdt.New()
+	txt := d.GetText("t") // outside Transact: GetText inside deadlocks
+	var out []byte
+	un := d.OnUpdate(func(u []byte, _ any) { out = append([]byte(nil), u...) })
+	defer un()
+	d.Transact(func(tr *crdt.Transaction) { txt.Insert(tr, 0, text, nil) })
+	require.NotEmpty(t, out)
+	require.Contains(t, string(out), text, "the test asserts on this text appearing in the blob")
+	return out
+}
+
+// THE HEADLINE TEST. A reader stops, another node publishes, the reader comes
+// back — and the update is still delivered. The pub/sub tier structurally
+// cannot pass this, which is the entire reason this tier exists.
+//
+// Verified non-vacuous: with the reader loop absent (Start not launching
+// runStreamReader) this fails at the FIRST require.Eventually, because
+// nothing is ever injected. See task-6-report.md for the recorded output.
+func TestIntegration_StreamReader_ResumesAfterStopAndDeliversMissedUpdates(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	// Node A reads. Node B publishes; a distinct NodeID is what stops A's
+	// self-delivery filter from discarding B's entries.
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+	a.RoomActivated("room1")
+
+	// A is up: it sees the first update.
+	first, whileDown := v1Update(t, "first-edit"), v1Update(t, "while-down-edit")
+	require.NoError(t, b.Publish(ctx, cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: first,
+	}))
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 10*time.Millisecond, "reader should deliver while running")
+
+	// A goes away. Everything B publishes now would be LOST under pub/sub.
+	require.NoError(t, a.Close())
+	require.NoError(t, b.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: whileDown,
+	}))
+
+	// A comes back with a fresh relay against the same Redis.
+	sink2 := &recordingSink{}
+	a2, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a2.Close() })
+	require.NoError(t, a2.Start(ctx, sink2))
+	a2.RoomActivated("room1")
+
+	require.Eventually(t, func() bool { return sink2.payloadSeen("while-down-edit") },
+		5*time.Second, 10*time.Millisecond,
+		"the update published while the reader was down must still arrive: this is the guarantee")
+}
+
+// Replaying already-applied entries is harmless (V1 updates are idempotent),
+// which is what lets the reader start at the oldest retained entry and so
+// removes the snapshot-load race entirely. But the catch-up batch must arrive
+// as ONE merged update, or replay re-broadcasts every entry to local peers.
+//
+// Note which assertion carries the weight. sink.count()==1 is only WEAKLY
+// coupled to reader-side merging: relaylane.Lane.TakeSync merges its own
+// pending backlog too, so five separate pushes still usually surface as one
+// Inject, purely depending on whether the room worker drained between them.
+// The Replayed assertion is the precise one — it can only be 4 if the reader
+// merged the batch itself. Verified by mutation: pushing the five payloads
+// individually leaves count()==1 and fails on Replayed.
+func TestIntegration_StreamReader_CatchUpMergedIntoSingleInject(t *testing.T) {
+	mr := newMiniRedis(t)
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Start(context.Background(), &countingSink{}))
+
+	// Five real V1 updates exist before any reader starts.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, b.Publish(context.Background(), cluster.Outbound{
+			Room: "room1", Kind: cluster.KindSync, Data: v1Update(t, fmt.Sprintf("edit-c%d", i)),
+		}))
+	}
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	a.RoomActivated("room1")
+
+	require.Eventually(t, func() bool { return sink.count() >= 1 },
+		5*time.Second, 10*time.Millisecond)
+	time.Sleep(500 * time.Millisecond) // let any extra injects land
+
+	require.Equal(t, 1, sink.count(),
+		"a five-entry catch-up must reach the sink as one merged update, not five")
+	require.Equal(t, uint64(4), a.StreamStats().Replayed,
+		"Replayed must record the merge saving (5 entries -> 1 inject)")
+	// All five edits must survive the merge: one inject is only correct if it
+	// carries every entry.
+	for i := 0; i < 5; i++ {
+		require.True(t, sink.payloadSeen(fmt.Sprintf("edit-c%d", i)),
+			"merging must not lose an entry")
+	}
+}
+
+// Awareness is read from the tail and never replayed: replaying it would
+// resurrect presence for clients that are long gone.
+//
+// The brief's version of this test asserted ONLY that the stale awareness
+// payload is absent, after a fixed sleep. That would have passed even if the
+// reader never ran at all, or never read awareness streams at all — which is
+// the same vacuous-test class already caught in tasks 3 and 4. Two positive
+// witnesses are added: a sync entry published before start MUST be replayed
+// (proving the reader reached this room), and an awareness entry published
+// after start MUST arrive (proving awareness delivery works at all, so the
+// absence below is about the replay policy and not about a dead code path).
+func TestIntegration_StreamReader_AwarenessIsNotReplayed(t *testing.T) {
+	mr := newMiniRedis(t)
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Start(context.Background(), &countingSink{}))
+
+	require.NoError(t, b.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("stale-presence"),
+	}))
+	require.NoError(t, b.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: v1Update(t, "pre-start-edit"),
+	}))
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	a.RoomActivated("room1")
+
+	// Witness 1: the sync stream IS replayed, so the reader did reach room1.
+	require.Eventually(t, func() bool { return sink.payloadSeen("pre-start-edit") },
+		5*time.Second, 10*time.Millisecond, "sync published before start must be replayed")
+
+	// Witness 2: awareness published while the reader is up DOES arrive, so
+	// the awareness half of the read is live rather than silently broken.
+	require.NoError(t, b.Publish(ctx, cluster.Outbound{
+		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("live-presence"),
+	}))
+	require.Eventually(t, func() bool { return sink.payloadSeen("live-presence") },
+		5*time.Second, 10*time.Millisecond, "awareness published after start must arrive")
+
+	require.False(t, sink.payloadSeen("stale-presence"),
+		"awareness published before the reader started must NOT be replayed")
+}
+
+// A node must not re-inject its own writes.
+//
+// Strengthened over the brief, which asserted only the absence of the node's
+// own payload after a fixed sleep — vacuous if the reader had not yet read
+// anything. Node B's payload is the witness: it proves the reader consumed
+// the same stream past A's own entry.
+func TestIntegration_StreamReader_SelfFilter(t *testing.T) {
+	mr := newMiniRedis(t)
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+	a.RoomActivated("room1")
+
+	require.NoError(t, a.Publish(ctx, cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("mine"),
+	}))
+	require.NoError(t, b.Publish(ctx, cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("theirs"),
+	}))
+
+	require.Eventually(t, func() bool { return sink.payloadSeen("theirs") },
+		5*time.Second, 10*time.Millisecond, "another node's entry must be delivered")
+	require.False(t, sink.payloadSeen("mine"), "a node must not re-inject its own entry")
+}
+
+// Transport's zero value is PubSub, and a PubSub relay must not grow a reader.
+//
+// The second half of this test is what actually pins the usesStreams gate in
+// Start. The first half — activate a room on a PubSub relay and see nothing
+// arrive — passes even with that gate removed, because RoomActivated has its
+// own usesStreams gate on streamRooms (task 5), so a launched reader would
+// simply idle with no assignment. Verified by mutation: replacing the Start
+// gate with `if true` left the first half green. So the second half forces
+// streamRooms to hold the room, which is the only other thing standing
+// between a reader and this stream; then the gate in Start is the sole
+// remaining defence, and removing it makes this test fail.
+func TestIntegration_StreamReader_PubSubModeReadsNoStreams(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	// A Streams-only publisher: it XADDs and never PUBLISHes.
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Start(context.Background(), &countingSink{}))
+	require.NoError(t, b.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("streams-only"),
+	}))
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), Config{NodeID: []byte(nodeA)}) // zero Transport == PubSub
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	a.RoomActivated("room1")
+
+	time.Sleep(700 * time.Millisecond)
+	require.False(t, sink.payloadSeen("streams-only"),
+		"a PubSub-mode relay must not read stream keys")
+
+	// Now remove the OTHER defence: hand the room to the reader assignment
+	// map directly, as Streams mode's RoomActivated would have. RoomActivated
+	// above already created room1's delivery worker, so a reader that existed
+	// would find a live lane and deliver. Nothing may still arrive.
+	a.streamMu.Lock()
+	a.streamRooms["room1"] = 1
+	a.streamMu.Unlock()
+
+	time.Sleep(700 * time.Millisecond)
+	require.False(t, sink.payloadSeen("streams-only"),
+		"Start must launch no reader at all in PubSub mode, even for an assigned room")
+	require.Equal(t, StreamStats{}, a.StreamStats(),
+		"a PubSub-mode relay's stream counters must all stay zero")
+}
+
+func TestUnit_StreamReader_CursorDefaultsAndRoundTrip(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.Equal(t, oldestID, r.cursorFor("never-read", oldestID),
+		"an unknown sync key must fall back to the oldest retained entry")
+	require.Equal(t, tailID, r.cursorFor("never-read", tailID),
+		"an unknown awareness key must fall back to the tail")
+
+	r.setCursor("k", "5-1")
+	require.Equal(t, "5-1", r.cursorFor("k", oldestID))
+}
+
+// Cursor eviction must not evict a room this relay is still reading.
+//
+// This deviates from the brief, which evicted an ARBITRARY map entry on
+// overflow. Doing that on a node with more than cursorLimit/2 active rooms
+// drops a live room's cursor roughly half the time, and losing a live
+// cursor replays that room's whole retention window — which is precisely
+// the condition StreamStats.Replayed tells operators to alert on. Evicting
+// only cursors whose room is no longer in streamRooms bounds the map by real
+// load instead.
+func TestUnit_StreamReader_CursorEvictionKeepsActiveRooms(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Deliberately NOT Started: no reader goroutine, so nothing races the
+	// cursor map while this test pokes it.
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	r.streamMu.Lock()
+	r.streamRooms["live"] = 1
+	r.streamMu.Unlock()
+
+	liveKey := r.scfg.syncKey("live")
+	r.setCursor(liveKey, "7-0")
+	for i := 0; i < cursorLimit; i++ {
+		r.setCursor(fmt.Sprintf("ygo:gone:%d", i), "1-0")
+	}
+	r.setCursor("ygo:gone:trigger", "2-0")
+
+	require.Equal(t, "7-0", r.cursorFor(liveKey, oldestID),
+		"an active room's cursor must survive eviction, or the room replays its whole window")
+
+	r.streamMu.Lock()
+	held := len(r.cursors)
+	r.streamMu.Unlock()
+	require.Less(t, held, cursorLimit, "eviction must actually bound the map")
+}
+
+// Close must not wait out ReadBlock. Both tests below deliberately use the
+// DEFAULT 5s ReadBlock, because that is the configuration the defect appeared
+// in and the one every operator gets.
+//
+// There is no way to interrupt a blocked XREAD — go-redis arms the socket read
+// deadline from ctx.Deadline() only, so cancelling the context mid-read has no
+// effect — and Close joins r.wg. Before readerBlockCap this Close took a
+// measured 4.80s, which is a five-second stall on every Server.Shutdown.
+func TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	require.Equal(t, defaultReadBlock, r.scfg.readBlock, "this test is about the DEFAULT ReadBlock")
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+	r.RoomActivated("room1")
+
+	time.Sleep(400 * time.Millisecond) // let the reader get well into an XREAD
+
+	start := time.Now()
+	require.NoError(t, r.Close())
+	require.Less(t, time.Since(start), 2*time.Second,
+		"Close must not block for ReadBlock (%s); a reader cannot be interrupted mid-XREAD, so the block itself has to be capped", defaultReadBlock)
+}
+
+// Config.ReadBlock's doc promises "a newly activated room gets a fresh short
+// read folded in immediately". A reader already parked in an XREAD for
+// room1 cannot see room2 until that read returns, so the read interval IS the
+// activation latency. At the default 5s ReadBlock and without readerBlockCap
+// this fails: the room2 update arrives about five seconds late.
+func TestIntegration_StreamReader_ActivationDoesNotWaitOutReadBlock(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	bcfg := readerConfig(nodeB)
+	b, err := New(newClient(t, mr), bcfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	require.NoError(t, b.Start(context.Background(), &countingSink{}))
+
+	sink := &recordingSink{}
+	// Default ReadBlock (5s) on purpose — see the doc comment.
+	a, err := New(newClient(t, mr), Config{Transport: Streams, NodeID: []byte(nodeA), Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	require.Equal(t, defaultReadBlock, a.scfg.readBlock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	a.RoomActivated("room1")
+
+	// Give the reader time to be sitting inside an XREAD whose key set is
+	// room1 only.
+	time.Sleep(500 * time.Millisecond)
+
+	require.NoError(t, b.Publish(ctx, cluster.Outbound{
+		Room: "room2", Kind: cluster.KindSync, Data: []byte("room2-edit"),
+	}))
+	a.RoomActivated("room2")
+
+	require.Eventually(t, func() bool { return sink.payloadSeen("room2-edit") },
+		3*time.Second, 10*time.Millisecond,
+		"a room activated mid-read must not wait out ReadBlock (%s)", defaultReadBlock)
 }

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -1,0 +1,120 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Assignment must be stable: a room that moved readers between cycles would
+// have two readers holding cursors for it.
+func TestUnit_StreamReader_AssignmentIsStable(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 4})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	first := r.readerFor("room-alpha")
+	for i := 0; i < 100; i++ {
+		require.Equal(t, first, r.readerFor("room-alpha"))
+	}
+	require.GreaterOrEqual(t, first, 0)
+	require.Less(t, first, 4)
+}
+
+// With many rooms every reader should get work; a hash that piles everything
+// onto one reader would defeat the sharding.
+func TestUnit_StreamReader_AssignmentSpreadsAcrossReaders(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 4})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	used := map[int]int{}
+	for i := 0; i < 400; i++ {
+		used[r.readerFor(fmt.Sprintf("room-%d", i))]++
+	}
+	require.Len(t, used, 4, "every reader should own some rooms")
+	for idx, n := range used {
+		require.Greater(t, n, 20, "reader %d got only %d of 400 rooms", idx, n)
+	}
+}
+
+// XREAD command size must be bounded independently of Readers: 10k rooms over
+// 4 readers would otherwise build a ~5000-argument command.
+func TestUnit_StreamReader_KeyBatching(t *testing.T) {
+	keys := make([]string, 0, 1300)
+	for i := 0; i < 1300; i++ {
+		keys = append(keys, fmt.Sprintf("k%d", i))
+	}
+
+	batches := keyBatches(keys, maxKeysPerRead)
+	require.Len(t, batches, 3)
+	require.Len(t, batches[0], 512)
+	require.Len(t, batches[1], 512)
+	require.Len(t, batches[2], 276)
+
+	seen := 0
+	for _, b := range batches {
+		seen += len(b)
+	}
+	require.Equal(t, len(keys), seen, "batching must not drop keys")
+}
+
+func TestUnit_StreamReader_KeyBatchingEmpty(t *testing.T) {
+	require.Empty(t, keyBatches(nil, maxKeysPerRead))
+}
+
+// The Relay contract requires tolerating a successor RoomActivated before the
+// predecessor's RoomDeactivated, in either order. Refcounting rides that out;
+// treating deactivation as an unconditional removal would drop a live room.
+//
+// r.Start is required here even though the brief's version of this test
+// omitted it: RoomActivated/RoomDeactivated both return immediately when
+// !r.started.Load(), before ever reaching the pub/sub work this task's
+// stream block is appended after — so without Start, streamRooms would
+// never be touched and this test would fail regardless of whether the new
+// refcounting code is correct (the same class of gap already caught and
+// documented in streams_test.go's Both/PubSub Publish tests).
+//
+// The brief's version of this test asserted only presence/absence via
+// roomsForReader, which does not actually distinguish a true integer refcount
+// from a naive boolean flag that merely mirrors whether activeRooms[room] is
+// zero: since every RoomActivated/RoomDeactivated call drives BOTH activeRooms
+// and streamRooms off the exact same events, a flag that flips on the 0->1
+// and >0->0 crossings would show identically "present" after the successor
+// activation and "absent" after the final deactivation, with no assertion
+// ever distinguishing it from streamRooms holding the real count (2, then 1).
+// Added a direct read of r.streamRooms (this is package redis, so the
+// unexported field is reachable) to require the count itself is 2 after both
+// activations, and 1 after the predecessor's deactivation — the "reference
+// count" the interface's own doc comment calls for, not just a derived flag.
+func TestUnit_StreamReader_ActivationRefcounts(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1") // predecessor
+	r.RoomActivated("room1") // successor, before the predecessor tears down
+
+	r.streamMu.Lock()
+	require.Equal(t, 2, r.streamRooms["room1"], "two activations must produce a count of 2, not a boolean flag")
+	r.streamMu.Unlock()
+
+	r.RoomDeactivated("room1")
+
+	r.streamMu.Lock()
+	require.Equal(t, 1, r.streamRooms["room1"], "one of two activations released must leave a count of 1")
+	r.streamMu.Unlock()
+
+	idx := r.readerFor("room1")
+	require.Contains(t, r.roomsForReader(idx), "room1",
+		"a successor activation must keep the room assigned")
+
+	r.RoomDeactivated("room1")
+	require.NotContains(t, r.roomsForReader(idx), "room1")
+}

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -873,6 +873,80 @@ func TestUnit_StreamReader_NoteSeqIsPerNodePerStream(t *testing.T) {
 	require.Equal(t, uint64(1), r.StreamStats().Restarts)
 }
 
+// A source that restarts its in-memory counter must not just avoid being
+// misreported as data loss — detection must keep working against the NEW
+// baseline afterwards. This is the half of restart-handling that a
+// restarts-vs-gaps classification alone does not prove: a baseline that
+// never resets down would either report every post-restart entry as a fresh
+// gap, or (if the fix instead treated already-seen-looking lower numbers as
+// duplicates) silently stop advancing for that source at all — a stall, not
+// merely a miscount.
+//
+// Verified by mutation: changing noteSeq to only ever raise its baseline
+// (`if seq > prev { r.lastSeq[src] = seq }`, imitating a fix that tracks the
+// high-water mark instead of the last-seen value) leaves this test as the
+// only one in the package that fails; every other gap/restart test still
+// passes because none of them re-probes classification after a decrease.
+func TestUnit_StreamReader_GapDetectionResumesAfterARestart(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := r.scfg.syncKey("room1")
+	src := []byte(nodeB)
+
+	for _, seq := range []uint64{1, 2, 3} {
+		r.noteSeq(key, src, seq)
+	}
+
+	r.noteSeq(key, src, 1) // the same node, restarted
+	require.Equal(t, uint64(1), r.StreamStats().Restarts)
+	require.Zero(t, r.StreamStats().Gaps, "a restart must not itself be reported as data loss")
+
+	// The baseline must now be the restarted value, not the pre-restart one:
+	// a contiguous follow-on must stay silent...
+	r.noteSeq(key, src, 2)
+	require.Zero(t, r.StreamStats().Gaps)
+	require.Equal(t, uint64(1), r.StreamStats().Restarts, "no second restart on ordinary advancement")
+
+	// ...and a real jump measured from that new baseline must still be
+	// caught, proving detection did not stall or silently latch onto the
+	// pre-restart series.
+	r.noteSeq(key, src, 7)
+	require.Equal(t, uint64(1), r.StreamStats().Gaps, "gap detection must work after a restart")
+}
+
+// The first sequence number ever seen from a source establishes a baseline,
+// however large it is — it must never be compared against an implicit zero.
+// A relay that only just started tracking a stream (or a source whose first
+// live entry lands well past 1, e.g. after a retention window skipped ahead
+// of a fresh reader) must not have that first observation mistaken for a
+// jump.
+//
+// Deliberately uses a large first value (12345, not 1): every other test in
+// this file happens to start its series at 1, which cannot distinguish
+// "unknown source treated as a fresh baseline" from "unknown source treated
+// as if its previous seq were 0" — both behave identically when the first
+// real seq is 1. Confirmed by mutation: dropping noteSeq's `!known` case (so
+// an untracked source silently compares against a zero-value prev) passes
+// every other gap/restart test in the package but fails only this one.
+func TestUnit_StreamReader_FirstSeqEstablishesBaselineRegardlessOfValue(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := r.scfg.syncKey("room1")
+	r.noteSeq(key, []byte(nodeB), 12345)
+	require.Zero(t, r.StreamStats().Gaps, "a source's first observed seq is a baseline, never a gap")
+	require.Zero(t, r.StreamStats().Restarts)
+
+	// And normal tracking proceeds from that baseline.
+	r.noteSeq(key, []byte(nodeB), 12346)
+	require.Zero(t, r.StreamStats().Gaps)
+}
+
 // A healthy node publishing to SEVERAL rooms must leave a reader's Gaps and
 // Restarts at zero. This is the assertion that protects the contract:
 // StreamStats.Gaps is documented "ALERT ON PRESENCE, not on rate — a single

--- a/cluster/redis/streams_reader_test.go
+++ b/cluster/redis/streams_reader_test.go
@@ -188,18 +188,21 @@ const (
 // readerConfig is the shared Streams config for the reader tests.
 //
 // Readers: 1 makes every room land on reader 0, so a test never has to guess
-// which goroutine owns its room. ReadBlock is shortened from the 5s default
-// because it also bounds how long an idle reader waits for Redis; leaving it
-// at 5s would put the tests' own assertions inside a single XREAD's blocking
-// window and make them race the default rather than the code.
+// which goroutine owns its room. ReadBlock is set explicitly, just below the
+// 250ms default and ceiling, so these tests state the interval their own
+// sleeps are sized against rather than inheriting it.
 func readerConfig(node string) Config {
 	return Config{
 		Transport: Streams,
 		NodeID:    []byte(node),
 		Readers:   1,
-		ReadBlock: 200 * time.Millisecond,
+		ReadBlock: readerTestBlock,
 	}
 }
+
+// readerTestBlock is readerConfig's ReadBlock, named so a test that has to
+// outwait a read cycle says so instead of hard-coding a number.
+const readerTestBlock = 200 * time.Millisecond
 
 // v1Update produces a real V1 update blob containing text verbatim, so the
 // catch-up path exercises crdt.MergeUpdatesV1 for real instead of falling
@@ -511,14 +514,16 @@ func TestUnit_StreamReader_CursorEvictionKeepsActiveRooms(t *testing.T) {
 	require.Less(t, held, cursorLimit, "eviction must actually bound the map")
 }
 
-// Close must not wait out ReadBlock. Both tests below deliberately use the
-// DEFAULT 5s ReadBlock, because that is the configuration the defect appeared
-// in and the one every operator gets.
+// Both tests below run at the DEFAULT ReadBlock, because that is what every
+// operator gets and, since it is also the ceiling, the worst case any
+// operator can configure.
 //
-// There is no way to interrupt a blocked XREAD — go-redis arms the socket read
-// deadline from ctx.Deadline() only, so cancelling the context mid-read has no
-// effect — and Close joins r.wg. Before readerBlockCap this Close took a
-// measured 4.80s, which is a five-second stall on every Server.Shutdown.
+// A blocked XREAD cannot be interrupted — go-redis arms the socket read
+// deadline from ctx.Deadline() only, so cancelling the context mid-read has
+// no effect — and Close joins r.wg, so the block interval IS how long Close
+// takes. At the 5s ReadBlock this package used to default to, Close was
+// measured at 4.80s: a five-second stall on every Server.Shutdown. See
+// maxReadBlock, which now rejects any value that could bring that back.
 func TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1})
@@ -531,15 +536,15 @@ func TestUnit_StreamReader_CloseDoesNotWaitOutReadBlock(t *testing.T) {
 
 	start := time.Now()
 	require.NoError(t, r.Close())
-	require.Less(t, time.Since(start), 2*time.Second,
-		"Close must not block for ReadBlock (%s); a reader cannot be interrupted mid-XREAD, so the block itself has to be capped", defaultReadBlock)
+	require.Less(t, time.Since(start), time.Second,
+		"Close must not stall on a reader: a reader cannot be interrupted mid-XREAD, so the block itself has to be short (ReadBlock %s)", defaultReadBlock)
 }
 
-// Config.ReadBlock's doc promises "a newly activated room gets a fresh short
-// read folded in immediately". A reader already parked in an XREAD for
-// room1 cannot see room2 until that read returns, so the read interval IS the
-// activation latency. At the default 5s ReadBlock and without readerBlockCap
-// this fails: the room2 update arrives about five seconds late.
+// A reader already parked in an XREAD for room1 cannot see room2 until that
+// read returns, so the read interval IS the activation latency — a room
+// joining and then seeing no remote edits for that long. At the 5s ReadBlock
+// this package used to default to, the room2 update arrived about five
+// seconds late; maxReadBlock is what bounds it.
 func TestIntegration_StreamReader_ActivationDoesNotWaitOutReadBlock(t *testing.T) {
 	mr := newMiniRedis(t)
 
@@ -550,7 +555,7 @@ func TestIntegration_StreamReader_ActivationDoesNotWaitOutReadBlock(t *testing.T
 	require.NoError(t, b.Start(context.Background(), &countingSink{}))
 
 	sink := &recordingSink{}
-	// Default ReadBlock (5s) on purpose — see the doc comment.
+	// Default ReadBlock on purpose — see the doc comment.
 	a, err := New(newClient(t, mr), Config{Transport: Streams, NodeID: []byte(nodeA), Readers: 1})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = a.Close() })
@@ -573,6 +578,246 @@ func TestIntegration_StreamReader_ActivationDoesNotWaitOutReadBlock(t *testing.T
 	require.Eventually(t, func() bool { return sink.payloadSeen("room2-edit") },
 		3*time.Second, 10*time.Millisecond,
 		"a room activated mid-read must not wait out ReadBlock (%s)", defaultReadBlock)
+}
+
+// A room this reader owns but has no worker for must not lose its backlog.
+//
+// RoomActivated adds the room to streamRooms BEFORE it creates the room's
+// worker, so a reader can own a room with no lane to deliver to. A reader
+// that treated that as a drop and advanced the cursor anyway would consume
+// the room's ENTIRE retained backlog — a room reached in that window is read
+// from the oldest retained entry — and discard it before the worker that was
+// about to exist could receive any of it.
+//
+// The witness room is what makes this airtight: Readers is 1, so both rooms'
+// keys are in the SAME XREAD, and the witness edit arriving proves the
+// orphan's entries were in that very response.
+func TestIntegration_StreamReader_BacklogSurvivesAMissingWorker(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+
+	// "witness" is activated properly, so it has a worker. "orphan" is only
+	// added to the reader's assignment map — exactly the state RoomActivated
+	// passes through on its way to creating the worker, held open here.
+	a.RoomActivated("witness")
+	a.streamMu.Lock()
+	a.streamRooms["orphan"] = 1
+	a.streamMu.Unlock()
+
+	publish := func(room, text string) {
+		require.NoError(t, b.Publish(ctx, cluster.Outbound{
+			Room: room, Kind: cluster.KindSync, Data: v1Update(t, text),
+		}))
+	}
+	orphanEdits := []string{"orphan-edit-0", "orphan-edit-1", "orphan-edit-2"}
+	for _, text := range orphanEdits {
+		publish("orphan", text)
+	}
+	publish("witness", "witness-edit")
+
+	require.Eventually(t, func() bool { return sink.payloadSeen("witness-edit") },
+		5*time.Second, 10*time.Millisecond,
+		"the witness proves the reader completed a cycle covering both rooms")
+
+	for _, text := range orphanEdits {
+		require.False(t, sink.payloadSeen(text), "a room with no worker has nowhere to deliver")
+	}
+	require.Equal(t, oldestID, a.cursorFor(a.scfg.syncKey("orphan"), oldestID),
+		"the cursor must NOT advance past entries nobody could receive")
+	require.Equal(t, uint64(0), a.Stats().RouterDrops,
+		"nothing was discarded, only deferred; RouterDrops counts discards and operators watch its rate")
+
+	// The worker exists now. The backlog must still be there to read.
+	a.RoomActivated("orphan")
+	require.Eventually(t, func() bool {
+		for _, text := range orphanEdits {
+			if !sink.payloadSeen(text) {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond,
+		"every entry read while the room had no worker must still be delivered once it has one")
+}
+
+// Awareness must not be replayed across a room's deactivate/reactivate.
+//
+// TestIntegration_StreamReader_AwarenessIsNotReplayed covers only a FRESH
+// relay, where no cursor exists and the tail default applies on its own. The
+// case that actually happens in production is a room evicted and reloaded
+// inside one process — the websocket provider has done that continuously
+// since idle-room residency landed (#183) — where a retained awareness cursor
+// resumes mid-stream and replays presence for the room's previous occupants.
+//
+// The sync half is asserted in the same test on purpose: the two kinds need
+// OPPOSITE retention (see cursorLimit), so a fix that dropped both would stop
+// the replay and reintroduce the whole-window sync replay it exists to
+// prevent.
+func TestIntegration_StreamReader_AwarenessNotReplayedAcrossReactivation(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+	a.RoomActivated("room1")
+
+	pubSync := func(text string) {
+		require.NoError(t, b.Publish(ctx, cluster.Outbound{
+			Room: "room1", Kind: cluster.KindSync, Data: v1Update(t, text),
+		}))
+	}
+	pubPresence := func(text string) error {
+		return b.Publish(ctx, cluster.Outbound{
+			Room: "room1", Kind: cluster.KindAwareness, Data: []byte(text),
+		})
+	}
+
+	// Establish BOTH cursors by getting both kinds delivered.
+	pubSync("edit-before")
+	require.Eventually(t, func() bool {
+		if err := pubPresence("presence-before"); err != nil {
+			return false
+		}
+		return sink.payloadSeen("edit-before") && sink.payloadSeen("presence-before")
+	}, 5*time.Second, 20*time.Millisecond, "both kinds must flow before the room is deactivated")
+
+	a.RoomDeactivated("room1")
+	// Outwait any read that was already in flight: its id vector was built
+	// before the deactivation, so it can still write a cursor back once.
+	time.Sleep(3 * readerTestBlock)
+
+	a.streamMu.Lock()
+	_, awKnown := a.cursors[a.scfg.awKey("room1")]
+	_, syncKnown := a.cursors[a.scfg.syncKey("room1")]
+	a.streamMu.Unlock()
+	require.False(t, awKnown,
+		"deactivation must forget the awareness cursor, or reactivation resumes mid-presence-stream")
+	require.True(t, syncKnown,
+		"deactivation must KEEP the sync cursor, or room churn replays the whole retention window")
+
+	// Published to a room nothing is reading: this presence belongs to
+	// clients that left with the room.
+	require.NoError(t, pubPresence("presence-while-gone"))
+	pubSync("edit-while-gone")
+
+	a.RoomActivated("room1")
+
+	// Witness: the surviving sync cursor still delivers what was published
+	// while the room was gone, which also proves the reader is reading room1
+	// again — so the awareness absence below is policy, not a dead path.
+	require.Eventually(t, func() bool { return sink.payloadSeen("edit-while-gone") },
+		5*time.Second, 10*time.Millisecond, "a kept sync cursor must still deliver")
+
+	// Witness: live presence flows again after reactivation. Republished each
+	// attempt because a tail-started stream has a one-cycle blind spot for an
+	// entry appended between two reads — which is what a real client's
+	// heartbeat rides out too.
+	require.Eventually(t, func() bool {
+		if err := pubPresence("presence-after"); err != nil {
+			return false
+		}
+		return sink.payloadSeen("presence-after")
+	}, 5*time.Second, 20*time.Millisecond, "awareness must flow after reactivation")
+
+	require.False(t, sink.payloadSeen("presence-while-gone"),
+		"presence published while the room was gone must not be replayed to its new occupants")
+}
+
+// Inbound latency must not scale with a reader's batch COUNT.
+//
+// Each XREAD blocks for the whole ReadBlock, so running the batches of one
+// cycle sequentially with every one of them blocking puts data waiting in
+// batch 10 behind nine full blocks. keyBatches's own doc cites 2500 rooms per
+// reader, which is 10 batches.
+func TestUnit_StreamReader_OnlyTheLastBatchOfACycleBlocks(t *testing.T) {
+	mr := newMiniRedis(t)
+	block := 40 * time.Millisecond
+	r, err := New(newClient(t, mr), Config{Transport: Streams, Readers: 1, ReadBlock: block})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.Negative(t, int64(nonBlockingRead),
+		"a non-blocking read needs a NEGATIVE Block: go-redis emits the BLOCK argument for any Block >= 0, and Redis reads BLOCK 0 as block FOREVER")
+
+	// One batch is also the last batch, so nothing changes for the ordinary
+	// single-batch reader: it still blocks.
+	require.Equal(t, block, r.blockForBatch(0, 1, false))
+	require.Equal(t, nonBlockingRead, r.blockForBatch(0, 1, true),
+		"a cycle that already found entries has work to do and must not sit in a block")
+
+	const n = 10 // 2500 rooms at maxKeysPerRead/streamsPerRoom per batch
+	for i := 0; i < n-1; i++ {
+		require.Equal(t, nonBlockingRead, r.blockForBatch(i, n, false),
+			"batch %d of %d must not block: an entry in a later batch would wait out every earlier one", i, n)
+	}
+	require.Equal(t, block, r.blockForBatch(n-1, n, false),
+		"the trailing block is what stops an idle reader spinning")
+	require.Equal(t, nonBlockingRead, r.blockForBatch(n-1, n, true))
+}
+
+// End-to-end companion to the test above: a room in the SECOND batch is
+// delivered normally.
+//
+// This is the guard against getting the non-blocking value wrong. "BLOCK 0"
+// means block forever, so a batch-0 read issued with Block: 0 would never
+// return and nothing here would ever arrive.
+func TestIntegration_StreamReader_DeliversToARoomInALaterBatch(t *testing.T) {
+	mr := newMiniRedis(t)
+
+	sink := &recordingSink{}
+	a, err := New(newClient(t, mr), readerConfig(nodeA))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := New(newClient(t, mr), readerConfig(nodeB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, a.Start(ctx, sink))
+	require.NoError(t, b.Start(ctx, &countingSink{}))
+
+	// More rooms than one batch holds, so there are two. roomsForReader sorts,
+	// so the last name is in the last batch.
+	perBatch := maxKeysPerRead / streamsPerRoom
+	rooms := make([]string, 0, perBatch+4)
+	for i := 0; i < perBatch+4; i++ {
+		rooms = append(rooms, fmt.Sprintf("room-%04d", i))
+	}
+	for _, room := range rooms {
+		a.RoomActivated(room)
+	}
+	require.Len(t, keyBatches(a.roomsForReader(0), perBatch), 2, "this test needs two batches")
+
+	last := rooms[len(rooms)-1]
+	require.NoError(t, b.Publish(ctx, cluster.Outbound{
+		Room: last, Kind: cluster.KindSync, Data: v1Update(t, "later-batch-edit"),
+	}))
+
+	require.Eventually(t, func() bool { return sink.payloadSeen("later-batch-edit") },
+		5*time.Second, 10*time.Millisecond,
+		"a room in the last batch must be delivered to, not stuck behind an earlier batch's block")
 }
 
 // --- Gap detection ---------------------------------------------------------

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -34,10 +34,32 @@ type StreamStats struct {
 	Trimmed uint64
 
 	// Stalled counts cursor advances declined because a room's inbound lane
-	// was full. Routine in bursts — declining to advance is the safe,
-	// zero-loss response, and the entries are re-read next cycle. Alert on a
-	// sustained rate, which means a room's consumer cannot keep up.
+	// was full.
+	//
+	// Routine in bursts: declining is the safe response — the entries stay in
+	// the stream and are read again next cycle, so nothing is discarded and
+	// the lane is not made to coalesce. What that costs is lag, and lag is
+	// only safe while the entries survive it: delivery is at-least-once within
+	// min(retention, MaxLen/publish-rate), and a stall that outlasts that
+	// window shows up as Gaps.
+	//
+	// Alert on a sustained rate, which means a room's consumer cannot keep up.
+	// See Deferred for the other reason an advance is declined.
 	Stalled uint64
+
+	// Deferred counts cursor advances declined because the room had no inbound
+	// delivery worker yet — the window inside RoomActivated between a room
+	// joining a reader's assignment set and its worker existing. Routine and
+	// self-clearing: the entries are re-read as soon as the worker exists.
+	//
+	// Deliberately NOT folded into Stalled, though both count a declined
+	// advance on entries that were kept. The two ask for opposite responses: a
+	// sustained Stalled rate means a room's consumer cannot keep up and wants
+	// capacity, while a sustained Deferred rate means rooms are being read
+	// without ever acquiring a worker, which is an activation bug and no
+	// amount of capacity fixes it. One counter carrying both would answer
+	// neither question — the same reason Restarts is not folded into Gaps.
+	Deferred uint64
 }
 
 // StreamStats returns a snapshot of the Streams tier's counters. Safe to call
@@ -49,5 +71,6 @@ func (r *Relay) StreamStats() StreamStats {
 		Restarts: r.restarts.Load(),
 		Trimmed:  r.trimmed.Load(),
 		Stalled:  r.stalled.Load(),
+		Deferred: r.deferred.Load(),
 	}
 }

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -12,10 +12,24 @@ package redis
 // take rates rather than absolute values — except Gaps, where presence alone
 // is the signal.
 type StreamStats struct {
-	// Replayed counts entries re-delivered from before a cursor, i.e. the
-	// merge savings on catch-up. Routine on activation and after a restart —
-	// this is the tier working. Alert on a sustained rate, which means
-	// cursors are being lost repeatedly.
+	// Replayed counts entries a merge folded into another entry rather than
+	// pushing separately: len(batch)-1 for every multi-entry batch handed to
+	// a room's lane as one merged update.
+	//
+	// Read it as a MERGE/BATCHING gauge, not as a replay alarm. It is not a
+	// count of entries re-delivered from before a cursor, and it cannot
+	// distinguish catch-up from ordinary throughput: any room taking more
+	// than one remote update per ReadBlock (250ms by default) batches on
+	// every cycle, so a busy room produces a permanent, healthy rate with no
+	// cursor ever having been lost. Do NOT alert on its rate.
+	//
+	// What it is good for: it tracks inbound remote-update volume. Divided by
+	// the read rate it approximates merged entries per cycle, so a step
+	// change means the cluster's write traffic stepped, and a catch-up burst
+	// — activation, a node restart, a stall clearing — is a spike against
+	// that room's own baseline. The existence of the baseline is exactly why
+	// an absolute threshold on it means nothing. The counters that do report
+	// loss or lag are Gaps, Stalled and Deferred.
 	Replayed uint64
 
 	// Gaps counts PROVABLE losses: a source node's seq jumped, so entries

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -37,6 +37,12 @@ type StreamStats struct {
 	//
 	// ALERT ON PRESENCE, not on rate. A single gap means data was lost and
 	// the retention window was too small for the reader's actual lag.
+	//
+	// Detects jumps only AFTER this process has observed a baseline for a
+	// source: lastSeq is in-memory, so the first entry seen from a source is a
+	// baseline whatever its number. Loss that happened while this reader was
+	// down is therefore bounded by the retention window rather than reported
+	// here.
 	Gaps uint64
 
 	// Restarts counts source nodes observed restarting, inferred from a seq

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -2,69 +2,56 @@ package redis
 
 // StreamStats is a point-in-time snapshot of the Streams tier's counters.
 //
-// Deliberately separate from Stats rather than extra fields on it. Stats
-// carries pub/sub concepts (Coalesced, AwarenessSuperseded, HardDrops) that
-// are permanently zero under Streams, and these are permanently zero under
-// pub/sub. A type whose fields are meaningless half the time is how a metric
-// stops being trusted.
+// Separate from Stats rather than extra fields on it: Stats carries pub/sub
+// concepts (Coalesced, AwarenessSuperseded, HardDrops) permanently zero under
+// Streams, and these are permanently zero under pub/sub. A type whose fields
+// are meaningless half the time is how a metric stops being trusted.
 //
-// Every counter is monotonic for the life of the Relay, so a scrape should
-// take rates rather than absolute values — except Gaps, where presence alone
-// is the signal.
+// Every counter is monotonic for the life of the Relay, so a scrape should take
+// rates rather than absolute values — except Gaps, where presence is the signal.
 type StreamStats struct {
-	// Replayed counts entries a merge folded into another entry rather than
-	// pushing separately: len(batch)-1 for every multi-entry batch handed to
-	// a room's lane as one merged update.
+	// Replayed counts entries a merge folded into another rather than pushing
+	// separately: len(batch)-1 for every multi-entry batch handed to a lane.
 	//
-	// Read it as a MERGE/BATCHING gauge, not as a replay alarm. It is not a
-	// count of entries re-delivered from before a cursor, and it cannot
-	// distinguish catch-up from ordinary throughput: any room taking more
-	// than one remote update per ReadBlock (250ms by default) batches on
-	// every cycle, so a busy room produces a permanent, healthy rate with no
-	// cursor ever having been lost. Do NOT alert on its rate.
-	//
-	// What it is good for: it tracks inbound remote-update volume. Divided by
-	// the read rate it approximates merged entries per cycle, so a step
-	// change means the cluster's write traffic stepped, and a catch-up burst
-	// — activation, a node restart, a stall clearing — is a spike against
-	// that room's own baseline. The existence of the baseline is exactly why
-	// an absolute threshold on it means nothing. The counters that do report
-	// loss or lag are Gaps, Stalled and Deferred.
+	// A MERGE/BATCHING gauge, not a replay alarm — do NOT alert on its rate. It
+	// is not a count of entries re-delivered from before a cursor and cannot
+	// distinguish catch-up from ordinary throughput: any room taking more than
+	// one remote update per ReadBlock (250ms default) batches every cycle, so a
+	// busy room shows a permanent, healthy rate with no cursor ever lost. Read
+	// as volume it is useful — a catch-up burst is a spike against that room's
+	// own baseline — but Gaps, Stalled and Deferred are what report loss.
 	Replayed uint64
 
 	// Gaps counts PROVABLE losses: a source node's seq jumped, so entries
 	// existed and were trimmed before this reader reached them.
 	//
-	// ALERT ON PRESENCE, not on rate. A single gap means data was lost and
-	// the retention window was too small for the reader's actual lag.
+	// ALERT ON PRESENCE, not on rate. A single gap means data was lost and the
+	// retention window was too small for the reader's actual lag.
 	//
 	// Detects jumps only AFTER this process has observed a baseline for a
-	// source: lastSeq is in-memory, so the first entry seen from a source is a
-	// baseline whatever its number. Loss that happened while this reader was
-	// down is therefore bounded by the retention window rather than reported
-	// here.
+	// source, lastSeq being in-memory: the first entry seen from a source is a
+	// baseline whatever its number, so loss that happened while this reader was
+	// down is bounded by the retention window rather than reported here.
 	Gaps uint64
 
 	// Restarts counts source nodes observed restarting, inferred from a seq
-	// DECREASE. Informational: expected once per node per deploy. It exists
-	// so a restart is never miscounted as a Gap.
+	// DECREASE. Informational: expected once per node per deploy. It exists so
+	// a restart is never miscounted as a Gap.
 	Restarts uint64
 
 	// Trimmed counts entries removed by the MINID sweeper. Routine.
 	Trimmed uint64
 
-	// Stalled counts cursor advances declined because a room's inbound lane
-	// was full.
+	// Stalled counts cursor advances declined because a room's inbound lane was
+	// full.
 	//
-	// Routine in bursts: declining is the safe response — the entries stay in
-	// the stream and are read again next cycle, so nothing is discarded and
-	// the lane is not made to coalesce. What that costs is lag, and lag is
-	// only safe while the entries survive it: delivery is at-least-once within
-	// min(retention, MaxLen/publish-rate), and a stall that outlasts that
-	// window shows up as Gaps.
+	// Routine in bursts: the entries stay in the stream and are read again next
+	// cycle, so nothing is discarded and the lane is not made to coalesce. What
+	// that costs is lag, and lag is only safe while the entries survive it —
+	// delivery is at-least-once within min(retention, MaxLen/publish-rate), and
+	// a stall outlasting that window shows up as Gaps.
 	//
 	// Alert on a sustained rate, which means a room's consumer cannot keep up.
-	// See Deferred for the other reason an advance is declined.
 	Stalled uint64
 
 	// Deferred counts cursor advances declined because the room had no inbound
@@ -72,24 +59,18 @@ type StreamStats struct {
 	// joining a reader's assignment set and its worker existing. Routine and
 	// self-clearing.
 	//
-	// What becomes of the deferred entries depends on which stream they were
-	// on. On a SYNC stream they are re-read: that cursor is relay-scoped and
-	// was not advanced, so the next cycle asks for the same entries and the
-	// worker, once it exists, receives all of them. On an AWARENESS stream
-	// they are NOT re-read — the baseline there is the residency's own cursor
-	// (roomWorker.awCursor), which does not exist yet, so the next read
-	// starts from tailID and those entries are already behind it. That is the
-	// intended outcome rather than a loss to fix: presence appended before a
-	// room had any local residency belongs to nobody here, and live clients
-	// re-announce within one heartbeat interval.
+	// SYNC entries are then re-read (the cursor is relay-scoped and was not
+	// advanced), so the worker receives all of them once it exists. AWARENESS
+	// entries are NOT: their baseline is the residency's own cursor
+	// (roomWorker.awCursor), which does not exist yet, so the next read starts
+	// from tailID and those entries are already behind it. Intended rather than
+	// a loss to fix — presence appended before a room had any local residency
+	// belongs to nobody here, and live clients re-announce within one interval.
 	//
-	// Deliberately NOT folded into Stalled, though both count a declined
-	// advance on entries that were kept. The two ask for opposite responses: a
-	// sustained Stalled rate means a room's consumer cannot keep up and wants
-	// capacity, while a sustained Deferred rate means rooms are being read
-	// without ever acquiring a worker, which is an activation bug and no
-	// amount of capacity fixes it. One counter carrying both would answer
-	// neither question — the same reason Restarts is not folded into Gaps.
+	// Deliberately NOT folded into Stalled: a sustained Stalled rate means a
+	// consumer cannot keep up and wants capacity, while a sustained Deferred
+	// rate means rooms are read without ever acquiring a worker, an activation
+	// bug no capacity fixes.
 	Deferred uint64
 }
 

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -1,0 +1,53 @@
+package redis
+
+// StreamStats is a point-in-time snapshot of the Streams tier's counters.
+//
+// Deliberately separate from Stats rather than extra fields on it. Stats
+// carries pub/sub concepts (Coalesced, AwarenessSuperseded, HardDrops) that
+// are permanently zero under Streams, and these are permanently zero under
+// pub/sub. A type whose fields are meaningless half the time is how a metric
+// stops being trusted.
+//
+// Every counter is monotonic for the life of the Relay, so a scrape should
+// take rates rather than absolute values — except Gaps, where presence alone
+// is the signal.
+type StreamStats struct {
+	// Replayed counts entries re-delivered from before a cursor, i.e. the
+	// merge savings on catch-up. Routine on activation and after a restart —
+	// this is the tier working. Alert on a sustained rate, which means
+	// cursors are being lost repeatedly.
+	Replayed uint64
+
+	// Gaps counts PROVABLE losses: a source node's seq jumped, so entries
+	// existed and were trimmed before this reader reached them.
+	//
+	// ALERT ON PRESENCE, not on rate. A single gap means data was lost and
+	// the retention window was too small for the reader's actual lag.
+	Gaps uint64
+
+	// Restarts counts source nodes observed restarting, inferred from a seq
+	// DECREASE. Informational: expected once per node per deploy. It exists
+	// so a restart is never miscounted as a Gap.
+	Restarts uint64
+
+	// Trimmed counts entries removed by the MINID sweeper. Routine.
+	Trimmed uint64
+
+	// Stalled counts cursor advances declined because a room's inbound lane
+	// was full. Routine in bursts — declining to advance is the safe,
+	// zero-loss response, and the entries are re-read next cycle. Alert on a
+	// sustained rate, which means a room's consumer cannot keep up.
+	Stalled uint64
+}
+
+// StreamStats returns a snapshot of the Streams tier's counters. Safe to call
+// concurrently, and safe on a PubSub-mode relay, where every field is zero.
+func (r *Relay) StreamStats() StreamStats {
+	return StreamStats{
+		Replayed: r.replayed.Load(),
+		Gaps:     r.gaps.Load(),
+		Restarts: r.restarts.Load(),
+		Trimmed:  r.trimmed.Load(),
+		Stalled:  r.stalled.Load(),
+	}
+}

--- a/cluster/redis/streams_stats.go
+++ b/cluster/redis/streams_stats.go
@@ -50,7 +50,18 @@ type StreamStats struct {
 	// Deferred counts cursor advances declined because the room had no inbound
 	// delivery worker yet — the window inside RoomActivated between a room
 	// joining a reader's assignment set and its worker existing. Routine and
-	// self-clearing: the entries are re-read as soon as the worker exists.
+	// self-clearing.
+	//
+	// What becomes of the deferred entries depends on which stream they were
+	// on. On a SYNC stream they are re-read: that cursor is relay-scoped and
+	// was not advanced, so the next cycle asks for the same entries and the
+	// worker, once it exists, receives all of them. On an AWARENESS stream
+	// they are NOT re-read — the baseline there is the residency's own cursor
+	// (roomWorker.awCursor), which does not exist yet, so the next read
+	// starts from tailID and those entries are already behind it. That is the
+	// intended outcome rather than a loss to fix: presence appended before a
+	// room had any local residency belongs to nobody here, and live clients
+	// re-announce within one heartbeat interval.
 	//
 	// Deliberately NOT folded into Stalled, though both count a declined
 	// advance on entries that were kept. The two ask for opposite responses: a

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -159,3 +159,36 @@ func TestUnit_Streams_SeqIsMonotonicUnderConcurrency(t *testing.T) {
 	}
 	require.Len(t, seen, n)
 }
+
+// A separate type, not extra fields on Stats: a counter that is permanently
+// zero for the tier you are running is what makes a dashboard untrustworthy.
+func TestUnit_StreamStats_SnapshotsEveryCounter(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.Equal(t, StreamStats{}, r.StreamStats(), "a fresh relay has zero of everything")
+
+	r.replayed.Add(3)
+	r.gaps.Add(1)
+	r.restarts.Add(2)
+	r.trimmed.Add(10)
+	r.stalled.Add(4)
+
+	require.Equal(t, StreamStats{
+		Replayed: 3, Gaps: 1, Restarts: 2, Trimmed: 10, Stalled: 4,
+	}, r.StreamStats())
+}
+
+// Stats() is the pub/sub tier's and must not grow stream fields.
+func TestUnit_StreamStats_PubSubStatsUnchanged(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	_ = r.Stats() // must still compile and run for a pub/sub relay
+	require.Equal(t, StreamStats{}, r.StreamStats(),
+		"a pub/sub relay reports zero stream activity")
+}

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -1,11 +1,13 @@
 package redis
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
@@ -197,4 +199,122 @@ func TestUnit_StreamStats_PubSubStatsUnchanged(t *testing.T) {
 	// The pub/sub tier's Stats() must also report zero values (no events have occurred)
 	require.Equal(t, Stats{}, r.Stats(),
 		"a fresh pub/sub relay has zero degraded-path activity")
+}
+
+// streamEntries reads every entry currently in a stream key.
+func streamEntries(t *testing.T, mr *miniredis.Miniredis, key string) []miniredis.StreamEntry {
+	t.Helper()
+	e, err := mr.Stream(key)
+	if err != nil {
+		return nil // key absent: no entries
+	}
+	return e
+}
+
+// entryValues flattens one miniredis entry's fields into a map.
+//
+// miniredis.StreamEntry.Values is a []string of alternating key/value — NOT a
+// map — so it cannot be indexed by field name directly.
+func entryValues(e miniredis.StreamEntry) map[string]string {
+	m := make(map[string]string, len(e.Values)/2)
+	for i := 0; i+1 < len(e.Values); i += 2 {
+		m[e.Values[i]] = e.Values[i+1]
+	}
+	return m
+}
+
+func TestUnit_Streams_PublishSyncLandsInSyncStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
+	}))
+
+	entries := streamEntries(t, mr, "ygo:stream:room1")
+	require.Len(t, entries, 1)
+	require.Equal(t, "update", entryValues(entries[0])["d"])
+	require.Equal(t, "1", entryValues(entries[0])["s"], "first publish must be seq 1")
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:aw:room1"))
+}
+
+// Awareness must go to its own stream: sharing would let heartbeat traffic
+// evict sync entries out of the retention window.
+func TestUnit_Streams_PublishAwarenessLandsInAwarenessStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("presence"),
+	}))
+
+	require.Len(t, streamEntries(t, mr, "ygo:stream:aw:room1"), 1)
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:room1"))
+}
+
+// Server.Shutdown cancels the relay ctx and then joins lane workers; a
+// Publish that ignores cancellation stalls that join (#202).
+func TestUnit_Streams_PublishHonoursCancelledContext(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = r.publishStream(ctx, cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// Both must reach BOTH tiers, since pub/sub and Streams nodes do not
+// interoperate and migration rolls through Both.
+//
+// r.Start is required here even though the brief's version of this test
+// omitted it: Publish's existing started-guard returns ErrRelayNotStarted
+// before reaching the transport-routing branch this task adds, so without
+// Start the require.NoError below would fail regardless of whether the new
+// routing code is correct.
+func TestUnit_Streams_BothPublishesToChannelAndStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Both})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	require.NoError(t, r.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
+	}))
+
+	// Stream side is synchronous and observable immediately.
+	require.Eventually(t, func() bool {
+		return len(streamEntries(t, mr, "ygo:stream:room1")) == 1
+	}, 2*time.Second, 10*time.Millisecond, "Both must XADD to the stream")
+}
+
+// PubSub mode must never touch the keyspace.
+//
+// r.Start is required here for the same reason as the Both test above: the
+// brief's version discarded Publish's error and never called Start, so
+// Publish returned ErrRelayNotStarted before ever reaching the new
+// transport-routing branch — meaning the stream-emptiness assertion below
+// would have passed even if PubSub mode wrongly wrote to a stream. Calling
+// Start first makes Publish actually exercise usesStreams()/usesPubSub().
+func TestUnit_Streams_PubSubModeWritesNoStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	require.NoError(t, r.Publish(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
+	}))
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:room1"))
 }

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -379,11 +379,9 @@ func TestUnit_Streams_PublishHonoursCancelledContext(t *testing.T) {
 // Both must reach BOTH tiers, since pub/sub and Streams nodes do not
 // interoperate and migration rolls through Both.
 //
-// r.Start is required here even though the brief's version of this test
-// omitted it: Publish's existing started-guard returns ErrRelayNotStarted
-// before reaching the transport-routing branch this task adds, so without
-// Start the require.NoError below would fail regardless of whether the new
-// routing code is correct.
+// r.Start is REQUIRED: Publish's started-guard returns ErrRelayNotStarted
+// before reaching the transport-routing branch, so without it the
+// require.NoError below fails regardless of the routing code.
 func TestUnit_Streams_BothPublishesToChannelAndStream(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{Transport: Both})
@@ -403,12 +401,10 @@ func TestUnit_Streams_BothPublishesToChannelAndStream(t *testing.T) {
 
 // PubSub mode must never touch the keyspace.
 //
-// r.Start is required here for the same reason as the Both test above: the
-// brief's version discarded Publish's error and never called Start, so
-// Publish returned ErrRelayNotStarted before ever reaching the new
-// transport-routing branch — meaning the stream-emptiness assertion below
-// would have passed even if PubSub mode wrongly wrote to a stream. Calling
-// Start first makes Publish actually exercise usesStreams()/usesPubSub().
+// r.Start is REQUIRED for the same reason as the Both test above: without it
+// Publish returns ErrRelayNotStarted before reaching the transport-routing
+// branch, so the stream-emptiness assertion below would pass even if PubSub
+// mode wrongly wrote to a stream.
 func TestUnit_Streams_PubSubModeWritesNoStream(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{})
@@ -431,9 +427,8 @@ func TestUnit_Streams_PubSubModeWritesNoStream(t *testing.T) {
 // This is the end-to-end shape of the defect the per-stream counter fixes: a
 // single per-relay counter, incremented for every publish regardless of room,
 // wrote [1 3 5] into room1's stream and [2 4 6] into room2's, so every reader
-// of either room raised StreamStats.Gaps against a node that was doing
-// nothing but working. Verified failing against that counter — see
-// task-6-report.md.
+// of either room raised StreamStats.Gaps against a healthy node. Verified
+// failing against that counter.
 func TestUnit_Streams_InterleavedRoomPublishesAreContiguousPerStream(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{Transport: Streams})

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -140,26 +141,51 @@ func TestUnit_Streams_DecodeRejectsGarbageSeq(t *testing.T) {
 	require.ErrorContains(t, err, "seq")
 }
 
-// seq must be monotonic per relay and safe under concurrent Publish, which
-// the Relay contract explicitly permits for distinct rooms.
-func TestUnit_Streams_SeqIsMonotonicUnderConcurrency(t *testing.T) {
-	r := &Relay{}
-	const n = 200
-	got := make(chan uint64, n)
+// seq must be monotonic and gap-free WITHIN EACH STREAM, and safe under
+// concurrent Publish, which the Relay contract explicitly permits for
+// distinct rooms.
+//
+// Two streams, interleaved concurrently, is the shape that broke the earlier
+// per-relay counter: it issued each stream a non-contiguous subset of one
+// series, which is exactly what the reader's gap detection reports as loss.
+func TestUnit_Streams_SeqIsMonotonicPerStreamUnderConcurrency(t *testing.T) {
+	r := &Relay{seqs: map[string]uint64{}}
+	const perStream = 200
+	keys := []string{"ygo:stream:s:room1", "ygo:stream:s:room2"}
+
+	got := make(chan [2]any, perStream*len(keys))
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() { defer wg.Done(); got <- r.nextSeq() }()
+	for _, key := range keys {
+		for i := 0; i < perStream; i++ {
+			wg.Add(1)
+			go func(key string) {
+				defer wg.Done()
+				got <- [2]any{key, r.nextSeq(key)}
+			}(key)
+		}
 	}
 	wg.Wait()
 	close(got)
 
-	seen := map[uint64]bool{}
-	for s := range got {
-		require.False(t, seen[s], "seq %d issued twice", s)
-		seen[s] = true
+	seen := map[string]map[uint64]bool{}
+	for pair := range got {
+		key, seq := pair[0].(string), pair[1].(uint64)
+		if seen[key] == nil {
+			seen[key] = map[uint64]bool{}
+		}
+		require.False(t, seen[key][seq], "seq %d issued twice for %s", seq, key)
+		seen[key][seq] = true
 	}
-	require.Len(t, seen, n)
+
+	require.Len(t, seen, len(keys))
+	for _, key := range keys {
+		require.Len(t, seen[key], perStream)
+		// Contiguous 1..perStream: a hole here is what a reader would report
+		// as a Gap, i.e. as lost data.
+		for i := uint64(1); i <= perStream; i++ {
+			require.True(t, seen[key][i], "%s is missing seq %d of %d", key, i, perStream)
+		}
+	}
 }
 
 // A separate type, not extra fields on Stats: a counter that is permanently
@@ -233,11 +259,11 @@ func TestUnit_Streams_PublishSyncLandsInSyncStream(t *testing.T) {
 		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
 	}))
 
-	entries := streamEntries(t, mr, "ygo:stream:room1")
+	entries := streamEntries(t, mr, "ygo:stream:s:room1")
 	require.Len(t, entries, 1)
 	require.Equal(t, "update", entryValues(entries[0])["d"])
 	require.Equal(t, "1", entryValues(entries[0])["s"], "first publish must be seq 1")
-	require.Empty(t, streamEntries(t, mr, "ygo:stream:aw:room1"))
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:a:room1"))
 }
 
 // Awareness must go to its own stream: sharing would let heartbeat traffic
@@ -252,8 +278,8 @@ func TestUnit_Streams_PublishAwarenessLandsInAwarenessStream(t *testing.T) {
 		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("presence"),
 	}))
 
-	require.Len(t, streamEntries(t, mr, "ygo:stream:aw:room1"), 1)
-	require.Empty(t, streamEntries(t, mr, "ygo:stream:room1"))
+	require.Len(t, streamEntries(t, mr, "ygo:stream:a:room1"), 1)
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:s:room1"))
 }
 
 // Server.Shutdown cancels the relay ctx and then joins lane workers; a
@@ -294,7 +320,7 @@ func TestUnit_Streams_BothPublishesToChannelAndStream(t *testing.T) {
 
 	// Stream side is synchronous and observable immediately.
 	require.Eventually(t, func() bool {
-		return len(streamEntries(t, mr, "ygo:stream:room1")) == 1
+		return len(streamEntries(t, mr, "ygo:stream:s:room1")) == 1
 	}, 2*time.Second, 10*time.Millisecond, "Both must XADD to the stream")
 }
 
@@ -316,5 +342,195 @@ func TestUnit_Streams_PubSubModeWritesNoStream(t *testing.T) {
 	require.NoError(t, r.Publish(context.Background(), cluster.Outbound{
 		Room: "room1", Kind: cluster.KindSync, Data: []byte("update"),
 	}))
-	require.Empty(t, streamEntries(t, mr, "ygo:stream:room1"))
+	require.Empty(t, streamEntries(t, mr, "ygo:stream:s:room1"))
+}
+
+// --- seq is per (node, stream), not per node -------------------------------
+
+// A node publishing to several rooms must write a CONTIGUOUS series into each
+// room's stream, because a reader of one stream sees only that stream's
+// entries and reports a jump as lost data.
+//
+// This is the end-to-end shape of the defect the per-stream counter fixes: a
+// single per-relay counter, incremented for every publish regardless of room,
+// wrote [1 3 5] into room1's stream and [2 4 6] into room2's, so every reader
+// of either room raised StreamStats.Gaps against a node that was doing
+// nothing but working. Verified failing against that counter — see
+// task-6-report.md.
+func TestUnit_Streams_InterleavedRoomPublishesAreContiguousPerStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	const rounds = 3
+	for i := 0; i < rounds; i++ {
+		for _, room := range []string{"room1", "room2"} {
+			require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+				Room: room, Kind: cluster.KindSync, Data: []byte(fmt.Sprintf("%s-%d", room, i)),
+			}))
+		}
+	}
+
+	for _, room := range []string{"room1", "room2"} {
+		entries := streamEntries(t, mr, r.scfg.syncKey(room))
+		require.Len(t, entries, rounds)
+		for i, e := range entries {
+			require.Equal(t, strconv.Itoa(i+1), entryValues(e)["s"],
+				"%s entry %d: a stream's own series must be contiguous from 1", room, i)
+		}
+	}
+}
+
+// The two kinds of stream for one room have independent counters too: they
+// are separate keys, and a reader reads them as separate series.
+func TestUnit_Streams_SyncAndAwarenessCountSeparately(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	for i := 0; i < 2; i++ {
+		for _, kind := range []cluster.Kind{cluster.KindSync, cluster.KindAwareness} {
+			require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+				Room: "room1", Kind: kind, Data: []byte("x"),
+			}))
+		}
+	}
+
+	for _, key := range []string{r.scfg.syncKey("room1"), r.scfg.awKey("room1")} {
+		entries := streamEntries(t, mr, key)
+		require.Len(t, entries, 2)
+		require.Equal(t, "1", entryValues(entries[0])["s"], key)
+		require.Equal(t, "2", entryValues(entries[1])["s"], key)
+	}
+}
+
+// The counter map is bounded, and the bound must not touch a stream whose
+// room this node still holds: resetting a live stream's counter would make
+// every reader of it record a Restart for nothing.
+func TestUnit_Streams_SeqEvictionKeepsLiveStreams(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	r.streamMu.Lock()
+	r.streamRooms["live"] = 1
+	r.streamMu.Unlock()
+
+	liveKey := r.scfg.syncKey("live")
+	require.Equal(t, uint64(1), r.nextSeq(liveKey))
+	for i := 0; i < seqLimit; i++ {
+		r.nextSeq(fmt.Sprintf("ygo:stream:s:gone-%d", i))
+	}
+	r.nextSeq("ygo:stream:s:gone-trigger")
+
+	require.Equal(t, uint64(2), r.nextSeq(liveKey),
+		"a live stream's counter must survive eviction, or its readers see a phantom restart")
+
+	r.streamMu.Lock()
+	held := len(r.seqs)
+	r.streamMu.Unlock()
+	require.Less(t, held, seqLimit, "eviction must actually bound the map")
+}
+
+// --- Key namespaces ---------------------------------------------------------
+
+// No two (room, kind) pairs may share a Redis key.
+//
+// Room names are permissive by design — internal/roomname.Valid accepts every
+// printable character, ":" included, to match the y-websocket JS server — so
+// the key layout has to be collision-proof for adversarial names, not merely
+// for tidy ones. The "aw:foo" row is the one that failed under the earlier
+// layout: prefix+"aw:foo" was simultaneously that room's sync key and room
+// "foo"'s awareness key, so one Redis stream carried two rooms' traffic.
+func TestUnit_Streams_KeyNamespacesCannotCollide(t *testing.T) {
+	sc := streamCfg{prefix: defaultStreamPrefix}
+	// "" is included even though roomname.Valid rejects it: the property is
+	// about the key layout, and asserting it for names the validator would
+	// never pass costs nothing and removes one dependency between the two.
+	rooms := []string{"foo", "a:foo", "s:foo", "aw:foo", "a:", "s:", "", ":", "a:s:foo"}
+
+	owner := map[string]string{}
+	for _, room := range rooms {
+		for kind, key := range map[string]string{
+			"sync":      sc.syncKey(room),
+			"awareness": sc.awKey(room),
+		} {
+			who := fmt.Sprintf("%s(%q)", kind, room)
+			if prev, dup := owner[key]; dup {
+				t.Fatalf("key %q is shared by %s and %s", key, prev, who)
+			}
+			owner[key] = who
+		}
+	}
+	require.Len(t, owner, len(rooms)*streamsPerRoom)
+}
+
+// The end-to-end form of the same property: two rooms whose names differ only
+// by a discriminator-shaped prefix must not see each other's traffic.
+func TestUnit_Streams_ColonRoomsDoNotShareAStream(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	// Sync traffic for the rooms whose names could forge a discriminator...
+	for _, room := range []string{"a:foo", "aw:foo"} {
+		require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+			Room: room, Kind: cluster.KindSync, Data: []byte("sync-" + room),
+		}))
+	}
+	// ...and presence for the room they might be mistaken for.
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "foo", Kind: cluster.KindAwareness, Data: []byte("presence-foo"),
+	}))
+
+	want := map[string]string{
+		r.scfg.syncKey("a:foo"):  "sync-a:foo",
+		r.scfg.syncKey("aw:foo"): "sync-aw:foo",
+		r.scfg.awKey("foo"):      "presence-foo",
+	}
+	require.Len(t, want, 3, "the three keys must be distinct")
+
+	for key, payload := range want {
+		entries := streamEntries(t, mr, key)
+		require.Len(t, entries, 1, "key %q must hold exactly its own entry", key)
+		require.Equal(t, payload, entryValues(entries[0])["d"], "key %q", key)
+	}
+	// And nothing leaked into the room-"foo" sync stream, which was never
+	// published to.
+	require.Empty(t, streamEntries(t, mr, r.scfg.syncKey("foo")))
+}
+
+// parseStreamKey must be exact, and must refuse rather than guess.
+func TestUnit_Streams_ParseStreamKeyIsExactOrRefuses(t *testing.T) {
+	sc := streamCfg{prefix: defaultStreamPrefix}
+
+	for _, room := range []string{"foo", "a:foo", "s:foo", "aw:foo", "", ":"} {
+		got, isAw, ok := sc.parseStreamKey(sc.syncKey(room))
+		require.True(t, ok)
+		require.False(t, isAw)
+		require.Equal(t, room, got, "sync key of %q must round-trip verbatim", room)
+
+		got, isAw, ok = sc.parseStreamKey(sc.awKey(room))
+		require.True(t, ok)
+		require.True(t, isAw)
+		require.Equal(t, room, got, "awareness key of %q must round-trip verbatim", room)
+	}
+
+	// Neither discriminator: ignored, not coerced into a room name.
+	for _, key := range []string{
+		"ygo:stream:",       // prefix only
+		"ygo:stream:aw:foo", // the OLD awareness layout
+		"ygo:stream:foo",    // the OLD sync layout
+		"ygo:cluster:s:foo", // another namespace entirely
+		"s:foo",             // unprefixed
+	} {
+		room, isAw, ok := sc.parseStreamKey(key)
+		require.False(t, ok, "key %q must be refused", key)
+		require.Empty(t, room)
+		require.False(t, isAw)
+	}
 }

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -1,0 +1,75 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// Transport's zero value must be PubSub so an existing Config keeps working.
+func TestUnit_Streams_TransportZeroValueIsPubSub(t *testing.T) {
+	require.Equal(t, PubSub, Transport(0))
+}
+
+func TestUnit_Streams_ResolveDefaults(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	got, err := resolveStreamCfg(c, Config{Transport: Streams})
+	require.NoError(t, err)
+
+	require.Equal(t, "ygo:stream:", got.prefix)
+	require.Equal(t, 60*time.Second, got.retention)
+	require.Equal(t, int64(4096), got.maxLen)
+	require.Equal(t, int64(64), got.awMaxLen)
+	require.Equal(t, 10*time.Second, got.awRetention)
+	require.Equal(t, 4, got.readers)
+	require.Equal(t, 30*time.Second, got.trimInterval)
+	require.Equal(t, 5*time.Second, got.readBlock)
+}
+
+// An undersized pool starves publishes: every blocking XREAD holds a pool
+// connection for its whole ReadBlock. Failing construction is much kinder
+// than presenting as mysterious publish latency later.
+func TestUnit_Streams_RejectsPoolSmallerThanReaders(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := goredis.NewClient(&goredis.Options{Addr: mr.Addr(), PoolSize: 2})
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err := resolveStreamCfg(c, Config{Transport: Streams, Readers: 8})
+	require.ErrorContains(t, err, "PoolSize")
+}
+
+// A sweeper slower than the window it enforces cannot enforce it.
+func TestUnit_Streams_RejectsTrimIntervalAboveRetention(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	_, err := resolveStreamCfg(c, Config{
+		Transport:       Streams,
+		StreamRetention: 10 * time.Second,
+		TrimInterval:    30 * time.Second,
+	})
+	require.ErrorContains(t, err, "TrimInterval")
+}
+
+func TestUnit_Streams_RejectsUnknownTransport(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	_, err := resolveStreamCfg(c, Config{Transport: Transport(99)})
+	require.ErrorContains(t, err, "Transport")
+}
+
+// PubSub mode must not validate stream settings at all — an existing caller
+// has never set them and must not start failing construction.
+func TestUnit_Streams_PubSubModeSkipsStreamValidation(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := goredis.NewClient(&goredis.Options{Addr: mr.Addr(), PoolSize: 1})
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err := resolveStreamCfg(c, Config{Readers: 999})
+	require.NoError(t, err)
+}

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -1,11 +1,15 @@
 package redis
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/cluster"
 )
 
 // Transport's zero value must be PubSub so an existing Config keeps working.
@@ -72,4 +76,86 @@ func TestUnit_Streams_PubSubModeSkipsStreamValidation(t *testing.T) {
 
 	_, err := resolveStreamCfg(c, Config{Readers: 999})
 	require.NoError(t, err)
+}
+
+// Round-tripping through native stream fields is what lets the reader read
+// seq without decoding the payload.
+func TestUnit_Streams_EntryRoundTrip(t *testing.T) {
+	nodeID := []byte("0123456789abcdef")
+	fields := streamFields(nodeID, 42, cluster.KindSync, []byte("payload"))
+
+	vals := asRedisValues(fields)
+
+	gotNode, gotSeq, gotKind, gotData, err := decodeStreamEntry(vals)
+	require.NoError(t, err)
+	require.Equal(t, nodeID, gotNode)
+	require.Equal(t, uint64(42), gotSeq)
+	require.Equal(t, cluster.KindSync, gotKind)
+	require.Equal(t, []byte("payload"), gotData)
+}
+
+// room is deliberately NOT a field: the key is authoritative and every
+// omitted byte is multiplied by retention x rate.
+func TestUnit_Streams_EntryOmitsRoom(t *testing.T) {
+	fields := streamFields([]byte("n"), 1, cluster.KindSync, []byte("d"))
+	for i := 0; i < len(fields); i += 2 {
+		require.NotEqual(t, "room", fields[i])
+	}
+	require.Len(t, fields, 8) // exactly n, s, k, d
+}
+
+// asRedisValues rebuilds what XREAD hands back from what XADD was given.
+//
+// The conversion is the point: XADD takes []byte happily, but Redis stores
+// bulk strings and go-redis surfaces XMessage.Values as map[string]any holding
+// STRINGS. A test that fed []byte straight back in would pass against a
+// decoder that accepts []byte and then fail against real Redis.
+func asRedisValues(fields []any) map[string]any {
+	out := make(map[string]any, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		k, _ := fields[i].(string)
+		switch v := fields[i+1].(type) {
+		case []byte:
+			out[k] = string(v)
+		case string:
+			out[k] = v
+		default:
+			out[k] = fmt.Sprint(v)
+		}
+	}
+	return out
+}
+
+func TestUnit_Streams_DecodeRejectsMissingFields(t *testing.T) {
+	_, _, _, _, err := decodeStreamEntry(map[string]any{"n": "x"})
+	require.Error(t, err)
+}
+
+func TestUnit_Streams_DecodeRejectsGarbageSeq(t *testing.T) {
+	_, _, _, _, err := decodeStreamEntry(map[string]any{
+		"n": "x", "s": "not-a-number", "k": "0", "d": "d",
+	})
+	require.ErrorContains(t, err, "seq")
+}
+
+// seq must be monotonic per relay and safe under concurrent Publish, which
+// the Relay contract explicitly permits for distinct rooms.
+func TestUnit_Streams_SeqIsMonotonicUnderConcurrency(t *testing.T) {
+	r := &Relay{}
+	const n = 200
+	got := make(chan uint64, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); got <- r.nextSeq() }()
+	}
+	wg.Wait()
+	close(got)
+
+	seen := map[uint64]bool{}
+	for s := range got {
+		require.False(t, seen[s], "seq %d issued twice", s)
+		seen[s] = true
+	}
+	require.Len(t, seen, n)
 }

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -90,6 +90,30 @@ func TestUnit_Streams_RejectsReadBlockBelowMin(t *testing.T) {
 	require.Equal(t, 100*time.Microsecond, got.readBlock)
 }
 
+// A NEGATIVE ReadBlock must reach the same rejection as a sub-millisecond
+// one. Defaulting everything <= 0 turned -5ms into the 250ms default, so the
+// documented "New fails if it is smaller than 1ms" did not hold for the values
+// most likely to be a typo.
+func TestUnit_Streams_RejectsNegativeReadBlock(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	_, err := resolveStreamCfg(c, Config{Transport: Streams, ReadBlock: -5 * time.Millisecond})
+	require.ErrorContains(t, err, "ReadBlock")
+	require.ErrorContains(t, err, "1ms", "the error must name the floor")
+
+	// Only the UNSET value may be defaulted.
+	got, err := resolveStreamCfg(c, Config{Transport: Streams})
+	require.NoError(t, err)
+	require.Equal(t, defaultReadBlock, got.readBlock)
+
+	// PubSub mode validates nothing: an existing caller must not start
+	// failing construction because a Streams-only field exists.
+	got, err = resolveStreamCfg(c, Config{ReadBlock: -5 * time.Millisecond})
+	require.NoError(t, err)
+	require.Equal(t, -5*time.Millisecond, got.readBlock)
+}
+
 // An undersized pool leaves publishes waiting on a connection: a reader holds
 // one for as long as its XREAD blocks. Failing construction is much kinder
 // than presenting as mysterious publish latency later.

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -182,13 +182,19 @@ func TestUnit_StreamStats_SnapshotsEveryCounter(t *testing.T) {
 }
 
 // Stats() is the pub/sub tier's and must not grow stream fields.
+// Verify that a pub/sub-mode relay reports zero stream activity, and that
+// the pub/sub tier's Stats() method still works correctly.
 func TestUnit_StreamStats_PubSubStatsUnchanged(t *testing.T) {
 	mr := newMiniRedis(t)
 	r, err := New(newClient(t, mr), Config{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Close() })
 
-	_ = r.Stats() // must still compile and run for a pub/sub relay
+	// A pub/sub relay's StreamStats must be all zeros
 	require.Equal(t, StreamStats{}, r.StreamStats(),
 		"a pub/sub relay reports zero stream activity")
+
+	// The pub/sub tier's Stats() must also report zero values (no events have occurred)
+	require.Equal(t, Stats{}, r.Stats(),
+		"a fresh pub/sub relay has zero degraded-path activity")
 }

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -34,11 +34,40 @@ func TestUnit_Streams_ResolveDefaults(t *testing.T) {
 	require.Equal(t, 10*time.Second, got.awRetention)
 	require.Equal(t, 4, got.readers)
 	require.Equal(t, 30*time.Second, got.trimInterval)
-	require.Equal(t, 5*time.Second, got.readBlock)
+	require.Equal(t, 250*time.Millisecond, got.readBlock)
+	require.Equal(t, maxReadBlock, got.readBlock,
+		"the default must be a value the reader actually uses: it is the ceiling too")
 }
 
-// An undersized pool starves publishes: every blocking XREAD holds a pool
-// connection for its whole ReadBlock. Failing construction is much kinder
+// ReadBlock above the ceiling is REJECTED, not capped. A knob silently
+// ignored above some threshold is worse than one with a documented range —
+// and the operator who set 5s wanted something (fewer commands) that this
+// package cannot deliver without extending shutdown and activation latency
+// by the same 5s. See maxReadBlock.
+func TestUnit_Streams_RejectsReadBlockAboveMax(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	_, err := resolveStreamCfg(c, Config{Transport: Streams, ReadBlock: 5 * time.Second})
+	require.ErrorContains(t, err, "ReadBlock")
+	require.ErrorContains(t, err, "250ms", "the error must name the ceiling")
+
+	// At the ceiling exactly, and below it, are both fine.
+	for _, ok := range []time.Duration{maxReadBlock, 10 * time.Millisecond} {
+		got, err := resolveStreamCfg(c, Config{Transport: Streams, ReadBlock: ok})
+		require.NoError(t, err)
+		require.Equal(t, ok, got.readBlock, "an accepted value must be used verbatim, not capped")
+	}
+
+	// PubSub mode validates nothing: an existing caller must not start
+	// failing construction because a Streams-only field exists.
+	got, err := resolveStreamCfg(c, Config{ReadBlock: time.Hour})
+	require.NoError(t, err)
+	require.Equal(t, time.Hour, got.readBlock)
+}
+
+// An undersized pool leaves publishes waiting on a connection: a reader holds
+// one for as long as its XREAD blocks. Failing construction is much kinder
 // than presenting as mysterious publish latency later.
 func TestUnit_Streams_RejectsPoolSmallerThanReaders(t *testing.T) {
 	mr := newMiniRedis(t)

--- a/cluster/redis/streams_test.go
+++ b/cluster/redis/streams_test.go
@@ -66,6 +66,30 @@ func TestUnit_Streams_RejectsReadBlockAboveMax(t *testing.T) {
 	require.Equal(t, time.Hour, got.readBlock)
 }
 
+func TestUnit_Streams_RejectsReadBlockBelowMin(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+
+	// A sub-millisecond value truncates to BLOCK 0 in go-redis, which Redis
+	// reads as block forever. The reader would hang and Close would deadlock.
+	_, err := resolveStreamCfg(c, Config{Transport: Streams, ReadBlock: 500 * time.Microsecond})
+	require.ErrorContains(t, err, "ReadBlock")
+	require.ErrorContains(t, err, "1ms", "the error must name the floor")
+
+	// At the floor exactly, and above it, are both fine.
+	for _, ok := range []time.Duration{minReadBlock, 100 * time.Millisecond} {
+		got, err := resolveStreamCfg(c, Config{Transport: Streams, ReadBlock: ok})
+		require.NoError(t, err)
+		require.Equal(t, ok, got.readBlock, "an accepted value must be used verbatim, not adjusted")
+	}
+
+	// PubSub mode validates nothing: an existing caller must not start
+	// failing construction because a Streams-only field exists.
+	got, err := resolveStreamCfg(c, Config{ReadBlock: 100 * time.Microsecond})
+	require.NoError(t, err)
+	require.Equal(t, 100*time.Microsecond, got.readBlock)
+}
+
 // An undersized pool leaves publishes waiting on a connection: a reader holds
 // one for as long as its XREAD blocks. Failing construction is much kinder
 // than presenting as mysterious publish latency later.

--- a/cluster/redis/streams_trim.go
+++ b/cluster/redis/streams_trim.go
@@ -50,8 +50,21 @@ func (r *Relay) runTrimSweeper(ctx context.Context) {
 // trimOnce sweeps every active room's streams once.
 //
 // Only ACTIVE rooms are swept. A room nobody on this node holds is somebody
-// else's to sweep, and its entries are still bounded by the inline MAXLEN, so
-// scanning the keyspace for orphans would cost more than it saves.
+// else's to sweep while anybody holds it at all, and its ENTRIES are still
+// bounded by the inline MAXLEN, so scanning the keyspace for orphans on every
+// sweep would cost more than it saves.
+//
+// KNOWN LIMITATION, stated plainly because the trim story reads as complete
+// without it: MAXLEN and MINID bound the SIZE of each stream, not the NUMBER
+// of streams. Nothing in this package ever sets an EXPIRE, and a room that has
+// gone idle on every node in the cluster is active nowhere, so it is swept
+// nowhere — its two stream keys keep whatever they last held, for as long as
+// the Redis instance lives. Redis memory therefore grows with the number of
+// DISTINCT ROOMS EVER PUBLISHED TO, not with the number concurrently active,
+// and operators must size for the former. An EXPIRE-based reclaim on each
+// XADD (so an untouched key falls out on its own, with no keyspace scan and
+// nothing to coordinate between nodes) is the intended fix and is tracked as a
+// follow-up issue; docs/CLUSTERING.md says the same in the cost model.
 //
 // The room list is copied out under streamMu and the lock released before any
 // Redis call — streamMu must never be held across I/O (see its doc on

--- a/cluster/redis/streams_trim.go
+++ b/cluster/redis/streams_trim.go
@@ -21,28 +21,17 @@ type trimTarget struct {
 	minID string
 }
 
-// runTrimSweeper enforces the age half of the delivery guarantee.
-//
-// Both strategies are required. Inline MAXLEN on XADD (see publishStream) is
-// a memory ceiling with no age bound — a hot room's 4096 entries might be two
-// seconds. MINID is an age bound with no memory ceiling. The honest window is
-// therefore min(StreamRetention, StreamMaxLen/rate), which is what the docs
-// state.
+// runTrimSweeper enforces the age half of the delivery guarantee. Both
+// strategies are required: inline MAXLEN on XADD (see publishStream) is a
+// memory ceiling with no age bound — a hot room's 4096 entries might be two
+// seconds — and MINID is an age bound with no memory ceiling, so the honest
+// window is min(StreamRetention, StreamMaxLen/rate), as the docs state.
 //
 // The select watches r.done as well as ctx.Done(), matching runPublisher and
-// runSubscriber rather than the stream readers' derived streamReadCtx. The
-// readers need that derived context because a blocked XREAD cannot be
-// interrupted by cancellation at all (go-redis arms the socket deadline from
-// ctx.Deadline(), never watches ctx.Done() mid-read — see maxReadBlock), so
-// they need the r.done→cancel forwarding streamReadCtx provides. A
-// time.Ticker has no such blind spot: selecting on r.done directly ends the
-// loop the instant Close fires, with no forwarding goroutine required. ctx
-// ordinarily OUTLIVES the relay (Server cancels relayCtx only after Close
-// returns — see streamReadCtx's doc), so a sweeper that watched only
-// ctx.Done() would still be running when Close calls r.wg.Wait(), and would
-// not exit until the caller cancels ctx afterwards — which for Server never
-// happens before Close returns. That is a shutdown deadlock of the exact
-// shape #202/#229 already fixed twice for other goroutines in this package.
+// runSubscriber rather than the readers' derived streamReadCtx: a ticker has no
+// uninterruptible read to be woken out of. Watching ctx.Done() alone would
+// deadlock Close, ctx ordinarily OUTLIVING the relay (see streamReadCtx) — the
+// shape #202/#229 already fixed twice here.
 func (r *Relay) runTrimSweeper(ctx context.Context) {
 	defer r.wg.Done()
 	t := time.NewTicker(r.scfg.trimInterval)
@@ -63,28 +52,23 @@ func (r *Relay) runTrimSweeper(ctx context.Context) {
 
 // trimOnce sweeps every active room's streams once.
 //
-// Only ACTIVE rooms are swept. A room nobody on this node holds is somebody
-// else's to sweep while anybody holds it at all, and its ENTRIES are still
-// bounded by the inline MAXLEN, so scanning the keyspace for orphans on every
-// sweep would cost more than it saves.
+// Only ACTIVE rooms are swept: a room nobody here holds is somebody else's to
+// sweep while anybody holds it, and its entries are still bounded by the inline
+// MAXLEN, so scanning the keyspace for orphans every sweep would cost more than
+// it saves.
 //
 // KNOWN LIMITATION, stated plainly because the trim story reads as complete
-// without it: MAXLEN and MINID bound the SIZE of each stream, not the NUMBER
-// of streams. Nothing in this package ever sets an EXPIRE, and a room that has
-// gone idle on every node in the cluster is active nowhere, so it is swept
-// nowhere — its two stream keys keep whatever they last held, for as long as
+// without it: MAXLEN and MINID bound the SIZE of each stream, not the NUMBER of
+// streams. Nothing here ever sets an EXPIRE, and a room idle on every node is
+// swept nowhere, so its two keys keep whatever they last held for as long as
 // the Redis instance lives. Redis memory therefore grows with the number of
-// DISTINCT ROOMS EVER PUBLISHED TO, not with the number concurrently active,
-// and operators must size for the former. An EXPIRE-based reclaim on each
-// XADD (so an untouched key falls out on its own, with no keyspace scan and
-// nothing to coordinate between nodes) is the intended fix and is tracked as a
-// follow-up (#248); docs/CLUSTERING.md says the same in the cost model.
+// DISTINCT ROOMS EVER PUBLISHED TO, not the number concurrently active, and
+// operators must size for the former. An EXPIRE-based reclaim on each XADD is
+// the intended fix (#248); docs/CLUSTERING.md's cost model says the same.
 //
 // The room list is copied out under streamMu and the lock released before any
-// Redis call — streamMu must never be held across I/O (see its doc on
-// Relay), and a sweep of thousands of rooms would otherwise pin the lock for
-// the length of that many round trips, blocking RoomActivated/RoomDeactivated
-// bookkeeping on every other room for the whole sweep.
+// Redis call: streamMu must never be held across I/O, and a sweep of thousands
+// of rooms would otherwise pin it for that many round trips.
 func (r *Relay) trimOnce(ctx context.Context) error {
 	r.streamMu.Lock()
 	rooms := make([]string, 0, len(r.streamRooms))
@@ -99,13 +83,12 @@ func (r *Relay) trimOnce(ctx context.Context) error {
 		return nil
 	}
 
-	// The cutoff must come from the clock that MINTED the ids: XADD * takes
-	// its milliseconds from the Redis server, so a cutoff read off an app host
+	// The cutoff must come from the clock that MINTED the ids: XADD * takes its
+	// milliseconds from the Redis server, so a cutoff read off an app host
 	// running ahead deletes entries still inside the window — and the streams
 	// are shared, so one skewed node shrinks it for every node. One TIME per
-	// sweep, because the drift a sweep's own duration adds is bounded by that
-	// duration while host skew is not bounded at all; a failed TIME skips the
-	// sweep, since trimming nothing only costs memory until the next tick.
+	// sweep, because a sweep's own drift is bounded by its duration where host
+	// skew is not; a failed TIME skips the sweep, costing only memory.
 	now, err := r.client.Time(ctx).Result()
 	if err != nil {
 		return fmt.Errorf("TIME: %w", err)
@@ -137,14 +120,13 @@ func minIDAt(cutoff time.Time) string {
 }
 
 // trimChunk issues one pipelined round trip of XTRIMs and counts what they
-// removed. A failing key is logged and the rest still go: aborting would leave
-// every key behind it untrimmed until the next tick, and one log line per
-// chunk rather than per key because a broken connection fails all of them
-// alike.
+// removed. A failing key is logged and the rest still go, since aborting would
+// leave every key behind it untrimmed until the next tick; one log line per
+// chunk, because a broken connection fails all of them alike.
 //
-// A key that does not exist yet (a room activated but never published to)
-// trims zero entries rather than erroring — XTRIM MINID on a missing key
-// returns 0 in both Redis and miniredis.
+// A key that does not exist yet (a room activated but never published to) trims
+// zero rather than erroring — XTRIM MINID on a missing key returns 0 in both
+// Redis and miniredis.
 func (r *Relay) trimChunk(ctx context.Context, targets []trimTarget) {
 	cmds := make([]*goredis.IntCmd, len(targets))
 	_, _ = r.client.Pipelined(ctx, func(p goredis.Pipeliner) error {

--- a/cluster/redis/streams_trim.go
+++ b/cluster/redis/streams_trim.go
@@ -1,0 +1,103 @@
+// Package-internal: the Redis Streams delivery tier. See Config.Transport.
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// runTrimSweeper enforces the age half of the delivery guarantee.
+//
+// Both strategies are required. Inline MAXLEN on XADD (see publishStream) is
+// a memory ceiling with no age bound — a hot room's 4096 entries might be two
+// seconds. MINID is an age bound with no memory ceiling. The honest window is
+// therefore min(StreamRetention, StreamMaxLen/rate), which is what the docs
+// state.
+//
+// The select watches r.done as well as ctx.Done(), matching runPublisher and
+// runSubscriber rather than the stream readers' derived streamReadCtx. The
+// readers need that derived context because a blocked XREAD cannot be
+// interrupted by cancellation at all (go-redis arms the socket deadline from
+// ctx.Deadline(), never watches ctx.Done() mid-read — see maxReadBlock), so
+// they need the r.done→cancel forwarding streamReadCtx provides. A
+// time.Ticker has no such blind spot: selecting on r.done directly ends the
+// loop the instant Close fires, with no forwarding goroutine required. ctx
+// ordinarily OUTLIVES the relay (Server cancels relayCtx only after Close
+// returns — see streamReadCtx's doc), so a sweeper that watched only
+// ctx.Done() would still be running when Close calls r.wg.Wait(), and would
+// not exit until the caller cancels ctx afterwards — which for Server never
+// happens before Close returns. That is a shutdown deadlock of the exact
+// shape #202/#229 already fixed twice for other goroutines in this package.
+func (r *Relay) runTrimSweeper(ctx context.Context) {
+	defer r.wg.Done()
+	t := time.NewTicker(r.scfg.trimInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-r.done:
+			return
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := r.trimOnce(ctx); err != nil && ctx.Err() == nil {
+				r.log.Warn("cluster/redis: stream trim failed", "err", err)
+			}
+		}
+	}
+}
+
+// trimOnce sweeps every active room's streams once.
+//
+// Only ACTIVE rooms are swept. A room nobody on this node holds is somebody
+// else's to sweep, and its entries are still bounded by the inline MAXLEN, so
+// scanning the keyspace for orphans would cost more than it saves.
+//
+// The room list is copied out under streamMu and the lock released before any
+// Redis call — streamMu must never be held across I/O (see its doc on
+// Relay), and a sweep of thousands of rooms would otherwise pin the lock for
+// the length of that many round trips, blocking RoomActivated/RoomDeactivated
+// bookkeeping on every other room for the whole sweep.
+func (r *Relay) trimOnce(ctx context.Context) error {
+	r.streamMu.Lock()
+	rooms := make([]string, 0, len(r.streamRooms))
+	for room, n := range r.streamRooms {
+		if n > 0 {
+			rooms = append(rooms, room)
+		}
+	}
+	r.streamMu.Unlock()
+
+	now := time.Now()
+	for _, room := range rooms {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := r.trimKey(ctx, r.scfg.syncKey(room), now.Add(-r.scfg.retention)); err != nil {
+			return err
+		}
+		if err := r.trimKey(ctx, r.scfg.awKey(room), now.Add(-r.scfg.awRetention)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// trimKey removes entries older than cutoff from one stream.
+//
+// Stream IDs are milliseconds-sequence, so the cutoff is expressed as
+// "<unix-millis>-0": every entry with a smaller ID is older than the window.
+// A key that does not exist yet (a room activated but never published to)
+// trims zero entries rather than erroring — XTRIM MINID on a missing key
+// returns 0 in both Redis and miniredis.
+func (r *Relay) trimKey(ctx context.Context, key string, cutoff time.Time) error {
+	minID := fmt.Sprintf("%d-0", cutoff.UnixMilli())
+	n, err := r.client.XTrimMinID(ctx, key, minID).Result()
+	if err != nil {
+		return fmt.Errorf("XTRIM MINID %s %s: %w", key, minID, err)
+	}
+	if n > 0 {
+		r.trimmed.Add(uint64(n)) //nolint:gosec // XTRIM returns a non-negative count
+	}
+	return nil
+}

--- a/cluster/redis/streams_trim.go
+++ b/cluster/redis/streams_trim.go
@@ -5,7 +5,21 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	goredis "github.com/redis/go-redis/v9"
 )
+
+// trimBatch is how many XTRIMs go into one pipelined round trip. Sequentially
+// the 10k-room target is 20k round trips per sweep, which cannot finish inside
+// TrimInterval at any realistic latency; 256 bounds one command's reply and
+// keeps the ctx check frequent.
+const trimBatch = 256
+
+// trimTarget is one key and the MINID cutoff for its kind.
+type trimTarget struct {
+	key   string
+	minID string
+}
 
 // runTrimSweeper enforces the age half of the delivery guarantee.
 //
@@ -81,36 +95,81 @@ func (r *Relay) trimOnce(ctx context.Context) error {
 	}
 	r.streamMu.Unlock()
 
-	now := time.Now()
+	if len(rooms) == 0 {
+		return nil
+	}
+
+	// The cutoff must come from the clock that MINTED the ids: XADD * takes
+	// its milliseconds from the Redis server, so a cutoff read off an app host
+	// running ahead deletes entries still inside the window — and the streams
+	// are shared, so one skewed node shrinks it for every node. One TIME per
+	// sweep, because the drift a sweep's own duration adds is bounded by that
+	// duration while host skew is not bounded at all; a failed TIME skips the
+	// sweep, since trimming nothing only costs memory until the next tick.
+	now, err := r.client.Time(ctx).Result()
+	if err != nil {
+		return fmt.Errorf("TIME: %w", err)
+	}
+	syncMinID := minIDAt(now.Add(-r.scfg.retention))
+	awMinID := minIDAt(now.Add(-r.scfg.awRetention))
+
+	targets := make([]trimTarget, 0, len(rooms)*streamsPerRoom)
 	for _, room := range rooms {
+		targets = append(targets,
+			trimTarget{key: r.scfg.syncKey(room), minID: syncMinID},
+			trimTarget{key: r.scfg.awKey(room), minID: awMinID},
+		)
+	}
+	for start := 0; start < len(targets); start += trimBatch {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := r.trimKey(ctx, r.scfg.syncKey(room), now.Add(-r.scfg.retention)); err != nil {
-			return err
-		}
-		if err := r.trimKey(ctx, r.scfg.awKey(room), now.Add(-r.scfg.awRetention)); err != nil {
-			return err
-		}
+		r.trimChunk(ctx, targets[start:min(start+trimBatch, len(targets))])
 	}
 	return nil
 }
 
-// trimKey removes entries older than cutoff from one stream.
+// minIDAt renders a cutoff as an XTRIM MINID argument. Stream IDs are
+// milliseconds-sequence, so every entry with a smaller id is older than the
+// window.
+func minIDAt(cutoff time.Time) string {
+	return fmt.Sprintf("%d-0", cutoff.UnixMilli())
+}
+
+// trimChunk issues one pipelined round trip of XTRIMs and counts what they
+// removed. A failing key is logged and the rest still go: aborting would leave
+// every key behind it untrimmed until the next tick, and one log line per
+// chunk rather than per key because a broken connection fails all of them
+// alike.
 //
-// Stream IDs are milliseconds-sequence, so the cutoff is expressed as
-// "<unix-millis>-0": every entry with a smaller ID is older than the window.
 // A key that does not exist yet (a room activated but never published to)
 // trims zero entries rather than erroring — XTRIM MINID on a missing key
 // returns 0 in both Redis and miniredis.
-func (r *Relay) trimKey(ctx context.Context, key string, cutoff time.Time) error {
-	minID := fmt.Sprintf("%d-0", cutoff.UnixMilli())
-	n, err := r.client.XTrimMinID(ctx, key, minID).Result()
-	if err != nil {
-		return fmt.Errorf("XTRIM MINID %s %s: %w", key, minID, err)
+func (r *Relay) trimChunk(ctx context.Context, targets []trimTarget) {
+	cmds := make([]*goredis.IntCmd, len(targets))
+	_, _ = r.client.Pipelined(ctx, func(p goredis.Pipeliner) error {
+		for i, t := range targets {
+			cmds[i] = p.XTrimMinID(ctx, t.key, t.minID)
+		}
+		return nil
+	})
+
+	failed := 0
+	var first error
+	for i, cmd := range cmds {
+		n, err := cmd.Result()
+		if err != nil {
+			if failed == 0 {
+				first = fmt.Errorf("XTRIM MINID %s %s: %w", targets[i].key, targets[i].minID, err)
+			}
+			failed++
+			continue
+		}
+		if n > 0 {
+			r.trimmed.Add(uint64(n)) //nolint:gosec // XTRIM returns a non-negative count
+		}
 	}
-	if n > 0 {
-		r.trimmed.Add(uint64(n)) //nolint:gosec // XTRIM returns a non-negative count
+	if failed > 0 && ctx.Err() == nil {
+		r.log.Warn("cluster/redis: stream trim failed", "keys", failed, "err", first)
 	}
-	return nil
 }

--- a/cluster/redis/streams_trim.go
+++ b/cluster/redis/streams_trim.go
@@ -64,7 +64,7 @@ func (r *Relay) runTrimSweeper(ctx context.Context) {
 // and operators must size for the former. An EXPIRE-based reclaim on each
 // XADD (so an untouched key falls out on its own, with no keyspace scan and
 // nothing to coordinate between nodes) is the intended fix and is tracked as a
-// follow-up issue; docs/CLUSTERING.md says the same in the cost model.
+// follow-up (#248); docs/CLUSTERING.md says the same in the cost model.
 //
 // The room list is copied out under streamMu and the lock released before any
 // Redis call — streamMu must never be held across I/O (see its doc on

--- a/cluster/redis/streams_trim_test.go
+++ b/cluster/redis/streams_trim_test.go
@@ -1,0 +1,203 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/reearth/ygo/cluster"
+)
+
+// r.Start is required in every test below that calls RoomActivated, even
+// though the task-9 brief's version omitted it: RoomActivated returns
+// immediately when !r.started.Load(), before it ever touches streamRooms —
+// so without Start, streamRooms stays empty, trimOnce finds no rooms, and
+// these tests would pass vacuously (or fail outright) regardless of whether
+// trimOnce is correct. Same class of gap already documented in
+// streams_reader_test.go's TestUnit_StreamReader_ActivationRefcounts.
+//
+// These tests also do NOT use miniredis's mr.FastForward to simulate aged
+// entries, unlike the brief's version. FastForward only decreases TTLs
+// (miniredis's db.fastForward walks expiring keys) — it does not move
+// miniredis's own now() used by XADD's "*" auto-ID, which stays real
+// time.Now() unless a test calls the separate mr.SetTime. trimOnce's cutoff
+// is computed from real time.Now() too (see streams_trim.go), entirely on
+// the Go client side — XTRIM MINID takes an explicit ID and does not consult
+// any server-side clock at all. So mr.FastForward has NO effect on whether
+// an entry looks old to either side of this mechanism: an entry published a
+// few microseconds before trimOnce runs is still only a few microseconds
+// old by real time, FastForward or not, and the brief's tests would have
+// failed to observe any trimming at all. Real time.Sleep — already this
+// package's established idiom (see e.g. streams_reader_test.go,
+// internal_test.go, redis_test.go; grep finds no existing use of
+// FastForward anywhere in this package) — is what actually ages an entry,
+// so retention/AwarenessRetention below are set small enough to keep that
+// fast.
+
+// MAXLEN alone gives no age bound — a hot room's 4096 entries might be two
+// seconds. The MINID sweeper is the time half of the guarantee.
+func TestUnit_StreamTrim_RemovesEntriesOlderThanRetention(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:       Streams,
+		StreamRetention: 100 * time.Millisecond,
+		TrimInterval:    50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1")
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("old"),
+	}))
+	require.Len(t, streamEntries(t, mr, r.scfg.syncKey("room1")), 1)
+
+	time.Sleep(150 * time.Millisecond) // past StreamRetention, by real wall-clock time
+	require.NoError(t, r.trimOnce(context.Background()))
+
+	require.Empty(t, streamEntries(t, mr, r.scfg.syncKey("room1")),
+		"an entry older than StreamRetention must be swept")
+	require.Positive(t, r.StreamStats().Trimmed)
+}
+
+// The guarantee direction: entries INSIDE the window must survive. This is
+// asserted as a lower bound deliberately — miniredis ignores the ~/= trim
+// modifiers and trims exactly, while real Redis with MAXLEN ~ may retain MORE
+// than the cap. Approximate trimming never keeps FEWER entries than asked, so
+// a lower-bound assertion holds on both, while a tight upper bound would pass
+// here and fail against real Redis. (This test doesn't touch MAXLEN at all —
+// it exercises the MINID sweeper only — but the same asymmetry argument
+// applies: asserting "at least" is the only direction that is safe against
+// approximation on either axis of this tier.)
+func TestUnit_StreamTrim_KeepsEntriesInsideTheWindow(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:       Streams,
+		StreamRetention: time.Hour,
+		TrimInterval:    time.Minute,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1")
+	for i := 0; i < 10; i++ {
+		require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+			Room: "room1", Kind: cluster.KindSync, Data: []byte("fresh"),
+		}))
+	}
+	require.NoError(t, r.trimOnce(context.Background()))
+
+	require.GreaterOrEqual(t, len(streamEntries(t, mr, r.scfg.syncKey("room1"))), 10,
+		"nothing inside the retention window may be swept")
+}
+
+// The awareness stream has its own, shorter retention.
+func TestUnit_StreamTrim_AwarenessUsesItsOwnRetention(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:          Streams,
+		StreamRetention:    time.Hour,
+		TrimInterval:       time.Minute,
+		AwarenessRetention: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1")
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("presence"),
+	}))
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("edit"),
+	}))
+
+	time.Sleep(150 * time.Millisecond) // past AwarenessRetention, well inside StreamRetention
+	require.NoError(t, r.trimOnce(context.Background()))
+
+	require.Empty(t, streamEntries(t, mr, r.scfg.awKey("room1")),
+		"awareness must be swept on AwarenessRetention, not StreamRetention")
+	require.Len(t, streamEntries(t, mr, r.scfg.syncKey("room1")), 1,
+		"the sync stream's 1-hour retention must not be affected by the awareness sweep")
+}
+
+// Close must not hang with the sweeper running. runTrimSweeper's select
+// watches r.done directly, the same way runPublisher/runSubscriber do — NOT
+// only ctx.Done(), which is what the task-9 brief's version of this file
+// did. ctx here is context.Background(), which is never cancelled (matching
+// the ordinary case documented on streamReadCtx: ctx usually outlives the
+// relay), so a sweeper gated on ctx.Done() alone would never observe Close
+// at all, and Close's r.wg.Wait() would block forever. Verified by mutation:
+// dropping the "case <-r.done: return" arm reproduces exactly that hang
+// (Close does not return within a bounded wait).
+func TestUnit_StreamTrim_CloseDoesNotHang(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:    Streams,
+		TrimInterval: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+	r.RoomActivated("room1")
+
+	time.Sleep(50 * time.Millisecond) // let the sweeper tick at least once
+
+	start := time.Now()
+	require.NoError(t, r.Close())
+	require.Less(t, time.Since(start), time.Second,
+		"Close must not stall on the trim sweeper: its select must watch r.done, not only ctx.Done()")
+}
+
+func TestUnit_StreamTrim_NoRoomsIsANoOp(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{Transport: Streams})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	require.NoError(t, r.trimOnce(context.Background()))
+	require.Zero(t, r.StreamStats().Trimmed)
+}
+
+// A room with a stream reference count of zero left lingering in the map (see
+// RoomActivated/RoomDeactivated's use of streamRooms as a refcount, not a
+// set) must not be swept: it is not active, and the zero-count branch is
+// filtered by "if n > 0" in trimOnce, not by the map simply lacking the key.
+// This distinguishes trimOnce's room selection from "every key in
+// streamRooms" — a mutation that dropped the n > 0 guard would still pass
+// every test above, because RoomDeactivated always DELETES a room whose
+// count reaches zero (see redis.go) rather than leaving a zero entry behind.
+// This test manufactures the zero-count case directly, bypassing
+// RoomDeactivated's delete, to cover the guard on its own.
+func TestUnit_StreamTrim_ZeroRefcountRoomIsSkipped(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:       Streams,
+		StreamRetention: 100 * time.Millisecond,
+		TrimInterval:    50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+
+	r.RoomActivated("room1")
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("old"),
+	}))
+
+	// Force the refcount to zero without going through RoomDeactivated's
+	// delete, so the map entry survives with n == 0.
+	r.streamMu.Lock()
+	r.streamRooms["room1"] = 0
+	r.streamMu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+	require.NoError(t, r.trimOnce(context.Background()))
+
+	require.Len(t, streamEntries(t, mr, r.scfg.syncKey("room1")), 1,
+		"a room with a zero refcount must not be swept even though it is still a map key")
+	require.Zero(t, r.StreamStats().Trimmed)
+}

--- a/cluster/redis/streams_trim_test.go
+++ b/cluster/redis/streams_trim_test.go
@@ -2,9 +2,11 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
 	"github.com/reearth/ygo/cluster"
@@ -199,5 +201,165 @@ func TestUnit_StreamTrim_ZeroRefcountRoomIsSkipped(t *testing.T) {
 
 	require.Len(t, streamEntries(t, mr, r.scfg.syncKey("room1")), 1,
 		"a room with a zero refcount must not be swept even though it is still a map key")
+	require.Zero(t, r.StreamStats().Trimmed)
+}
+
+// The cutoff must be minted by the same clock as the ids it is compared
+// against. XADD * takes its milliseconds from the REDIS server, so a cutoff
+// read off the application host sweeps entries still inside the window
+// whenever that host's clock runs ahead — and because the streams are shared,
+// one skewed node shrinks the advertised window for every node.
+//
+// miniredis's own clock drives both XADD's auto-id and TIME (effectiveNow),
+// so SetTime makes the two clocks disagree the way a real deployment's do.
+// Verified by mutation: computing the cutoff from time.Now() again sweeps the
+// whole stream here, because a local cutoff sits two hours past every id.
+func TestUnit_StreamTrim_CutoffComesFromTheServerClock(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:       Streams,
+		StreamRetention: time.Minute,
+		TrimInterval:    30 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+	r.RoomActivated("room1")
+
+	base := time.Now().Add(-2 * time.Hour)
+	mr.SetTime(base)
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("aged"),
+	}))
+
+	// Two retention windows later ON THE SERVER CLOCK: "aged" is now outside
+	// the window and "fresh" is inside it, with no sleeping.
+	mr.SetTime(base.Add(2 * time.Minute))
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindSync, Data: []byte("fresh"),
+	}))
+
+	require.NoError(t, r.trimOnce(context.Background()))
+
+	entries := streamEntries(t, mr, r.scfg.syncKey("room1"))
+	require.Len(t, entries, 1,
+		"an entry inside the server-clock window must survive: a cutoff from this host's clock would be two hours past every id and sweep the stream")
+	require.Equal(t, "fresh", entryValues(entries[0])[fieldData],
+		"and the entry that survived must be the recent one, not merely some entry")
+	require.Equal(t, uint64(1), r.StreamStats().Trimmed)
+}
+
+// The sweep must not cost one round trip per key. At the 10k-room target a
+// sequential sweep is 20k round trips, which cannot finish inside
+// TrimInterval — so neither the age bound nor the memory model would hold.
+//
+// Round trips are counted from the connection pool, not from wall-clock time
+// (a race on a loaded machine) and not from the command count (which a
+// pipeline does not change): every command takes one pool connection for its
+// round trip, while one pipeline takes one for the whole chunk.
+func TestUnit_StreamTrim_SweepIsPipelined(t *testing.T) {
+	mr := newMiniRedis(t)
+	c := newClient(t, mr)
+	r, err := New(c, Config{
+		Transport:       Streams,
+		StreamRetention: time.Minute,
+		TrimInterval:    30 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	// Deliberately NOT Started: the reader goroutines Start launches issue
+	// their own XREADs on the same pool, which would make both counts below a
+	// race. streamRooms is what trimOnce reads, so it is populated directly.
+	const rooms = 300 // 600 keys: more than trimBatch, so chunking is exercised
+	r.streamMu.Lock()
+	for i := 0; i < rooms; i++ {
+		r.streamRooms[fmt.Sprintf("room-%d", i)] = 1
+	}
+	r.streamMu.Unlock()
+
+	// Warm the pool: go-redis runs a handshake (HELLO, CLIENT SETINFO) on
+	// every new connection, and those commands would land inside the window
+	// measured below.
+	require.NoError(t, c.Ping(context.Background()).Err())
+
+	beforeCmds := mr.CommandCount()
+	before := c.PoolStats()
+	require.NoError(t, r.trimOnce(context.Background()))
+	after := c.PoolStats()
+
+	// One TIME plus every key's XTRIM: pipelining saves round trips, not
+	// commands, so this is also the sequential count.
+	require.Equal(t, 1+rooms*streamsPerRoom, mr.CommandCount()-beforeCmds,
+		"every active room's two streams must be swept, on one TIME per sweep")
+
+	trips := (after.Hits + after.Misses) - (before.Hits + before.Misses)
+	chunks := (rooms*streamsPerRoom + trimBatch - 1) / trimBatch
+	require.LessOrEqual(t, int(trips), 1+chunks,
+		"600 XTRIMs must go in %d pipelined round trips (plus TIME), not 600", chunks)
+}
+
+// A failing XTRIM is logged and the sweep goes on: aborting would leave every
+// key after it untrimmed until the next tick, and Trimmed must still count
+// what actually went.
+//
+// The BROKEN key is the room's sync key, which trimOnce queues first, so the
+// surviving awareness sweep behind it is only reached by a chunk that carries
+// on past a failure.
+func TestUnit_StreamTrim_ChunkFailureDoesNotAbortTheSweep(t *testing.T) {
+	mr := newMiniRedis(t)
+	r, err := New(newClient(t, mr), Config{
+		Transport:       Streams,
+		StreamRetention: time.Minute,
+		TrimInterval:    30 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, r.Start(context.Background(), &countingSink{}))
+	r.RoomActivated("room1")
+
+	base := time.Now().Add(-2 * time.Hour)
+	mr.SetTime(base)
+	require.NoError(t, r.publishStream(context.Background(), cluster.Outbound{
+		Room: "room1", Kind: cluster.KindAwareness, Data: []byte("aged"),
+	}))
+	mr.SetTime(base.Add(2 * time.Minute)) // past AwarenessRetention on the server clock
+
+	// A key of the wrong TYPE fails its own XTRIM and nothing else.
+	require.NoError(t, mr.Set(r.scfg.syncKey("room1"), "not-a-stream"))
+
+	require.NoError(t, r.trimOnce(context.Background()),
+		"one failed key must not fail the sweep")
+	require.Empty(t, streamEntries(t, mr, r.scfg.awKey("room1")),
+		"the healthy key queued behind the failing one must still be swept")
+	require.Equal(t, uint64(1), r.StreamStats().Trimmed,
+		"Trimmed must count what actually went, and only that")
+}
+
+// A failed TIME skips the sweep rather than falling back to this host's clock.
+// Trimming nothing costs memory until the next tick; trimming on a cutoff from
+// the wrong clock deletes live entries.
+func TestUnit_StreamTrim_TimeFailureSkipsTheSweep(t *testing.T) {
+	mr := newMiniRedis(t)
+	// MaxRetries: -1 so the dial against the closed server fails at once
+	// instead of spending the default backoff schedule on it.
+	c := goredis.NewClient(&goredis.Options{Addr: mr.Addr(), MaxRetries: -1})
+	t.Cleanup(func() { _ = c.Close() })
+	r, err := New(c, Config{
+		Transport:       Streams,
+		StreamRetention: time.Minute,
+		TrimInterval:    30 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	r.streamMu.Lock()
+	r.streamRooms["room1"] = 1
+	r.streamMu.Unlock()
+
+	mr.Close() // every command now fails, TIME first
+
+	require.ErrorContains(t, r.trimOnce(context.Background()), "TIME",
+		"the sweep must abandon on the clock rather than proceed on a local cutoff")
 	require.Zero(t, r.StreamStats().Trimmed)
 }

--- a/cluster/redis/streams_trim_test.go
+++ b/cluster/redis/streams_trim_test.go
@@ -12,31 +12,18 @@ import (
 	"github.com/reearth/ygo/cluster"
 )
 
-// r.Start is required in every test below that calls RoomActivated, even
-// though the task-9 brief's version omitted it: RoomActivated returns
-// immediately when !r.started.Load(), before it ever touches streamRooms —
-// so without Start, streamRooms stays empty, trimOnce finds no rooms, and
-// these tests would pass vacuously (or fail outright) regardless of whether
-// trimOnce is correct. Same class of gap already documented in
-// streams_reader_test.go's TestUnit_StreamReader_ActivationRefcounts.
+// r.Start is REQUIRED in every test below that calls RoomActivated:
+// RoomActivated returns immediately when !r.started.Load(), before it ever
+// touches streamRooms, so without it trimOnce finds no rooms and these tests
+// pass vacuously.
 //
-// These tests also do NOT use miniredis's mr.FastForward to simulate aged
-// entries, unlike the brief's version. FastForward only decreases TTLs
-// (miniredis's db.fastForward walks expiring keys) — it does not move
-// miniredis's own now() used by XADD's "*" auto-ID, which stays real
-// time.Now() unless a test calls the separate mr.SetTime. trimOnce's cutoff
-// is computed from real time.Now() too (see streams_trim.go), entirely on
-// the Go client side — XTRIM MINID takes an explicit ID and does not consult
-// any server-side clock at all. So mr.FastForward has NO effect on whether
-// an entry looks old to either side of this mechanism: an entry published a
-// few microseconds before trimOnce runs is still only a few microseconds
-// old by real time, FastForward or not, and the brief's tests would have
-// failed to observe any trimming at all. Real time.Sleep — already this
-// package's established idiom (see e.g. streams_reader_test.go,
-// internal_test.go, redis_test.go; grep finds no existing use of
-// FastForward anywhere in this package) — is what actually ages an entry,
-// so retention/AwarenessRetention below are set small enough to keep that
-// fast.
+// These tests do NOT use miniredis's mr.FastForward to age entries.
+// FastForward only decreases TTLs (db.fastForward walks expiring keys); it
+// moves neither miniredis's now() behind XADD's "*" auto-ID nor its TIME reply
+// — both stay real time.Now() unless a test calls mr.SetTime. Since trimOnce's
+// cutoff comes from TIME and the ids come from that same clock, FastForward has
+// no effect on whether an entry looks old to either side. Real time.Sleep ages
+// it, so retention/AwarenessRetention below are small enough to stay fast.
 
 // MAXLEN alone gives no age bound — a hot room's 4096 entries might be two
 // seconds. The MINID sweeper is the time half of the guarantee.
@@ -128,13 +115,12 @@ func TestUnit_StreamTrim_AwarenessUsesItsOwnRetention(t *testing.T) {
 }
 
 // Close must not hang with the sweeper running. runTrimSweeper's select
-// watches r.done directly, the same way runPublisher/runSubscriber do — NOT
-// only ctx.Done(), which is what the task-9 brief's version of this file
-// did. ctx here is context.Background(), which is never cancelled (matching
-// the ordinary case documented on streamReadCtx: ctx usually outlives the
-// relay), so a sweeper gated on ctx.Done() alone would never observe Close
-// at all, and Close's r.wg.Wait() would block forever. Verified by mutation:
-// dropping the "case <-r.done: return" arm reproduces exactly that hang
+// watches r.done directly, the same way runPublisher/runSubscriber do, NOT
+// only ctx.Done(). ctx here is context.Background(), which is never cancelled
+// (the ordinary case documented on streamReadCtx: ctx usually outlives the
+// relay), so a sweeper gated on ctx.Done() alone would never observe Close and
+// Close's r.wg.Wait() would block forever. Verified by mutation: dropping the
+// "case <-r.done: return" arm reproduces exactly that hang
 // (Close does not return within a bounded wait).
 func TestUnit_StreamTrim_CloseDoesNotHang(t *testing.T) {
 	mr := newMiniRedis(t)

--- a/cluster/redis/worker.go
+++ b/cluster/redis/worker.go
@@ -18,6 +18,42 @@ type roomWorker struct {
 	room string
 	lane *relaylane.Lane
 	done chan struct{} // closed to stop this worker
+
+	// awCursor is the last awareness stream ID the stream reader delivered
+	// FOR THIS RESIDENCY, or "" when it has delivered none yet (read the
+	// stream from its tail — see tailID).
+	//
+	// It lives on the worker rather than in Relay.cursors, and that placement
+	// IS the mechanism behind this package's cursor-retention rule. The two
+	// kinds of cursor need opposite retention across a room's
+	// deactivate/reactivate cycle, because they start from opposite defaults
+	// when they are missing:
+	//
+	//   - A SYNC cursor MUST survive the cycle. Its default is the oldest
+	//     retained entry, so forgetting it would make ordinary room churn —
+	//     the websocket provider evicts and reloads idle rooms continuously
+	//     (#183) — replay the room's whole retention window on every
+	//     reactivation, the condition StreamStats.Replayed exists to alarm
+	//     on. Sync cursors therefore live in the relay-scoped Relay.cursors
+	//     map and deliberately outlive any single residency.
+	//   - An AWARENESS cursor MUST NOT survive it. Its default is the tail,
+	//     so keeping it would resume a reactivated room mid-presence-stream
+	//     and replay up to AwarenessMaxLen blobs for whoever occupied the
+	//     room last time, resurrecting clients that are long gone.
+	//
+	// Deleting an awareness cursor from a relay-scoped map at deactivation
+	// cannot deliver the second rule, only narrow it: a reader builds its
+	// XREAD id vector before that delete and applies the response after it,
+	// so it writes the cursor straight back, and the next residency then
+	// resumes from it. Scoping the cursor to the worker resets it by
+	// construction instead — a new residency is a NEW worker, whose cursor is
+	// empty and which no earlier residency's reader can reach — so there is
+	// no ordering left for a reset to lose. See awarenessCursor and
+	// deliverAwareness for the fence that extends that to the payloads.
+	//
+	// Guarded by workersMu, the same lock that publishes the map entry
+	// through which this field is reachable at all.
+	awCursor string
 }
 
 // workerFor returns the worker for room, creating and starting it if needed.
@@ -181,6 +217,77 @@ func (r *Relay) workerForInbound(room string) (w *roomWorker, ok bool) {
 	w, ok = r.workers[room]
 	r.workersMu.Unlock()
 	return w, ok
+}
+
+// awarenessCursor resolves a room's residency together with the awareness
+// stream ID to read from, in ONE workersMu hold so the pair cannot be torn.
+//
+// The returned worker is a fence TOKEN, not a delivery handle: readBatch
+// carries it on the streamTarget and deliverAwareness accepts the response
+// only while that same worker is still the room's residency. Nothing is
+// pushed through it here.
+//
+// A nil worker — the room is assigned to a reader but has no worker yet,
+// which is RoomActivated's own increment→create window — reads from the tail
+// and can never be accepted by deliverAwareness. That is the right outcome
+// twice over: presence appended before a room's first residency existed
+// belongs to nobody local, and the sync stream's own non-resident branch in
+// handleStream already re-reads the cycle.
+func (r *Relay) awarenessCursor(room string) (residency *roomWorker, from string) {
+	r.workersMu.Lock()
+	defer r.workersMu.Unlock()
+
+	w, ok := r.workers[room]
+	if !ok || w.awCursor == "" {
+		return w, tailID // w is nil when !ok
+	}
+	return w, w.awCursor
+}
+
+// deliverAwareness pushes one awareness read's payloads onto a room's lane
+// and advances that residency's presence cursor — but only while want is
+// STILL the room's resident worker. Reports whether it did.
+//
+// The residency check and both writes happen under one workersMu hold, and
+// that atomicity is what closes the reactivation race rather than narrowing
+// it. stopWorker deletes the map entry and workerFor installs the successor
+// under this same lock, so "want is the mapped worker" holds for the whole
+// push: the entries reach the residency the read was issued for, or they
+// reach nothing. Checking residency and then pushing as two operations would
+// leave a window in which a deactivate/reactivate pair completes in between
+// and the payloads land in the NEW occupants' room — and a retired worker
+// performs one final drain into Sink.Inject (see runRoomWorker), so a push
+// into a lane whose worker has just been stopped is not inert either.
+//
+// Declining is a discard, not a deferral, and deliberately has no counter:
+// every payload it drops is presence published before a reactivation this
+// node has already performed, which is exactly what must not be delivered,
+// and the successor residency reads from the tail so nothing re-reads them.
+// Presence is self-healing heartbeat state, so the live clients whose blobs
+// happen to be caught in that window are re-announced within one interval.
+//
+// Holding workersMu across Lane.Push is safe: Push never blocks (see
+// relaylane.Lane) and awareness is latest-only, so N pushes are N
+// replacements of one slot. stopWorker already reads lane stats under this
+// same lock.
+func (r *Relay) deliverAwareness(room string, want *roomWorker, payloads [][]byte, lastID string) bool {
+	if want == nil {
+		return false
+	}
+
+	r.workersMu.Lock()
+	defer r.workersMu.Unlock()
+
+	if r.workers[room] != want {
+		return false
+	}
+	for _, data := range payloads {
+		want.lane.Push(cluster.KindAwareness, data)
+	}
+	if lastID != "" {
+		want.awCursor = lastID
+	}
+	return true
 }
 
 // inject hands one payload to the Sink, logging failures at Warn (a transient

--- a/cluster/redis/worker.go
+++ b/cluster/redis/worker.go
@@ -221,6 +221,16 @@ func (r *Relay) workerForInbound(room string) (w *roomWorker, ok bool) {
 	return w, ok
 }
 
+// stillResident reports whether w is currently the room's delivery worker: the
+// fence a resolved worker is checked against before its delivery is treated as
+// having happened. deliverAwareness inlines the same check because it writes
+// awCursor under the same hold.
+func (r *Relay) stillResident(room string, w *roomWorker) bool {
+	r.workersMu.Lock()
+	defer r.workersMu.Unlock()
+	return r.workers[room] == w
+}
+
 // awarenessCursor resolves a room's residency together with the awareness
 // stream ID to read from, in ONE workersMu hold so the pair cannot be torn.
 //

--- a/cluster/redis/worker.go
+++ b/cluster/redis/worker.go
@@ -47,9 +47,11 @@ type roomWorker struct {
 	// so it writes the cursor straight back, and the next residency then
 	// resumes from it. Scoping the cursor to the worker resets it by
 	// construction instead — a new residency is a NEW worker, whose cursor is
-	// empty and which no earlier residency's reader can reach — so there is
-	// no ordering left for a reset to lose. See awarenessCursor and
-	// deliverAwareness for the fence that extends that to the payloads.
+	// empty and which no earlier residency's reader can write — so there is
+	// no ordering left for a reset to lose. That closes the cursor half of
+	// the reactivation race outright; see awarenessCursor and
+	// deliverAwareness for how far the same fence reaches the PAYLOADS, which
+	// is narrowed rather than closed.
 	//
 	// Guarded by workersMu, the same lock that publishes the map entry
 	// through which this field is reachable at all.
@@ -244,50 +246,108 @@ func (r *Relay) awarenessCursor(room string) (residency *roomWorker, from string
 	return w, w.awCursor
 }
 
-// deliverAwareness pushes one awareness read's payloads onto a room's lane
-// and advances that residency's presence cursor — but only while want is
-// STILL the room's resident worker. Reports whether it did.
+// deliverAwareness hands one awareness read to a room — the latest payload
+// onto its lane, the stream position onto its residency-scoped cursor — but
+// only while want is STILL the room's resident worker.
 //
-// The residency check and both writes happen under one workersMu hold, and
-// that atomicity is what closes the reactivation race rather than narrowing
-// it. stopWorker deletes the map entry and workerFor installs the successor
-// under this same lock, so "want is the mapped worker" holds for the whole
-// push: the entries reach the residency the read was issued for, or they
-// reach nothing. Checking residency and then pushing as two operations would
-// leave a window in which a deactivate/reactivate pair completes in between
-// and the payloads land in the NEW occupants' room — and a retired worker
-// performs one final drain into Sink.Inject (see runRoomWorker), so a push
-// into a lane whose worker has just been stopped is not inert either.
+// # Only the last payload is pushed
+//
+// The lane keeps a SINGLE awareness slot and supersedes it on every push (see
+// relaylane's package doc), so pushing all N payloads of one read would be
+// N-1 replacements of a slot nothing has read yet: N-1 lane.Push calls, N-1
+// mutex acquisitions and N-1 Signal sends of work that is discarded on the
+// spot. It would also add N-1 AwarenessSuperseded increments that say "this
+// room's worker fell behind" when it did not — on a busy presence stream
+// every read returns several blobs, so the counter would be a healthy-traffic
+// gauge here and a backlog alarm under pub/sub, where one message is one
+// push. Pushing only the last keeps it meaning the same thing on both.
+//
+// What that gives up is the chance that the worker happened to drain between
+// two pushes of one read and so delivered an intermediate blob. That is the
+// lane's own latest-only policy, one read interval wide, on self-healing
+// heartbeat state: every live client re-announces on its next interval.
+//
+// # What the residency fence closes, and what it does not
+//
+// The CURSOR half is closed, and it is the cursor's PLACEMENT that closes it,
+// not this lock. awCursor lives on the worker, so a read issued on a prior
+// residency can only ever write the prior residency's own field — a worker
+// already gone from r.workers, which awarenessCursor will never look up
+// again. The successor is a NEW worker with an empty cursor, i.e. tailID, and
+// $ is resolved server-side at command time. By induction, then, no accepted
+// read's baseline can predate its own residency, for any interleaving of
+// lifecycle calls and in-flight reads. Contrast the relay-scoped map this
+// replaced, where a stale read wrote back a position keyed by STREAM, which
+// the next residency then read.
+//
+// So the cursor write sits inside the hold because workersMu is awCursor's
+// declared guard (see roomWorker) and awarenessCursor reads it under that
+// lock — not because the check and the write need to be atomic with each
+// other. Dropping the resident guard on the write, or moving the write below
+// the Unlock, are both EQUIVALENT mutations today: the only field either
+// could reach that the check would have protected is one nothing can read,
+// and a room's reads are single-goroutine anyway because readerFor is
+// deterministic. The guard is kept so "declined" means "nothing happened",
+// and the write stays under the field's one declared lock so it survives a
+// future where reads are not confined to one goroutine.
+//
+// The PAYLOAD half is NARROWED, not closed. A push whose residency check runs
+// after stopWorker has landed is rejected. But a check that passes
+// microseconds BEFORE stopWorker lands still pushes onto the retiring lane,
+// and a retired worker performs one final drainLane into Sink.Inject
+// addressed by ROOM NAME (see runRoomWorker's w.done case) — so if a
+// reactivation completes first, that pre-reactivation presence reaches the
+// new occupants. Do not read this fence as making that impossible.
+//
+// The residual is accepted, for three reasons. It is bounded at one in-flight
+// read times one drain window, against the whole AwarenessMaxLen window a
+// surviving relay-scoped cursor would replay on every reactivation. It is
+// pre-existing and identical on the pub/sub path, whose router pushes through
+// a stale workerForInbound handle with no lock held at all (see the retired
+// field's doc in redis.go, which accepts the same window for the same
+// reason). And presence is self-healing, so a blob delivered one interval too
+// late is corrected on the next one — the same asymmetry that makes the sync
+// path deliberately unfenced (see streamTarget.residency).
+//
+// # Why the push is outside the hold
+//
+// Lane.Push never blocks on CAPACITY — an over-cap sync queue merges and
+// awareness is latest-only — but it does acquire the lane's mutex, and both
+// Push (via collapseLocked) and TakeSync hold that mutex across
+// crdt.MergeUpdatesV1. Pushing under workersMu would therefore let ONE room's
+// in-flight merge stall workerForInbound (the pub/sub router's hot path under
+// Transport Both), workerFor, stopWorker and Stats() for EVERY other room:
+// exactly the cross-room head-of-line coupling #187 and PR #200 removed, and
+// the shape Relay.Stats()'s doc already rejects from the stats-polling side
+// (which is why Lane.Stats() is lock-free, and why stopWorker's stats read
+// under this lock is no precedent for a Push under it). Nothing that can
+// block is held here: the hold is a map lookup and one string assignment.
+//
+// Moving the push out costs only fence exactness at the boundary, and gains a
+// stale read nothing: a check-then-push whose push executes after stopWorker
+// lands is the same event as a push that landed just before stopWorker did,
+// which is the residual above — already open in the other direction.
 //
 // Declining is a discard, not a deferral, and deliberately has no counter:
 // every payload it drops is presence published before a reactivation this
 // node has already performed, which is exactly what must not be delivered,
 // and the successor residency reads from the tail so nothing re-reads them.
-// Presence is self-healing heartbeat state, so the live clients whose blobs
-// happen to be caught in that window are re-announced within one interval.
-//
-// Holding workersMu across Lane.Push is safe: Push never blocks (see
-// relaylane.Lane) and awareness is latest-only, so N pushes are N
-// replacements of one slot. stopWorker already reads lane stats under this
-// same lock.
-func (r *Relay) deliverAwareness(room string, want *roomWorker, payloads [][]byte, lastID string) bool {
+func (r *Relay) deliverAwareness(room string, want *roomWorker, payloads [][]byte, lastID string) {
 	if want == nil {
-		return false
+		return
 	}
 
 	r.workersMu.Lock()
-	defer r.workersMu.Unlock()
-
-	if r.workers[room] != want {
-		return false
-	}
-	for _, data := range payloads {
-		want.lane.Push(cluster.KindAwareness, data)
-	}
-	if lastID != "" {
+	resident := r.workers[room] == want
+	if resident && lastID != "" {
 		want.awCursor = lastID
 	}
-	return true
+	r.workersMu.Unlock()
+
+	if !resident || len(payloads) == 0 {
+		return
+	}
+	want.lane.Push(cluster.KindAwareness, payloads[len(payloads)-1])
 }
 
 // inject hands one payload to the Sink, logging failures at Warn (a transient

--- a/cluster/redis/worker.go
+++ b/cluster/redis/worker.go
@@ -19,42 +19,35 @@ type roomWorker struct {
 	lane *relaylane.Lane
 	done chan struct{} // closed to stop this worker
 
-	// awCursor is the last awareness stream ID the stream reader delivered
-	// FOR THIS RESIDENCY, or "" when it has delivered none yet (read the
-	// stream from its tail — see tailID).
+	// awCursor is the last awareness stream ID the stream reader delivered FOR
+	// THIS RESIDENCY, or "" when it has delivered none yet (read from the tail
+	// — see tailID).
 	//
-	// It lives on the worker rather than in Relay.cursors, and that placement
-	// IS the mechanism behind this package's cursor-retention rule. The two
-	// kinds of cursor need opposite retention across a room's
-	// deactivate/reactivate cycle, because they start from opposite defaults
-	// when they are missing:
+	// THIS IS THE PACKAGE'S CURSOR-RETENTION RULE, stated once here. The two
+	// kinds need OPPOSITE retention across a room's deactivate/reactivate
+	// cycle, because they start from opposite defaults when missing:
 	//
-	//   - A SYNC cursor MUST survive the cycle. Its default is the oldest
-	//     retained entry, so forgetting it would make ordinary room churn —
-	//     the websocket provider evicts and reloads idle rooms continuously
-	//     (#183) — replay the room's whole retention window on every
-	//     reactivation, the condition StreamStats.Replayed exists to alarm
-	//     on. Sync cursors therefore live in the relay-scoped Relay.cursors
-	//     map and deliberately outlive any single residency.
-	//   - An AWARENESS cursor MUST NOT survive it. Its default is the tail,
-	//     so keeping it would resume a reactivated room mid-presence-stream
-	//     and replay up to AwarenessMaxLen blobs for whoever occupied the
-	//     room last time, resurrecting clients that are long gone.
+	//   - A SYNC cursor MUST survive it. Default = oldest retained entry, so
+	//     forgetting it would make ordinary room churn (the websocket provider
+	//     evicts and reloads idle rooms continuously, #183) replay the room's
+	//     whole retention window on every reactivation — the condition
+	//     StreamStats.Replayed exists to alarm on. Hence the relay-scoped
+	//     Relay.cursors map, outliving any residency.
+	//   - An AWARENESS cursor MUST NOT survive it. Default = the tail, so
+	//     keeping it would resume a reactivated room mid-presence-stream and
+	//     replay up to AwarenessMaxLen blobs for the room's last occupants.
 	//
-	// Deleting an awareness cursor from a relay-scoped map at deactivation
-	// cannot deliver the second rule, only narrow it: a reader builds its
-	// XREAD id vector before that delete and applies the response after it,
-	// so it writes the cursor straight back, and the next residency then
-	// resumes from it. Scoping the cursor to the worker resets it by
-	// construction instead — a new residency is a NEW worker, whose cursor is
-	// empty and which no earlier residency's reader can write — so there is
-	// no ordering left for a reset to lose. That closes the cursor half of
-	// the reactivation race outright; see awarenessCursor and
-	// deliverAwareness for how far the same fence reaches the PAYLOADS, which
-	// is narrowed rather than closed.
+	// Deleting an awareness cursor from a relay-scoped map at deactivation can
+	// only NARROW the second rule, not deliver it: a reader builds its XREAD id
+	// vector before the delete and applies the response after, writing the
+	// cursor straight back for the next residency. Scoping it to the worker
+	// resets it by construction — a new residency is a NEW worker, whose cursor
+	// is empty and which no earlier reader can write — so no ordering is left
+	// for a reset to lose. deliverAwareness says how far the same fence reaches
+	// the PAYLOADS, which is narrowed, not closed.
 	//
-	// Guarded by workersMu, the same lock that publishes the map entry
-	// through which this field is reachable at all.
+	// Guarded by workersMu, the lock that publishes the map entry through which
+	// this field is reachable at all.
 	awCursor string
 }
 
@@ -222,8 +215,8 @@ func (r *Relay) workerForInbound(room string) (w *roomWorker, ok bool) {
 }
 
 // stillResident reports whether w is currently the room's delivery worker: the
-// fence a resolved worker is checked against before its delivery is treated as
-// having happened. deliverAwareness inlines the same check because it writes
+// fence a resolved worker is checked against before its delivery counts as
+// having happened. deliverAwareness inlines the same check, because it writes
 // awCursor under the same hold.
 func (r *Relay) stillResident(room string, w *roomWorker) bool {
 	r.workersMu.Lock()
@@ -235,16 +228,11 @@ func (r *Relay) stillResident(room string, w *roomWorker) bool {
 // stream ID to read from, in ONE workersMu hold so the pair cannot be torn.
 //
 // The returned worker is a fence TOKEN, not a delivery handle: readBatch
-// carries it on the streamTarget and deliverAwareness accepts the response
-// only while that same worker is still the room's residency. Nothing is
-// pushed through it here.
-//
-// A nil worker — the room is assigned to a reader but has no worker yet,
-// which is RoomActivated's own increment→create window — reads from the tail
-// and can never be accepted by deliverAwareness. That is the right outcome
-// twice over: presence appended before a room's first residency existed
-// belongs to nobody local, and the sync stream's own non-resident branch in
-// handleStream already re-reads the cycle.
+// carries it on the streamTarget and deliverAwareness accepts the response only
+// while that same worker is still the room's residency. A nil worker —
+// RoomActivated's increment→create window — reads from the tail and can never
+// be accepted, which is right: presence appended before a room's first
+// residency existed belongs to nobody local.
 func (r *Relay) awarenessCursor(room string) (residency *roomWorker, from string) {
 	r.workersMu.Lock()
 	defer r.workersMu.Unlock()
@@ -256,92 +244,50 @@ func (r *Relay) awarenessCursor(room string) (residency *roomWorker, from string
 	return w, w.awCursor
 }
 
-// deliverAwareness hands one awareness read to a room — the latest payload
-// onto its lane, the stream position onto its residency-scoped cursor — but
-// only while want is STILL the room's resident worker.
+// deliverAwareness hands one awareness read to a room — the latest payload onto
+// its lane, the stream position onto its residency-scoped cursor — but only
+// while want is STILL the room's resident worker.
 //
-// # Only the last payload is pushed
+// Only the LAST payload is pushed. The lane's single awareness slot is
+// superseded on every push, so pushing all N would be N-1 replacements of a
+// slot nothing has read, plus N-1 AwarenessSuperseded increments claiming the
+// worker fell behind when it did not — and since a busy presence stream returns
+// several blobs per read, that would make the counter a healthy-traffic gauge
+// here while it stays a backlog alarm under pub/sub, where one message is one
+// push. It gives up an intermediate blob the worker might have drained
+// mid-read: latest-only, one read interval wide, on state every live client
+// re-announces next interval.
 //
-// The lane keeps a SINGLE awareness slot and supersedes it on every push (see
-// relaylane's package doc), so pushing all N payloads of one read would be
-// N-1 replacements of a slot nothing has read yet: N-1 lane.Push calls, N-1
-// mutex acquisitions and N-1 Signal sends of work that is discarded on the
-// spot. It would also add N-1 AwarenessSuperseded increments that say "this
-// room's worker fell behind" when it did not — on a busy presence stream
-// every read returns several blobs, so the counter would be a healthy-traffic
-// gauge here and a backlog alarm under pub/sub, where one message is one
-// push. Pushing only the last keeps it meaning the same thing on both.
+// The CURSOR half of the reactivation race is closed by awCursor's PLACEMENT,
+// not by this lock (see roomWorker.awCursor). The write sits inside the hold
+// because workersMu is awCursor's declared guard, not because check and write
+// must be atomic — a room's reads are single-goroutine, readerFor being
+// deterministic. Keeping the guard makes "declined" mean "nothing happened".
 //
-// What that gives up is the chance that the worker happened to drain between
-// two pushes of one read and so delivered an intermediate blob. That is the
-// lane's own latest-only policy, one read interval wide, on self-healing
-// heartbeat state: every live client re-announces on its next interval.
+// The PAYLOAD half is NARROWED, NOT CLOSED. A check that passes microseconds
+// BEFORE stopWorker lands still pushes onto the retiring lane, and a retired
+// worker performs one final drainLane into Sink.Inject addressed by ROOM NAME
+// (see runRoomWorker's w.done case) — so if a reactivation completes first,
+// that pre-reactivation presence reaches the new occupants. Do not read this
+// fence as making that impossible.
 //
-// # What the residency fence closes, and what it does not
-//
-// The CURSOR half is closed, and it is the cursor's PLACEMENT that closes it,
-// not this lock. awCursor lives on the worker, so a read issued on a prior
-// residency can only ever write the prior residency's own field — a worker
-// already gone from r.workers, which awarenessCursor will never look up
-// again. The successor is a NEW worker with an empty cursor, i.e. tailID, and
-// $ is resolved server-side at command time. By induction, then, no accepted
-// read's baseline can predate its own residency, for any interleaving of
-// lifecycle calls and in-flight reads. Contrast the relay-scoped map this
-// replaced, where a stale read wrote back a position keyed by STREAM, which
-// the next residency then read.
-//
-// So the cursor write sits inside the hold because workersMu is awCursor's
-// declared guard (see roomWorker) and awarenessCursor reads it under that
-// lock — not because the check and the write need to be atomic with each
-// other. Dropping the resident guard on the write, or moving the write below
-// the Unlock, are both EQUIVALENT mutations today: the only field either
-// could reach that the check would have protected is one nothing can read,
-// and a room's reads are single-goroutine anyway because readerFor is
-// deterministic. The guard is kept so "declined" means "nothing happened",
-// and the write stays under the field's one declared lock so it survives a
-// future where reads are not confined to one goroutine.
-//
-// The PAYLOAD half is NARROWED, not closed. A push whose residency check runs
-// after stopWorker has landed is rejected. But a check that passes
-// microseconds BEFORE stopWorker lands still pushes onto the retiring lane,
-// and a retired worker performs one final drainLane into Sink.Inject
-// addressed by ROOM NAME (see runRoomWorker's w.done case) — so if a
-// reactivation completes first, that pre-reactivation presence reaches the
-// new occupants. Do not read this fence as making that impossible.
-//
-// The residual is accepted, for three reasons. It is bounded at one in-flight
+// The residual is accepted on three grounds: it is bounded at one in-flight
 // read times one drain window, against the whole AwarenessMaxLen window a
-// surviving relay-scoped cursor would replay on every reactivation. It is
-// pre-existing and identical on the pub/sub path, whose router pushes through
-// a stale workerForInbound handle with no lock held at all (see the retired
-// field's doc in redis.go, which accepts the same window for the same
-// reason). And presence is self-healing, so a blob delivered one interval too
-// late is corrected on the next one — the same asymmetry that makes the sync
-// path deliberately unfenced (see streamTarget.residency).
+// surviving relay-scoped cursor would replay on every reactivation; it is
+// pre-existing and identical on the pub/sub path, whose router pushes through a
+// stale workerForInbound handle with no lock at all; and presence is
+// self-healing (see streamTarget.residency).
 //
-// # Why the push is outside the hold
-//
-// Lane.Push never blocks on CAPACITY — an over-cap sync queue merges and
-// awareness is latest-only — but it does acquire the lane's mutex, and both
-// Push (via collapseLocked) and TakeSync hold that mutex across
-// crdt.MergeUpdatesV1. Pushing under workersMu would therefore let ONE room's
-// in-flight merge stall workerForInbound (the pub/sub router's hot path under
-// Transport Both), workerFor, stopWorker and Stats() for EVERY other room:
-// exactly the cross-room head-of-line coupling #187 and PR #200 removed, and
-// the shape Relay.Stats()'s doc already rejects from the stats-polling side
-// (which is why Lane.Stats() is lock-free, and why stopWorker's stats read
-// under this lock is no precedent for a Push under it). Nothing that can
-// block is held here: the hold is a map lookup and one string assignment.
-//
-// Moving the push out costs only fence exactness at the boundary, and gains a
-// stale read nothing: a check-then-push whose push executes after stopWorker
-// lands is the same event as a push that landed just before stopWorker did,
-// which is the residual above — already open in the other direction.
+// The push is OUTSIDE the hold because Lane.Push takes the lane's mutex, held
+// across crdt.MergeUpdatesV1 by both Push and TakeSync: pushing under workersMu
+// would let ONE room's in-flight merge stall workerForInbound, workerFor,
+// stopWorker and Stats() for EVERY other room — the cross-room head-of-line
+// coupling #187/#200 removed. That costs only fence exactness at the boundary,
+// which is the residual above.
 //
 // Declining is a discard, not a deferral, and deliberately has no counter:
-// every payload it drops is presence published before a reactivation this
-// node has already performed, which is exactly what must not be delivered,
-// and the successor residency reads from the tail so nothing re-reads them.
+// every payload it drops is presence published before a reactivation this node
+// has already performed, and the successor residency reads from the tail.
 func (r *Relay) deliverAwareness(room string, want *roomWorker, payloads [][]byte, lastID string) {
 	if want == nil {
 		return

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -579,8 +579,7 @@ per-session, per-tenant, or otherwise unbounded, budget for the whole history
 or reclaim the keys yourself (`XTRIM`/`DEL`/`EXPIRE` from an operations job
 against `StreamPrefix*`) until the built-in reclaim lands: setting an `EXPIRE`
 on each `XADD`, so an untouched key falls out on its own with no keyspace scan
-and nothing to coordinate between nodes, is the intended fix and is tracked as
-a follow-up issue.
+and nothing to coordinate between nodes, is the intended fix and is tracked in #249.
 
 The tier also adds a steady command floor: `Readers × (1 /
 ReadBlock)` blocking `XREAD`s per second per node even when nothing is

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -309,10 +309,17 @@ safe under this contract and must add its own synchronisation.
 
 ## Redis adapter (`cluster/redis`)
 
-`cluster/redis` is a turnkey production relay backed by Redis pub/sub.
-It's the recommended starting point for multi-process deployments behind
-a load balancer — drop it in front of `AttachRelay` and your existing
+`cluster/redis` is a turnkey production relay backed by Redis. It's the
+recommended starting point for multi-process deployments behind a load
+balancer — drop it in front of `AttachRelay` and your existing
 single-server code becomes horizontally scalable.
+
+It offers two delivery tiers, selected by `Config.Transport`: pub/sub
+(the default, at-most-once) and Redis Streams (at-least-once within a
+bounded window). The subsections immediately below describe the pub/sub
+tier and the lifecycle both tiers share; the tier choice, its cost, and
+the migration path between the two are in
+[Delivery tiers: pub/sub and Streams](#delivery-tiers-pubsub-and-streams).
 
 ```go
 import (
@@ -374,7 +381,7 @@ into a single SUBSCRIBE / UNSUBSCRIBE round trip. The underlying Redis
 RPCs are held under the relay's lifecycle mutex so concurrent calls for
 the same room can never reorder the pub/sub state.
 
-### Delivery semantics — fire-and-forget
+### Delivery semantics — pub/sub is fire-and-forget
 
 Redis pub/sub is at-most-once. **A node that subscribes *after* a
 publish does not receive that publish — there is no replay.** The
@@ -392,9 +399,11 @@ The intended pattern is to pair the relay with a persistence layer:
 This split — relay for live fan-out, persistence for catch-up — is also
 how Hocuspocus's `extension-redis` is conventionally deployed.
 
-If a deployment needs at-least-once delivery (no catch-up dependency on
-persistence), a Redis Streams-based adapter (`XADD` + last-read-id
-tracking) would replace this one. Tracked separately; not in v1.21.0.
+If a deployment cannot tolerate that, the same adapter also ships an
+at-least-once tier backed by Redis Streams — see
+[Delivery tiers: pub/sub and Streams](#delivery-tiers-pubsub-and-streams)
+below. It does not replace pub/sub; you select one with
+`Config.Transport`.
 
 **`Shutdown` drains queued outbound updates, and counts what it cannot
 deliver** (#202). `Server.Shutdown` used to cancel the relay context as its
@@ -447,6 +456,234 @@ detail.
 single atomic counter on a direct increment path with no fold-on-retirement
 step, so both are **exact**, not just monotonic.
 
+### Delivery tiers: pub/sub and Streams
+
+`cluster/redis` moves payloads over one of two Redis mechanisms, selected by
+`Config.Transport`. The zero value is `PubSub`, so an existing deployment that
+never sets the field behaves exactly as it always has.
+
+```go
+relay, err := ygoredis.New(rdb, ygoredis.Config{
+    Transport: ygoredis.Streams, // PubSub (default) | Streams | Both
+    // Everything below is optional; these are the defaults.
+    StreamPrefix:       "ygo:stream:",
+    StreamRetention:    60 * time.Second, // age bound, enforced by the MINID sweeper
+    StreamMaxLen:       4096,             // entry bound, enforced inline on XADD
+    AwarenessMaxLen:    64,
+    AwarenessRetention: 10 * time.Second,
+    Readers:            4,                // goroutines multiplexing this node's rooms
+    TrimInterval:       30 * time.Second, // must be < StreamRetention
+    ReadBlock:          250 * time.Millisecond,
+})
+```
+
+In `Streams` and `Both` mode, `New` **rejects** a configuration it cannot
+honour rather than silently adjusting it (in `PubSub` mode it validates none of
+these fields, so an existing caller cannot start failing construction because a
+new field exists):
+
+- an unknown `Transport`;
+- a client `PoolSize` not greater than `Readers` — a reader holds a pool
+  connection for as long as its `XREAD` blocks, so a pool that small leaves
+  publishes and the trim sweeper waiting on a connection every cycle;
+- a `TrimInterval` not less than `StreamRetention` — a sweeper slower than the
+  window it enforces cannot enforce it;
+- a `ReadBlock` outside **1ms – 250ms**. The ceiling is 250ms because a blocked
+  `XREAD` cannot be interrupted (go-redis arms the socket deadline from the
+  context *deadline*, and never watches for cancellation), so `ReadBlock` is
+  simultaneously the upper bound on how long `Close` waits for a reader to
+  notice shutdown and on how long a newly activated room waits before its
+  stream is read at all. Lowering it shortens both at the cost of more commands
+  per second; raising it is not offered, because those latencies could not then
+  be delivered. The floor is 1ms because go-redis truncates a sub-millisecond
+  value to `BLOCK 0`, which Redis reads as *block forever*.
+
+Delivery latency for a room already being read is **not** bounded by
+`ReadBlock`: an `XREAD` returns as soon as any of its keys gets an entry.
+
+#### What each tier guarantees
+
+| | `PubSub` (default) | `Streams` |
+|---|---|---|
+| Mechanism | `PUBLISH` / `SUBSCRIBE`, one channel per room | `XADD` / `XREAD`, two streams per room |
+| Guarantee | **at-most-once** | **at-least-once within `min(StreamRetention, StreamMaxLen / publish-rate)`** |
+| Late joiner / restart | no replay — catch up via persistence | replays the retained window |
+| Backpressure response | merge the backlog, or drop it | leave the entries in Redis and re-read |
+| Redis cost | none beyond the fan-out itself | a write: replication, AOF/RDB, and memory |
+
+**`PubSub` is at-most-once by Redis's own definition.** A subscriber that
+cannot keep up — an error, a network blip, or Redis disconnecting a client
+whose output buffer overflowed — loses the message for good, and no amount of
+client-side buffering changes that. Because CRDT updates carry causal
+dependencies, one lost update parks every *later* edit from that client on the
+receiving node: the apply reports no error, the node just stops converging for
+that client until the room is next reloaded from persistence.
+
+**`Streams` is at-least-once, and the window is bounded.** Each room gets two
+Redis streams — `<StreamPrefix>s:<room>` for document updates and
+`<StreamPrefix>a:<room>` for awareness. `Publish` `XADD`s inline on the
+caller's goroutine, so a failed write fails the call instead of being
+swallowed. Readers `XREAD` a room's sync stream **from its oldest retained
+entry** rather than from the tail: V1 updates are idempotent and commutative,
+so replay is harmless, which removes the race between loading a snapshot and
+starting to read, and makes late-joiner catch-up fall out for free. No cursor
+is persisted anywhere — a lost cursor costs a replay, not a loss.
+
+This is **not** a no-loss guarantee, and the docs will not call it one. A
+stream is trimmed from both ends of the same window: `StreamMaxLen` is enforced
+inline on every `XADD` (approximately — `MAXLEN ~`, which keeps *more* entries
+than asked, never fewer), and `StreamRetention` is enforced by a periodic
+`XTRIM MINID` sweeper. Whichever binds first is the real window, hence
+`min(StreamRetention, StreamMaxLen / publish-rate)`: on a hot room 4096 entries
+may be only a few seconds' worth. A reader that lags past its room's window
+loses whatever was trimmed underneath it — and, unlike pub/sub, *says so*: a
+per-node, per-stream sequence number in every entry makes that loss provable
+and it is counted in `StreamStats().Gaps`. Size `StreamRetention` and
+`StreamMaxLen` for the worst lag you intend to survive (a deploy rollover, a GC
+pause, a node restart); the 60s default matches y-redis's own
+`REDIS_MIN_MESSAGE_LIFETIME`.
+
+**Awareness is a separate stream, read from the tail, and never replayed.**
+Sharing the sync stream would let high-frequency presence traffic evict sync
+entries out of the retention window — silently shrinking the very guarantee the
+tier exists to provide — and replaying presence would resurrect clients that
+are long gone. Presence is idempotent heartbeat state, so a skipped awareness
+entry is re-sent within one heartbeat interval; awareness entries are therefore
+excluded from gap accounting on purpose. One residual is worth knowing about
+rather than glossing: across a room's eviction/reload handoff, an in-flight
+awareness read is fenced against the room's *current* residency, but the fence
+**narrows that race, it does not close it** — a payload accepted microseconds
+before the handoff lands can still reach the new occupants, bounded at one
+in-flight read times one drain window. It is the same window the pub/sub path
+has always had, and presence self-heals on the next interval.
+
+#### The cost trade — pub/sub is supported, not deprecated
+
+`PUBLISH` costs nothing: Redis fans the payload out to whoever is connected and
+forgets it. `XADD` is a **write** — it replicates, it lands in AOF/RDB if
+persistence is on, and it holds memory proportional to
+`retention × publish-rate × update size` for every room on the node, plus the
+`MAXLEN ~` overshoot. The default 4096 entries is roughly 800KB per hot room at
+200-byte updates. The tier also adds a steady command floor: `Readers × (1 /
+ReadBlock)` blocking `XREAD`s per second per node even when nothing is
+happening (4 readers at 250ms is 16/s), and one `XTRIM MINID` per stream per
+`TrimInterval`.
+
+So `PubSub` is not a legacy mode and is not deprecated. **At-most-once is a
+legitimate choice** when your rooms are hot, your Redis is sized for fan-out
+rather than for writes, and persistence-on-reload is an acceptable healer.
+Choose `Streams` when a missed update between reloads is not acceptable, and
+pay for it in Redis memory and write throughput.
+
+#### Migration path
+
+**A `Streams`-only node does not `PUBLISH`, so a `PubSub`-only node never sees
+its edits.** The two transports do not interoperate, and you should not rely on
+the asymmetry in the other direction either. Flipping a live cluster from
+`PubSub` straight to `Streams` therefore splits it for the length of the roll.
+
+Use `Both`, which publishes to *and* reads from both tiers:
+
+1. Roll every node from `PubSub` to `Both`. Every node can now hear every other
+   node, whichever tier it publishes on.
+2. Once no `PubSub`-only node remains, roll every node from `Both` to `Streams`.
+
+To go back, reverse it: roll to `Both`, then to `PubSub`.
+
+`Both` needs **no deduplication**. A payload delivered twice — once over each
+tier — is a V1 update blob, which is idempotent and commutative, so applying it
+again is a no-op. Awareness is delivered twice too and is absorbed by the
+receiving `Awareness`'s own per-client clock gate. Both inbound paths hand off
+to the same per-room lane and so to the same single worker goroutine, which is
+what keeps `Sink.Inject` serialised per room as the contract requires. What
+`Both` does cost is double the publish work and double the inbound traffic, so
+it is a migration state rather than a destination.
+
+The stream key layout — the `s:`/`a:` discriminator *before* the room name —
+was chosen because a room name may legally contain any printable character,
+`:` included, and any suffix-based scheme lets a room called `a:foo` forge
+another room's awareness key.
+
+#### Redis Cluster is not supported
+
+Both tiers target single-node Redis or Sentinel. `New` takes a
+`*redis.Client`, so a `*redis.ClusterClient` will not even compile in, and for
+the Streams tier that exclusion is deliberate rather than merely unfinished:
+
+- A multi-key `XREAD` requires every key in the command to live in **one hash
+  slot**. Rooms hash to arbitrary slots, so the reader's whole batching design
+  (up to 256 rooms per `XREAD`) collapses to one command per room.
+- Forcing the slot with a hash tag means baking the shard assignment into the
+  key names — and the assignment depends on `Readers`. Two nodes configured
+  with different `Readers` values would then compute *different key names for
+  the same room* and silently address different streams. That is split-brain
+  produced by a config typo, which is a worse failure than the one this tier
+  exists to fix.
+
+Scale Redis vertically, or use Sentinel for availability. If one Redis cannot
+hold the write rate, run independent ygo deployments — each with its own Redis
+and its own `StreamPrefix` — behind a room-aware router, rather than reaching
+for Cluster.
+
+#### Observability: `StreamStats()`
+
+`Relay.StreamStats()` is separate from `Relay.Stats()` on purpose: `Stats`'
+fields are permanently zero under `Streams` and these are permanently zero
+under `PubSub`, and a metric that is meaningless half the time stops being
+trusted. It is safe to call on a `PubSub` relay, where every field reads zero.
+Every counter is monotonic for the life of the relay, so scrape rates — except
+`Gaps`, where presence alone is the signal.
+
+- **`Gaps` — alert on presence.** A source node's sequence number jumped, which
+  means entries existed and were trimmed before this reader reached them. A
+  single gap means data was lost and the retention window was too small for the
+  reader's actual lag. This is the one counter that should always be zero.
+- **`Replayed` — alert on a sustained rate.** Entries re-delivered from before
+  a cursor, i.e. the merge savings on catch-up. Routine on activation and after
+  a restart; a sustained rate means cursors are being lost repeatedly.
+- **`Stalled` — alert on a sustained rate.** Cursor advances declined because a
+  room's inbound lane was full. Routine in bursts, and declining is the *safe*
+  response — the entries stay in the stream and are read again next cycle, so
+  nothing is discarded and the lane is not made to coalesce. What it costs is
+  lag, and lag is only safe while the entries survive it: a stall that outlasts
+  the delivery window shows up as `Gaps`. A sustained rate means a room's
+  consumer cannot keep up.
+- **`Deferred` — alert on a sustained rate.** Cursor advances declined because
+  the room had no inbound delivery worker yet (the brief window inside
+  `RoomActivated` between a room joining a reader's assignment set and its
+  worker existing). Routine and self-clearing; a sustained rate is an
+  activation bug, and no amount of capacity fixes it — which is why it is not
+  folded into `Stalled`.
+- **`Trimmed` — informational.** Entries removed by the `MINID` sweeper.
+  Routine; it is the retention window being enforced.
+- **`Restarts` — informational.** Source nodes observed restarting, inferred
+  from a sequence-number *decrease*. Expected once per node per deploy. It
+  exists so that a restart is never miscounted as a `Gaps`.
+
+`Stats()`' `RouterDrops` also serves the Streams tier: a malformed stream
+entry, an unrecognised `Kind`, or an entry whose kind disagrees with the stream
+it arrived on is dropped and counted there.
+
+#### `NodeID` and self-healing after a restart
+
+Entries carry the publishing relay's `NodeID` and readers skip their own, so a
+node never pays the decode-and-inject round trip for its own writes. That makes
+`Config.NodeID` a *recovery* decision under `Streams`, not just an identity one:
+
+- **Leave it empty (the default).** `New` generates 16 crypto-random bytes, so
+  a restarted process is a new identity. Its own pre-restart entries no longer
+  match the self-delivery filter, so it replays them out of Redis and **heals
+  its own last window of writes from the relay** — including anything it had
+  published but not yet persisted. Readers see a first-ever sequence number
+  from that identity, which is a baseline, so no counter fires.
+- **Set it to a stable value.** The restarted process filters its own
+  pre-restart entries as self-delivery and must recover them from
+  [persistence](PERSISTENCE.md) instead. Sequence counters are in memory and
+  restart at 0 under the same identity, which readers classify as a restart
+  (`Restarts`), never as a `Gaps`.
+
+Unless you have a reason to want stable node identity, leave `NodeID` unset.
+
 ### What's *not* in this adapter
 
 - **Distributed lock / writer election** (Redlock pattern). Persistence
@@ -454,8 +691,9 @@ step, so both are **exact**, not just monotonic.
   is the right place to add Redlock on top of the existing
   `VersionedPersistence` interface — not in the relay.
 - **Redis cluster mode** — go-redis supports it but pub/sub semantics
-  differ; this adapter targets single-node Redis (or Sentinel). Filed
-  separately if needed.
+  differ, and the Streams tier cannot be made safe on it at all; this
+  adapter targets single-node Redis (or Sentinel). See
+  [Redis Cluster is not supported](#redis-cluster-is-not-supported).
 
 ---
 

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -538,7 +538,10 @@ than asked, never fewer), and `StreamRetention` is enforced by a periodic
 may be only a few seconds' worth. A reader that lags past its room's window
 loses whatever was trimmed underneath it — and, unlike pub/sub, *says so*: a
 per-node, per-stream sequence number in every entry makes that loss provable
-and it is counted in `StreamStats().Gaps`. Size `StreamRetention` and
+and it is counted in `StreamStats().Gaps`. Within the limit that counter has:
+it detects a jump only once this process has observed a baseline for that
+source, and the baselines are in memory, so loss that happened while this node
+was **down** is bounded by the retention window rather than reported. Size `StreamRetention` and
 `StreamMaxLen` for the worst lag you intend to survive (a deploy rollover, a GC
 pause, a node restart); the 60s default matches y-redis's own
 `REDIS_MIN_MESSAGE_LIFETIME`.
@@ -581,10 +584,18 @@ against `StreamPrefix*`) until the built-in reclaim lands: setting an `EXPIRE`
 on each `XADD`, so an untouched key falls out on its own with no keyspace scan
 and nothing to coordinate between nodes, is the intended fix and is tracked in #248.
 
-The tier also adds a steady command floor: `Readers × (1 /
-ReadBlock)` blocking `XREAD`s per second per node even when nothing is
-happening (4 readers at 250ms is 16/s), and one `XTRIM MINID` per stream per
-`TrimInterval`.
+The tier also adds a steady command floor, and it **grows with the room
+count**: a reader issues one `XREAD` per 512-key batch, and each room
+contributes two keys, so an idle node costs
+
+    Readers × ceil(2 × rooms ÷ Readers ÷ 512) × (1 ÷ ReadBlock)
+
+blocking `XREAD`s per second. Four readers at 250ms is 16/s only while every
+reader's keys fit in one batch — up to roughly 1,000 rooms a node; at the
+10,000-room target each reader has ~5,000 keys, so it is ~160/s. Size Redis
+from the formula, not from the small-cluster number. On top of that, one `XTRIM
+MINID` per stream per `TrimInterval`, pipelined in chunks rather than one round
+trip per key.
 
 So `PubSub` is not a legacy mode and is not deprecated. **At-most-once is a
 legitimate choice** when your rooms are hot, your Redis is sized for fan-out
@@ -661,6 +672,12 @@ Every counter is monotonic for the life of the relay, so scrape rates — except
   means entries existed and were trimmed before this reader reached them. A
   single gap means data was lost and the retention window was too small for the
   reader's actual lag. This is the one counter that should always be zero.
+  **What it cannot see:** baselines are per-process and in memory, so the first
+  entry a restarted relay reads from a source establishes a baseline whatever
+  its sequence number — entries lost during that relay's own downtime leave
+  `Gaps` at zero. Loss over a reader's downtime is bounded by
+  `StreamRetention`, not reported; size the window for your restart and deploy
+  times rather than watching for it here.
 - **`Replayed` — a merge/batching gauge; do *not* alert on its rate.** It
   counts `len(batch)-1` for every multi-entry batch a reader folded into one
   merged update — whether or not any of those entries had been delivered

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -579,7 +579,7 @@ per-session, per-tenant, or otherwise unbounded, budget for the whole history
 or reclaim the keys yourself (`XTRIM`/`DEL`/`EXPIRE` from an operations job
 against `StreamPrefix*`) until the built-in reclaim lands: setting an `EXPIRE`
 on each `XADD`, so an untouched key falls out on its own with no keyspace scan
-and nothing to coordinate between nodes, is the intended fix and is tracked in #249.
+and nothing to coordinate between nodes, is the intended fix and is tracked in #248.
 
 The tier also adds a steady command floor: `Readers × (1 /
 ReadBlock)` blocking `XREAD`s per second per node even when nothing is
@@ -595,9 +595,15 @@ pay for it in Redis memory and write throughput.
 #### Migration path
 
 **A `Streams`-only node does not `PUBLISH`, so a `PubSub`-only node never sees
-its edits.** The two transports do not interoperate, and you should not rely on
-the asymmetry in the other direction either. Flipping a live cluster from
-`PubSub` straight to `Streams` therefore splits it for the length of the roll.
+its edits.** The gate is one-directional, not a clean separation: a
+`Streams`-only node still subscribes to the pub/sub channels, so it *does*
+apply what a `PubSub` node publishes. Do not build on that — it means a
+half-migrated cluster is one-way rather than symmetric, which is harder to
+notice than a clean split, because *some* edits propagate. Gating the receiving
+side too is tracked in #249.
+
+Either way, flipping a live cluster from `PubSub` straight to `Streams` splits
+it for the length of the roll.
 
 Use `Both`, which publishes to *and* reads from both tiers:
 

--- a/docs/CLUSTERING.md
+++ b/docs/CLUSTERING.md
@@ -564,7 +564,25 @@ forgets it. `XADD` is a **write** — it replicates, it lands in AOF/RDB if
 persistence is on, and it holds memory proportional to
 `retention × publish-rate × update size` for every room on the node, plus the
 `MAXLEN ~` overshoot. The default 4096 entries is roughly 800KB per hot room at
-200-byte updates. The tier also adds a steady command floor: `Readers × (1 /
+200-byte updates.
+
+**Size for distinct rooms *ever* used, not for concurrently active rooms.**
+`MAXLEN ~` and the `MINID` sweeper bound the size of each stream; neither
+bounds the *number* of streams, and this package never sets an `EXPIRE`. The
+sweeper only visits rooms some node currently holds, so once a room has gone
+idle everywhere, its two stream keys are swept nowhere and keep whatever they
+last held for the life of the Redis instance. Redis memory therefore grows
+monotonically with the number of distinct rooms that have ever been published
+to. If your room identifiers are long-lived and bounded — a fixed set of
+documents — this is a one-off ceiling you can multiply out. If they are
+per-session, per-tenant, or otherwise unbounded, budget for the whole history
+or reclaim the keys yourself (`XTRIM`/`DEL`/`EXPIRE` from an operations job
+against `StreamPrefix*`) until the built-in reclaim lands: setting an `EXPIRE`
+on each `XADD`, so an untouched key falls out on its own with no keyspace scan
+and nothing to coordinate between nodes, is the intended fix and is tracked as
+a follow-up issue.
+
+The tier also adds a steady command floor: `Readers × (1 /
 ReadBlock)` blocking `XREAD`s per second per node even when nothing is
 happening (4 readers at 250ms is 16/s), and one `XTRIM MINID` per stream per
 `TrimInterval`.
@@ -638,9 +656,19 @@ Every counter is monotonic for the life of the relay, so scrape rates — except
   means entries existed and were trimmed before this reader reached them. A
   single gap means data was lost and the retention window was too small for the
   reader's actual lag. This is the one counter that should always be zero.
-- **`Replayed` — alert on a sustained rate.** Entries re-delivered from before
-  a cursor, i.e. the merge savings on catch-up. Routine on activation and after
-  a restart; a sustained rate means cursors are being lost repeatedly.
+- **`Replayed` — a merge/batching gauge; do *not* alert on its rate.** It
+  counts `len(batch)-1` for every multi-entry batch a reader folded into one
+  merged update — whether or not any of those entries had been delivered
+  before. It is therefore not a count of re-deliveries and says nothing about
+  cursor loss: any room taking more than one remote update per `ReadBlock`
+  (250ms by default) batches on every cycle, so a busy room shows a permanent,
+  perfectly healthy rate. What it is good for is inbound volume — divided by
+  the read rate it approximates merged entries per cycle, so a step change
+  tracks a step change in cluster write traffic, and a catch-up burst
+  (activation, a node restart, a stall clearing) reads as a spike against that
+  room's own baseline. Because that baseline exists, an absolute threshold on
+  it is meaningless. `Gaps`, `Stalled` and `Deferred` are the counters that
+  report loss and lag.
 - **`Stalled` — alert on a sustained rate.** Cursor advances declined because a
   room's inbound lane was full. Routine in bursts, and declining is the *safe*
   response — the entries stay in the stream and are read again next cycle, so

--- a/internal/relaylane/lane.go
+++ b/internal/relaylane/lane.go
@@ -195,6 +195,50 @@ func (l *Lane) Empty() bool {
 	return len(l.syncQ) == 0 && !l.hasAw
 }
 
+// Depth reports how many payloads the lane currently holds: every queued sync
+// blob, plus one for a pending awareness blob.
+//
+// Read-only and purely observational. Empty() answers "is there work?" but
+// nothing answered "how much?", and the degraded-path counters only rise
+// AFTER a merge or a drop has already happened — too late for a producer that
+// wants to see saturation coming.
+//
+// Do NOT derive a full-lane decision from this by comparing it against a cap
+// held elsewhere: the awareness slot is latest-only and never contributes to
+// the capacity Push enforces, so such a comparison would report a lane as
+// full one payload early whenever awareness happened to be pending. Ask
+// Full() instead, which is defined against the queue the cap actually governs.
+func (l *Lane) Depth() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := len(l.syncQ)
+	if l.hasAw {
+		n++
+	}
+	return n
+}
+
+// Full reports whether the next KindSync Push would push the lane past its
+// capacity and so force a coalescing merge.
+//
+// The predicate lives here, not in the caller, because the cap and the
+// threshold Push compares it against are both lane-internal: a caller
+// recomputing "depth >= my copy of the cap" duplicates two facts it does not
+// own and drifts silently if either changes. It is exact rather than
+// conservative — collapseLocked triggers on len(syncQ) > cap after the
+// append, which is len(syncQ) >= cap before it.
+//
+// This is advisory only. Push still never blocks and never drops, so a
+// producer is free to ignore Full and take the merge. It exists for a producer
+// that has something CHEAPER to do than make the lane merge — cluster/redis's
+// stream reader declines to advance its cursor and re-reads the same durable
+// entries next cycle instead.
+func (l *Lane) Full() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.syncQ) >= l.cap
+}
+
 // Stats returns a snapshot of the degraded-path counters. Lock-free by
 // design (see the counters' doc on the Lane struct): it never acquires mu,
 // so it cannot block behind Push/collapseLocked/TakeSync's crdt.MergeUpdatesV1

--- a/internal/relaylane/lane.go
+++ b/internal/relaylane/lane.go
@@ -96,9 +96,18 @@ func New(capacity int) *Lane {
 	return &Lane{cap: capacity, signal: make(chan struct{}, 1)}
 }
 
-// Push enqueues a payload. It NEVER blocks: an over-cap sync queue is
-// collapsed by merging, and awareness is kept latest-only. data must not be
-// mutated by the caller afterwards — the Lane retains the slice.
+// Push enqueues a payload. It NEVER blocks on CAPACITY: an over-cap sync
+// queue is collapsed by merging, and awareness is kept latest-only, so a
+// producer is never made to wait for a consumer. data must not be mutated by
+// the caller afterwards — the Lane retains the slice.
+//
+// "Never blocks" stops at capacity, though: Push takes mu, and both Push
+// (via collapseLocked) and TakeSync hold mu across crdt.MergeUpdatesV1. So a
+// Push can wait for an in-flight merge on the SAME lane, and a caller must
+// not hold a lock that other rooms need across a Push — that turns one
+// room's merge into every room's stall, which is the coupling a lane per
+// room exists to remove. Stats() is deliberately lock-free for the same
+// reason (see the Lane struct's doc).
 func (l *Lane) Push(kind cluster.Kind, data []byte) {
 	l.mu.Lock()
 	if kind == cluster.KindAwareness {
@@ -198,16 +207,21 @@ func (l *Lane) Empty() bool {
 // Depth reports how many payloads the lane currently holds: every queued sync
 // blob, plus one for a pending awareness blob.
 //
-// Read-only and purely observational. Empty() answers "is there work?" but
-// nothing answered "how much?", and the degraded-path counters only rise
-// AFTER a merge or a drop has already happened — too late for a producer that
-// wants to see saturation coming.
+// This is a TEST-ASSERTION primitive, not a production signal, and relaylane
+// being an internal package is the whole of its audience. It exists so tests
+// here and in cluster/redis can state "exactly this much was queued" or
+// "nothing was pushed" directly, instead of inferring queue state from a
+// worker goroutine's observable side effects — which is the difference
+// between a deterministic assertion and a timing one. No production caller
+// exists, and none should: a producer deciding whether to send wants Full(),
+// a consumer wants Empty(), and neither wants a count.
 //
-// Do NOT derive a full-lane decision from this by comparing it against a cap
-// held elsewhere: the awareness slot is latest-only and never contributes to
-// the capacity Push enforces, so such a comparison would report a lane as
-// full one payload early whenever awareness happened to be pending. Ask
-// Full() instead, which is defined against the queue the cap actually governs.
+// A count is in fact the WRONG basis for a full-lane decision, which is the
+// second reason to keep it out of production. The awareness slot is
+// latest-only and never contributes to the capacity Push enforces, so
+// comparing Depth() against a cap held elsewhere would report a lane full one
+// payload early whenever awareness happened to be pending. Full() is defined
+// against the queue the cap actually governs.
 func (l *Lane) Depth() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/relaylane/lane.go
+++ b/internal/relaylane/lane.go
@@ -101,13 +101,11 @@ func New(capacity int) *Lane {
 // producer is never made to wait for a consumer. data must not be mutated by
 // the caller afterwards — the Lane retains the slice.
 //
-// "Never blocks" stops at capacity, though: Push takes mu, and both Push
-// (via collapseLocked) and TakeSync hold mu across crdt.MergeUpdatesV1. So a
-// Push can wait for an in-flight merge on the SAME lane, and a caller must
-// not hold a lock that other rooms need across a Push — that turns one
-// room's merge into every room's stall, which is the coupling a lane per
-// room exists to remove. Stats() is deliberately lock-free for the same
-// reason (see the Lane struct's doc).
+// "Never blocks" stops at capacity, though: Push takes mu, and both Push (via
+// collapseLocked) and TakeSync hold mu across crdt.MergeUpdatesV1. So a Push
+// can wait for an in-flight merge on the SAME lane, and a caller must not hold
+// a lock that other rooms need across a Push — that turns one room's merge into
+// every room's stall, the coupling a lane per room exists to remove.
 func (l *Lane) Push(kind cluster.Kind, data []byte) {
 	l.mu.Lock()
 	if kind == cluster.KindAwareness {
@@ -207,21 +205,15 @@ func (l *Lane) Empty() bool {
 // Depth reports how many payloads the lane currently holds: every queued sync
 // blob, plus one for a pending awareness blob.
 //
-// This is a TEST-ASSERTION primitive, not a production signal, and relaylane
-// being an internal package is the whole of its audience. It exists so tests
-// here and in cluster/redis can state "exactly this much was queued" or
-// "nothing was pushed" directly, instead of inferring queue state from a
-// worker goroutine's observable side effects — which is the difference
-// between a deterministic assertion and a timing one. No production caller
-// exists, and none should: a producer deciding whether to send wants Full(),
-// a consumer wants Empty(), and neither wants a count.
+// A TEST-ASSERTION primitive, not a production signal: it lets tests state
+// "exactly this much was queued" directly, rather than inferring queue state
+// from a worker goroutine's side effects.
 //
-// A count is in fact the WRONG basis for a full-lane decision, which is the
-// second reason to keep it out of production. The awareness slot is
-// latest-only and never contributes to the capacity Push enforces, so
+// A count is also the WRONG basis for a full-lane decision, since the awareness
+// slot is latest-only and never contributes to the capacity Push enforces:
 // comparing Depth() against a cap held elsewhere would report a lane full one
-// payload early whenever awareness happened to be pending. Full() is defined
-// against the queue the cap actually governs.
+// payload early whenever awareness was pending. Producers want Full(), defined
+// against the queue the cap actually governs; consumers want Empty().
 func (l *Lane) Depth() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -238,15 +230,13 @@ func (l *Lane) Depth() int {
 // The predicate lives here, not in the caller, because the cap and the
 // threshold Push compares it against are both lane-internal: a caller
 // recomputing "depth >= my copy of the cap" duplicates two facts it does not
-// own and drifts silently if either changes. It is exact rather than
-// conservative — collapseLocked triggers on len(syncQ) > cap after the
-// append, which is len(syncQ) >= cap before it.
+// own. It is exact rather than conservative — collapseLocked triggers on
+// len(syncQ) > cap after the append, which is len(syncQ) >= cap before it.
 //
-// This is advisory only. Push still never blocks and never drops, so a
-// producer is free to ignore Full and take the merge. It exists for a producer
-// that has something CHEAPER to do than make the lane merge — cluster/redis's
-// stream reader declines to advance its cursor and re-reads the same durable
-// entries next cycle instead.
+// Advisory only: Push still never blocks and never drops, so a producer may
+// ignore Full and take the merge. It exists for a producer with something
+// CHEAPER to do — cluster/redis's stream reader declines to advance its cursor
+// and re-reads the same durable entries next cycle instead.
 func (l *Lane) Full() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/relaylane/lane_test.go
+++ b/internal/relaylane/lane_test.go
@@ -147,3 +147,83 @@ func TestLane_Push_Signals(t *testing.T) {
 	}
 	require.False(t, l.Empty())
 }
+
+// Depth must track what the lane actually holds, in both directions, and must
+// count the two kinds independently — a producer reading it to gauge
+// saturation is misled by either a stuck or an over-counted number.
+//
+// Real V1 blobs, and a cap well above n, so nothing here coalesces: Depth is
+// being asserted against a known queue length, not against whatever a merge
+// left behind.
+func TestLane_Depth_RisesWithPushAndFallsWithTake(t *testing.T) {
+	const n = 3
+	updates, _ := syncUpdates(t, n)
+	l := relaylane.New(n + 5)
+	require.Zero(t, l.Depth(), "a fresh lane holds nothing")
+
+	for i, u := range updates {
+		l.Push(cluster.KindSync, u)
+		require.Equal(t, i+1, l.Depth(), "each sync push adds exactly one")
+	}
+
+	// Awareness is a separate, single slot: the first push adds one, and a
+	// second replaces rather than adds.
+	l.Push(cluster.KindAwareness, []byte{0xaa})
+	require.Equal(t, n+1, l.Depth(), "a pending awareness blob counts as one")
+	l.Push(cluster.KindAwareness, []byte{0xbb})
+	require.Equal(t, n+1, l.Depth(), "awareness is latest-only, so it cannot stack")
+
+	// TakeSync drains the WHOLE sync backlog as one merged blob, so it drops
+	// the sync contribution to zero in a single call.
+	_, ok := l.TakeSync()
+	require.True(t, ok)
+	require.Equal(t, 1, l.Depth(), "only the awareness blob is left")
+
+	_, ok = l.TakeAwareness()
+	require.True(t, ok)
+	require.Zero(t, l.Depth(), "a fully drained lane holds nothing")
+}
+
+// Full must flip exactly one push before a merge would happen, so a producer
+// that respects it never pays for a coalesce, and must clear once the queue is
+// drained.
+//
+// Asserted against Stats().Coalesced rather than against an arithmetic
+// restatement of the threshold: the promise is "the next push would merge",
+// and only the merge counter can witness that.
+func TestLane_Full_PredictsTheNextMerge(t *testing.T) {
+	const capacity = 3
+	updates, _ := syncUpdates(t, capacity+1)
+	l := relaylane.New(capacity)
+
+	for i := 0; i < capacity; i++ {
+		require.False(t, l.Full(), "a lane below capacity is not full (after %d pushes)", i)
+		l.Push(cluster.KindSync, updates[i])
+	}
+	require.True(t, l.Full(), "at capacity, the next sync push must merge")
+	require.Zero(t, l.Stats().Coalesced, "nothing has merged yet")
+
+	// Awareness must not affect the verdict: it is latest-only and is not
+	// governed by the cap. Shaped to be one short of the cap on the SYNC
+	// queue with awareness also pending, so a Full() that summed the two
+	// kinds — the obvious wrong implementation, and the one this change's
+	// brief proposed — would report full here while the next sync push still
+	// would not merge.
+	l2 := relaylane.New(capacity)
+	for i := 0; i < capacity-1; i++ {
+		l2.Push(cluster.KindSync, updates[i])
+	}
+	l2.Push(cluster.KindAwareness, []byte{0xaa})
+	require.Equal(t, capacity, l2.Depth(), "the two kinds together do reach the cap")
+	require.False(t, l2.Full(), "a pending awareness blob is not sync capacity")
+	l2.Push(cluster.KindSync, updates[capacity-1])
+	require.Zero(t, l2.Stats().Coalesced, "and indeed that push did not merge")
+
+	// Taking the honest-but-ignored path proves Full was telling the truth.
+	l.Push(cluster.KindSync, updates[capacity])
+	require.NotZero(t, l.Stats().Coalesced, "the push Full warned about did merge")
+
+	_, ok := l.TakeSync()
+	require.True(t, ok)
+	require.False(t, l.Full(), "a drained lane is not full")
+}


### PR DESCRIPTION
Closes #206, and satisfies #187's acceptance criterion "no silent divergence on backpressure" — which PR #200 could bound but not remove.

**Release: v1.50.0 (MINOR)** — new exported symbols only, `Transport`'s zero value is `PubSub`, so every existing deployment is byte-for-byte unchanged.

## Why

`cluster/redis` is built on Redis pub/sub, which is **at-most-once by Redis's own documentation**: Redis drops slow subscribers server-side and no amount of client buffering changes it. Our own docs tell operators that `HardDrops`/`Dropped` mean data was lost, healed only on a room's next reload — which a hot room never gets.

y-redis, Yjs's own Redis backend, represents each room as a **stream** rather than a channel. This does the same.

## The guarantee, stated as a formula

**At-least-once within `min(StreamRetention, StreamMaxLen/rate)`** — defaults 60s and 4096 entries, the 60s matching y-redis's own `REDIS_MIN_MESSAGE_LIFETIME`. The docs never say "no-loss": the window is bounded and says so. Pub/sub stays **supported, not deprecated** — `PUBLISH` costs nothing while `XADD` is a write with replication, AOF/RDB and memory, so at-most-once remains a legitimate choice.

**Headline test:** stop a reader, publish from another node, restart it, assert convergence. The pub/sub tier structurally cannot pass that.

## Design decisions worth not re-deriving

- **`Transport` lives on the existing `Config`, not a new constructor.** #206 proposed `NewStreams`/`StreamRelay`. That is unsafe: two relay objects own two lane sets, so one room could be `Inject`ed concurrently from the pub/sub subscriber and the stream reader, violating `Sink.Inject`'s same-room serialisation. One relay with one lane set and two ingest sources makes `Both` correct *structurally*. Pinned by a test asserting both tiers resolve a room to the **same** `*roomWorker`.
- **`seq` is per (node, stream), not per node.** A per-node counter writes `[1 3 5]` into one room and `[2 4 6]` into another, so a reader of either sees jumps and reports false `Gaps` on a healthy node. Measured and fixed mid-branch.
- **Keys put the discriminator first** — `prefix + "s:" + room` / `prefix + "a:" + room` — because `roomname.Valid` permits `:`, so a room named `aw:foo` would otherwise collide with room `foo`'s awareness stream.
- **Readers start at the oldest retained entry, not `$`.** V1 updates are idempotent, so replay is harmless — which *eliminates* the snapshot-load/read-start race rather than narrowing it, and gives late-joiner catch-up for free. No cursor is persisted anywhere.
- **Awareness gets its own stream**, read from the tail and never replayed. Sharing would let heartbeat traffic evict sync entries out of the retention window.
- **Under lane backpressure the reader declines to advance its cursor.** The stream is durable, so re-reading next cycle is zero-cost — backpressure toward Redis is safe for the first time.
- **Redis Cluster is deliberately unsupported.** Multi-key `XREAD` needs one slot, and the per-shard hash tag would bake `Readers` into key names — split-brain from a config typo.

## What review caught that I got wrong

Ten tasks, each independently reviewed, then a whole-branch review. It found **two Criticals** the per-task gates could not:

1. **A non-resident room's entire retained backlog was consumed and the cursor advanced past it** — silent, unbounded loss, the exact failure this tier exists to prevent. `RoomActivated` bumps the refcount ~10 lines before it creates the worker, and skips creation entirely on a second activation.
2. **Awareness was replayed across a room's deactivate/reactivate**, routine given v1.39's idle-room LRU. The fix ran deeper than the cursor: a stale push onto a just-retired lane still reached `Sink.Inject` via the worker's final drain, so the cursor moved onto `roomWorker` and became residency-scoped.

Plus an **`internal/relaylane` regression**: holding `workersMu` across `Lane.Push`, which can block on a merge under `lane.mu` — reintroducing the cross-room head-of-line coupling #187/#200 removed. The push now happens outside the hold.

A test guarding Critical 2 was itself a **25% flake** (measured 3/12); now 25/25.

## Verification

- **65 tests** across the tier; full suite green under `-race`; `golangci-lint` 0 issues
- Every task mutation-tested. Several tests were strengthened after surviving a mutation — including one where the implementer's own first draft passed and it said so
- `internal/relaylane` is **additive only** (`Depth`/`Full`); `provider/websocket` re-verified
- **No existing test was modified**, except the one flaky test above — the diff is insertion-only across `*_test.go`
- Tested with miniredis v2.38.0; **no new dependency, no real Redis**. Where miniredis is not faithful (it ignores the `~` trim modifier and trims exactly), tests assert the **lower** bound, which is the guarantee direction — `~` never keeps *fewer* entries than asked

## Known limitations, filed rather than hidden

| issue | what |
|---|---|
| [#247](https://github.com/reearth/ygo/issues/247) | `seq` is assigned outside the `XADD`, so two concurrent same-room publishes can still report a false `Gap`. Mitigated one comparison deep; the real fix is a per-stream-key lock |
| [#248](https://github.com/reearth/ygo/issues/248) | An everywhere-idle room's stream keys are never reclaimed — `MAXLEN` bounds size, not stream count. `EXPIRE`-per-`XADD` is the fix |
| [#249](https://github.com/reearth/ygo/issues/249) | The transport gate is one-directional: `Transport: Streams` still subscribes to pub/sub, so a half-migrated cluster is one-way rather than symmetric |

Also documented and not overstated: the reactivation race's **payload half is narrowed, not closed**, and `Replayed` is a batching gauge rather than an alarm — its earlier "alert on sustained rate" guidance was wrong at any real throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)