### PR TITLE
test(client): wait for server-side room residency before CloseRoom

### DIFF
--- a/provider/client/harness_test.go
+++ b/provider/client/harness_test.go
@@ -133,6 +133,29 @@ func connect(t *testing.T, c *Client) {
 	})
 }
 
+// awaitRoomResident blocks until room is resident on srv.
+//
+// StateSynced is a CLIENT-side signal; CloseRoom needs the room to exist
+// SERVER-side, and under CPU starvation the two diverge — the client can
+// report synced while a previous forced close's teardown is still evicting
+// the room the reconnect just created, so CloseRoom returns ErrRoomNotFound.
+// That is what failed TestClient_Reconnect_BackoffResetsOnlyAfterHandshake on
+// main when crdt's 85s run saturated both runner vCPUs alongside it.
+func awaitRoomResident(t *testing.T, srv *ygws.Server, room string) {
+	t.Helper()
+	deadline := time.Now().Add(hangDeadline)
+	for time.Now().Before(deadline) {
+		for _, r := range srv.Rooms() {
+			if r == room {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	dumpGoroutines(t, fmt.Sprintf("room %q never became resident", room))
+	t.Fatalf("room %q never became resident on the server within %s", room, hangDeadline)
+}
+
 // statusWaiter subscribes to c's status stream NOW and returns a function that
 // blocks until want has been reported (failing the test on timeout).
 //

--- a/provider/client/reconnect_test.go
+++ b/provider/client/reconnect_test.go
@@ -189,6 +189,9 @@ func TestClient_Reconnect_BackoffResetsOnlyAfterHandshake(t *testing.T) {
 	// catches starting at the very first un-reset iteration.
 	const resetThreshold = 700 * time.Millisecond
 	for i := 0; i < 3; i++ {
+		// The room must be resident before CloseRoom, or it returns
+		// ErrRoomNotFound — see awaitRoomResident.
+		awaitRoomResident(t, srv, room)
 		waitSynced := statusWaiter(t, c, StateSynced)
 		require.NoError(t, srv.CloseRoom(room, true))
 		waitSynced()


### PR DESCRIPTION
`main` went red at `4d6865d`. Test-only fix — no production code, no version bump.

## The failure

```
--- FAIL: TestClient_Reconnect_BackoffResetsOnlyAfterHandshake (0.00s)
    reconnect_test.go:193: Received unexpected error:
        ygo/websocket: room not found
```

Line 193 is `require.NoError(t, srv.CloseRoom(room, true))`, inside a loop that closes the room three times and waits for the client to re-sync between each.

## The gap

The loop waited on `StateSynced` — a **client-side** signal — but `CloseRoom` needs the room to exist **server-side**. Those can diverge: a previous forced close's teardown can still be evicting the room the reconnect just recreated, so the next iteration finds nothing. The loop now awaits residency via `srv.Rooms()` first, which is the precondition it always needed.

## Be clear about what this is

**A reasoned precondition, not a demonstrated fix.** I could not reproduce the failure:

| attempt | result |
|---|---|
| 40 isolated runs on `main` | pass |
| 12 runs under `GOMAXPROCS=2` + 6 busy loops, **guard removed** | pass |
| 12 runs, same conditions, **guard present** | pass |

So I cannot show the guard closes the observed race. I can only show the test was missing a precondition that matches the error exactly. Reviewers should weigh it on that basis rather than on a green reproduction I do not have.

**It does not mask a product bug.** If the reconnect path genuinely failed to recreate the room, the guard now fails with `room %q never became resident` plus a goroutine dump instead of `room not found` — a better signal pointing at the same place, not a suppressed one.

## Environment — the same profile as last time

`crdt` took **84.8s** in the failing run while `provider/client` ran alongside it on a 2-vCPU runner. That is the identical contention signature that broke `TestClient_Close_JoinsLoopBeforeReturning` in #243/#244 two days ago.

This is the **third** `provider/client` failure on `main` in eight days, and all three main failures in the last 30 CI runs are in that one package:

| date | test | cause |
|---|---|---|
| 09-02 | `TestClient_Auth_WrongTokenIsTerminal` | a real bug (#242) |
| 09-08 | `TestClient_Close_JoinsLoopBeforeReturning` | a tight 5s deadline (#244) |
| 09-10 | `TestClient_Reconnect_BackoffResetsOnlyAfterHandshake` | this |

Different mechanisms, one shared condition. Filed as its own issue rather than treated as three unrelated flakes.

## Verification

`provider/client` green under `-race`; full suite 18/18; `go vet` and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)