### PR TITLE
ci: add step-security/harden-runner to every workflow job (supersedes #218)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,6 +43,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
     env:
       YGO_REQUIRE_NODE: "1"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -69,6 +73,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -82,6 +90,10 @@ jobs:
     name: Vulnerability scan
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -111,6 +123,10 @@ jobs:
     name: Release docs
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
@@ -172,6 +188,10 @@ jobs:
     name: Conformance fixture drift
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,6 +21,10 @@ jobs:
           - { pkg: "./crdt/",     func: "FuzzApplyUpdateV2" }
           - { pkg: "./sync/",     func: "FuzzApplySyncMessage" }
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0


### PR DESCRIPTION
Supersedes [#218](https://github.com/reearth/ygo/pull/218). CI-only — no CHANGELOG/RELEASE_NOTES entry and no version bump, per CONTRIBUTING's exemption; it rides along with the next release.

## Why a new PR instead of fixing #218

#218 carries the same change but is not landable as-is:

| | #218 |
|---|---|
| Mergeable | CONFLICTING / DIRTY |
| Behind `main` | 22 commits (diverged) |
| Check runs on its head | **0 — never validated, since 2026-08-05** |

I reproduced its conflicts against current `main`: **9 hunks**, every one the same trivial shape — `<<<<<<< HEAD` / empty / `+ Harden Runner step`. Nothing semantic. `main` had simply edited lines adjacent to each insertion point over 22 commits, so git can no longer place them. One of those conflicts is even self-inflicted: #245 bumped `action-gh-release` in `release.yml`, which #218 also touches.

Re-applying the intent onto current `main` is cleaner than resolving that divergence — and unlike #218, this branch actually runs CI.

## What this is

Identical to #218 in substance: same pinned SHA (`e14015d5…` v2) and the same `egress-policy: audit`.

**Eight jobs, one step each, placed first** so the monitor is up before checkout:

| workflow | jobs |
|---|---|
| `ci.yml` | test, lint, vuln, release-docs, conformance-fixtures |
| `release.yml` | release |
| `fuzz.yml` | fuzz |
| `benchmark.yml` | benchmark |

## On `audit` rather than `block`

Deliberate, and worth stating so nobody "upgrades" it casually. A blocking policy needs every host the build touches enumerated up front — `proxy.golang.org`, the npm registry for `testutil`'s yjs oracle, codecov, the Go vulnerability database — and getting that list wrong **fails the build** instead of reporting it. `audit` is the step that produces the list; blocking is a later, separate decision informed by what it records.

## Verification

- Every workflow still parses, and in each of the 8 jobs the first step is `harden-runner` with `egress-policy: audit` — asserted structurally, not eyeballed
- Diff is `+32` insertions, zero deletions, across the four workflow files
- Seven of the eight jobs are exercised by this PR's own CI

**One caveat, stated rather than buried:** `release.yml` only runs on a tag push, so its job stays unvalidated until the next tag. That is the same gap that led to merging #245 *after* v1.50.0 rather than before.

Once this is green and merged, #218 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)